### PR TITLE
Add [TreatNullAs=EmptyString] to Attr.nodeValue/textContent

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6011,8 +6011,8 @@ interface Attr {
   readonly attribute DOMString localName;
   readonly attribute DOMString name;
            attribute DOMString value;
-           attribute DOMString nodeValue; // legacy alias of .value
-           attribute DOMString textContent; // legacy alias of .value
+  [TreatNullAs=EmptyString] attribute DOMString nodeValue; // legacy alias of .value
+  [TreatNullAs=EmptyString] attribute DOMString textContent; // legacy alias of .value
 
   readonly attribute Element? ownerElement;
 


### PR DESCRIPTION
This came up in an attempt to align Blink with the spec:
https://codereview.chromium.org/1146393003/

By adding [TreatNullAs=EmptyString], the spec would match current
Firefox and IE behavior. It probably doesn't matter, but is a quick
path to interop and less risky.