### PR TITLE
Remove unnecessary conditions from the 'traverse children' algorithm.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -8440,9 +8440,11 @@ To <dfn export for=TreeWalker id=concept-traverse-children>traverse children</df
  <a>last child</a> if
  <var>type</var> is last.
 
+ <li>If <var>node</var> is null, return null.
+
  <li>
   <dfn export id=concept-traverse-children-main lt="Traverse children main step">Main</dfn>:
-  While <var>node</var> is not null, run these substeps:
+  Repeat these substeps:
 
   <ol>
    <li><a for=Node>Filter</a>
@@ -8472,7 +8474,7 @@ To <dfn export for=TreeWalker id=concept-traverse-children>traverse children</df
     </ol>
 
    <li>
-    While <var>node</var> is not null, run these subsubsteps:
+    Repeat these subsubsteps:
 
     <ol>
      <li>Let <var>sibling</var> be <var>node</var>'s
@@ -8497,7 +8499,6 @@ To <dfn export for=TreeWalker id=concept-traverse-children>traverse children</df
      <li>Otherwise, set <var>node</var> to <var>parent</var>.
     </ol>
   </ol>
- <li>Return null.
 </ol>
 
 The <dfn method for="TreeWalker">firstChild()</dfn>

--- a/dom.html
+++ b/dom.html
@@ -163,7 +163,7 @@ pre[class*="language-"] {
    <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
   
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated
-    <time class="dt-updated" datetime="2015-06-15">15 June 2015</time></span></h2>
+    <time class="dt-updated" datetime="2015-06-20">20 June 2015</time></span></h2>
   
    <div data-fill-with="spec-metadata">
     <dl>
@@ -10739,9 +10739,12 @@ method must run these steps:</p>
  <var>type</var> is last.
 
  
+    <li>If <var>node</var> is null, return null.
+
+ 
     <li>
   <dfn data-dfn-type="dfn" data-export="" data-lt="Traverse children main step" id="concept-traverse-children-main">Main<a class="self-link" href="#concept-traverse-children-main"></a></dfn>:
-  While <var>node</var> is not null, run these substeps:
+  Repeat these substeps:
 
   
      <ol>
@@ -10781,7 +10784,7 @@ method must run these steps:</p>
 
    
       <li>
-    While <var>node</var> is not null, run these subsubsteps:
+    Repeat these subsubsteps:
 
     
        <ol>
@@ -10816,8 +10819,6 @@ method must run these steps:</p>
   
      </ol>
      
- 
-    <li>Return null.
 </ol>
 
 


### PR DESCRIPTION
/node/ will never be null when reaching the head of these loops, unless it is
null when starting the outer loop.  This should somewhat clarify how the loop
actually runs.