### PR TITLE
Fix another NodeIterator removing step

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -8279,9 +8279,9 @@ Each {{NodeIterator}} object has these
   </ol>
 
  <li>Set the {{NodeIterator/referenceNode}} attribute
- to first <a>node</a>
- <a>preceding</a> <var>oldPreviousSibling</var>, if
- <var>oldPreviousSibling</var> is non-null, and to <var>oldParent</var> otherwise.
+ to the <a>inclusive descendant</a> of <var>oldPreviousSibling</var> that
+ appears last in <a>tree order</a>, if <var>oldPreviousSibling</var> is non-null,
+ and to <var>oldParent</var> otherwise.
 </ol>
 
 Note: As mentioned earlier {{NodeIterator}} objects have an


### PR DESCRIPTION
This change makes it more consistent with the other rules. Also,
it is what the w3c test suite expects and how the browsers behave.

Here's a quick snippit to test:
```javascript
document.body.innerHTML = "<p>Efghijkl</p><p>Mnopqrst</p>";
var it = document.createNodeIterator(document);
while (it.nextNode());

var removed = document.body.children[1];
removed.parentNode.removeChild(removed);

console.info(it.referenceNode === document.body.children[0].lastChild);
console.info(it.pointerBeforeReferenceNode === false);
```