### PR TITLE
Remove stray "in" in definition of DOMImplementation.createDocumentType

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -4963,7 +4963,7 @@ method must run these steps:
  <span title=concept-throw>throw</span> an
  "<code>InvalidCharacterError</code>" exception.
  <li><p>If <var title>qualifiedName</var> does not match the <code
- data-anolis-spec=xmlns>QName</code> production in,
+ data-anolis-spec=xmlns>QName</code> production,
  <span title=concept-throw>throw</span> a
  "<code>NamespaceError</code>" exception.
  <!-- <li><p>If <var title>publicId</var> contains a character that does not

--- a/dom-core.html
+++ b/dom-core.html
@@ -5034,7 +5034,7 @@ method must run these steps:
  <code class="external" data-anolis-spec="xml"><a href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production,
  <a href="#concept-throw" title="concept-throw">throw</a> an
  "<code><a href="#invalidcharactererror">InvalidCharacterError</a></code>" exception.
- <li><p>If <var title="">qualifiedName</var> does not match the <code class="external" data-anolis-spec="xmlns"><a href="http://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production in,
+ <li><p>If <var title="">qualifiedName</var> does not match the <code class="external" data-anolis-spec="xmlns"><a href="http://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production,
  <a href="#concept-throw" title="concept-throw">throw</a> a
  "<code><a href="#namespaceerror">NamespaceError</a></code>" exception.
  <!-- <li><p>If <var title>publicId</var> contains a character that does not


### PR DESCRIPTION
An early Christmas typo fix for you!
