### PR TITLE
Add a common conjugation of "case-sensitive"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -341,9 +341,9 @@ of <a>preceding</a>
 <h3 id='strings'>
 Strings</h3>
 
-Comparing two strings in a <dfn export>case-sensitive</dfn> manner means comparing them exactly, code point for code point.
+Comparing two strings in a <dfn export lt="case-sensitive|case-sensitively">case-sensitive</dfn> manner means comparing them exactly, code point for code point.
 
-Comparing two strings in a <dfn export>ASCII case-insensitive</dfn> manner means comparing them exactly, code point for code point, except that the characters in the range U+0041 .. U+005A (i.e. LATIN CAPITAL LETTER A to LATIN CAPITAL LETTER Z) and the corresponding characters in the range U+0061 .. U+007A (i.e. LATIN SMALL LETTER A to LATIN SMALL LETTER Z) are considered to also match.
+Comparing two strings in a <dfn export lt="ASCII case-insensitive|ASCII case-insensitively">ASCII case-insensitive</dfn> manner means comparing them exactly, code point for code point, except that the characters in the range U+0041 .. U+005A (i.e. LATIN CAPITAL LETTER A to LATIN CAPITAL LETTER Z) and the corresponding characters in the range U+0061 .. U+007A (i.e. LATIN SMALL LETTER A to LATIN SMALL LETTER Z) are considered to also match.
 
 <dfn export lt="converted to ascii uppercase">Converting a string to ASCII uppercase</dfn> means replacing all characters in the range U+0061 to U+007A (i.e. LATIN SMALL LETTER A to LATIN SMALL LETTER Z) with the corresponding characters in the range U+0041 to U+005A (i.e. LATIN CAPITAL LETTER A to LATIN CAPITAL LETTER Z).
 


### PR DESCRIPTION
CSS Syntax also defines these terms, but your definitions are better, so I'm removing them from Syntax.  But it also explicitly gives these conjugations, because they're used in the spec.