### PR TITLE
Fix NodeIterator removing step

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -8264,9 +8264,9 @@ Each {{NodeIterator}} object has these
    <li>Let <var>next</var> be the first <a>node</a>
    <a>following</a> <var>oldParent</var>.
 
-   <li>If <var>next</var> is not an
+   <li>If <a for="traversal">root</a> is an
    <a>inclusive ancestor</a> of
-   <a for="traversal">root</a>, set the
+   <var>next</var>, set the
    {{NodeIterator/referenceNode}} attribute to
    <var>next</var> and terminate these steps.
 


### PR DESCRIPTION
https://dom.spec.whatwg.org/#interface-nodeiterator

> 4\. If __next__ __is not__ an inclusive ancestor of __root__, set the referenceNode attribute to next and terminate these steps. 

This should be:

> 4\. If __root__ __is__ an inclusive ancestor of __next__, set the referenceNode attribute to next and terminate these steps. 

Otherwise you will end up with the following node of the iterator's `root`. Firefox and Chrome seem to behave in line with this fix.