### PR TITLE
Move promise resolved flag checking/setting.

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -734,6 +734,11 @@ and <span title=concept-promise-result>result</span>.
 and optionally a <i title>synchronous flag</i>, and runs these steps:
 
 <ol>
+ <li><p>If the <span>context object</span>'s <span>resolved flag</span> is set, terminate
+ these steps.
+
+ <li><p>Set the <span>context object</span>'s <span>resolved flag</span>.
+
  <li><p>Let <var title>promise</var> be the <span>context object</span>'s associated
  <span title=concept-promise>promise</span>.
 
@@ -760,6 +765,11 @@ and optionally a <i title>synchronous flag</i>, and runs these steps:
 and optionally a <i title>synchronous flag</i>, and runs these steps:
 
 <ol>
+ <li><p>If the <span>context object</span>'s <span>resolved flag</span> is set, terminate
+ these steps.
+
+ <li><p>Set the <span>context object</span>'s <span>resolved flag</span>.
+
  <li>
   <p>Let <var title>then</var> be null.
 
@@ -810,6 +820,11 @@ and optionally a <i title>synchronous flag</i>, and runs these steps:
 and optionally a <i title>synchronous flag</i>, and runs these steps:
 
 <ol>
+ <li><p>If the <span>context object</span>'s <span>resolved flag</span> is set, terminate
+ these steps.
+
+ <li><p>Set the <span>context object</span>'s <span>resolved flag</span>.
+
  <li><p>Let <var title>promise</var> be the <span>context object</span>'s associated
  <span title=concept-promise>promise</span>.
 
@@ -882,11 +897,6 @@ interface <dfn>Promise</dfn> {
 method must run these steps:
 
 <ol>
- <li><p>If the <span>context object</span>'s <span>resolved flag</span> is set, terminate
- these steps.
-
- <li><p>Set the <span>context object</span>'s <span>resolved flag</span>.
-
  <li><p>Run <span>context object</span>'s
  <span title=concept-resolver-fulfill>fulfill</span> with <var title>value</var>.
 </ol>
@@ -895,11 +905,6 @@ method must run these steps:
 method must run these steps:
 
 <ol>
- <li><p>If the <span>context object</span>'s <span>resolved flag</span> is set, terminate
- these steps.
-
- <li><p>Set the <span>context object</span>'s <span>resolved flag</span>.
-
  <li><p>Run <span>context object</span>'s
  <span title=concept-resolver-resolve>resolve</span> with <var title>value</var>.
 </ol>
@@ -908,11 +913,6 @@ method must run these steps:
 method must run these steps:
 
 <ol>
- <li><p>If the <span>context object</span>'s <span>resolved flag</span> is set, terminate
- these steps.
-
- <li><p>Set the <span>context object</span>'s <span>resolved flag</span>.
-
  <li><p>Run <span>context object</span>'s
  <span title=concept-resolver-reject>reject</span> with <var title>value</var>.
 </ol>
@@ -966,8 +966,7 @@ run these steps:
 
  <li><p>Invoke <var title>init</var> with <var title>resolver</var> passed as parameter.
 
- <li><p>If <var title>init</var> threw an exception, catch it, and then, if
- <var title>resolver</var>'s <span>resolved flag</span> is unset, run <var title>resolver</var>'s
+ <li><p>If <var title>init</var> threw an exception, catch it, and then run <var title>resolver</var>'s
  <span title=concept-resolver-reject>reject</span> with the thrown exception as argument.
  <!-- ES6-exception -->
 


### PR DESCRIPTION
This moves the checking and subsequent setting of the resolved flag from `fulfill`, `reject`, and `resolve` to the internal fulfill, reject, and resolve algorithms. This is more resilient in the face of malicious thenables, which as currently specified can cause multiple fulfillment, multiple rejection, or any combination thereof.

Fixes http://lists.w3.org/Archives/Public/www-dom/2013AprJun/0283.html
