### PR TITLE
Fix iterator collection removal algorithm

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -8006,14 +8006,11 @@ method.
 <span>iterator collection</span>, these steps must be run:
 
 <ol>
- <li><p>If the <span title=concept-node>node</span> is not a
- <span title=concept-tree-descendant>descendant</span> of
- <span title=concept-traversal-root>root</span> and is not an
- <span title=concept-tree-ancestor>ancestor</span> of the
+ <li><p>If the <span title=concept-node>node</span> is
+ <span title=concept-traversal-root>root</span> or is not an
+ <span title=concept-tree-inclusive-ancestor>inclusive ancestor</span> of the
  <code title=dom-NodeIterator-referenceNode>referenceNode</code> attribute
- value or the
- <code title=dom-NodeIterator-referenceNode>referenceNode</code> attribute
- value itself, terminate these steps.
+ value, terminate these steps.
 
  <li><p>If the
  <code title=dom-NodeIterator-pointerBeforeReferenceNode>pointerBeforeReferenceNode</code>
@@ -8024,11 +8021,10 @@ method.
  <span title=concept-node>node</span> that is being removed, and terminate
  these steps.
 
- <li><p>If the
- <code title=dom-NodeIterator-pointerBeforeReferenceNode>pointerBeforeReferenceNode</code>
- attribute value is true and there is a <span title=concept-node>node</span>
- <span title=concept-tree-following>following</span> the
- <span title=concept-node>node</span> that is being removed, set the
+ <li><p>If there is a <span title=concept-node>node</span>
+ <span title=concept-tree-following>following</span> the last
+ <span title=concept-tree-inclusive-descendant>inclusive descendant</span> of
+ the <span title=concept-node>node</span> that is being removed, set the
  <code title=dom-NodeIterator-referenceNode>referenceNode</code> attribute
  to the first such <span title=concept-node>node</span>, and terminate these
  steps.

--- a/dom-core.html
+++ b/dom-core.html
@@ -8,7 +8,7 @@
 <p><a class="logo" href="//www.whatwg.org/"><img alt="WHATWG" height="100" src="//resources.whatwg.org/logo-dom.svg" width="100"></a></p>
 
 <h1 class="allcaps">DOM</h1>
-<h2 class="no-num no-toc" id="living-standard-—-last-updated-14-april-2014">Living Standard — Last Updated 14 April 2014</h2>
+<h2 class="no-num no-toc" id="living-standard-—-last-updated-24-april-2014">Living Standard — Last Updated 24 April 2014</h2>
 
 <dl>
  <dt>This Version:
@@ -42,7 +42,7 @@
 <p class="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="http://i.creativecommons.org/p/zero/1.0/80x15.png"></a>
 To the extent possible under law, the editors have waived all copyright and
 related or neighboring rights to this work. In addition, as of
-14 April 2014, the editors have made this specification available
+24 April 2014, the editors have made this specification available
 under the
 <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
 which is available at
@@ -8077,14 +8077,11 @@ method.
 <a href="#iterator-collection">iterator collection</a>, these steps must be run:
 
 <ol>
- <li><p>If the <a href="#concept-node" title="concept-node">node</a> is not a
- <a href="#concept-tree-descendant" title="concept-tree-descendant">descendant</a> of
- <a href="#concept-traversal-root" title="concept-traversal-root">root</a> and is not an
- <a href="#concept-tree-ancestor" title="concept-tree-ancestor">ancestor</a> of the
+ <li><p>If the <a href="#concept-node" title="concept-node">node</a> is
+ <a href="#concept-traversal-root" title="concept-traversal-root">root</a> or is not an
+ <a href="#concept-tree-inclusive-ancestor" title="concept-tree-inclusive-ancestor">inclusive ancestor</a> of the
  <code title="dom-NodeIterator-referenceNode"><a href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute
- value or the
- <code title="dom-NodeIterator-referenceNode"><a href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute
- value itself, terminate these steps.
+ value, terminate these steps.
 
  <li><p>If the
  <code title="dom-NodeIterator-pointerBeforeReferenceNode"><a href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code>
@@ -8095,11 +8092,10 @@ method.
  <a href="#concept-node" title="concept-node">node</a> that is being removed, and terminate
  these steps.
 
- <li><p>If the
- <code title="dom-NodeIterator-pointerBeforeReferenceNode"><a href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code>
- attribute value is true and there is a <a href="#concept-node" title="concept-node">node</a>
- <a href="#concept-tree-following" title="concept-tree-following">following</a> the
- <a href="#concept-node" title="concept-node">node</a> that is being removed, set the
+ <li><p>If there is a <a href="#concept-node" title="concept-node">node</a>
+ <a href="#concept-tree-following" title="concept-tree-following">following</a> the last
+ <a href="#concept-tree-inclusive-descendant" title="concept-tree-inclusive-descendant">inclusive descendant</a> of
+ the <a href="#concept-node" title="concept-node">node</a> that is being removed, set the
  <code title="dom-NodeIterator-referenceNode"><a href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute
  to the first such <a href="#concept-node" title="concept-node">node</a>, and terminate these
  steps.


### PR DESCRIPTION
It has two bugs, see:
https://www.w3.org/Bugs/Public/show_bug.cgi?id=25430
Also shortened the wording in two places while I was here (use
"inclusive descendant," and skip redundant pointerBeforeReferenceNode
check).
