### PR TITLE
Less ambiguous step description for Node.before

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2120,9 +2120,9 @@ invoked, must run these steps:
  <li><p>Let <var>node</var> be the result of
  <a>converting <var>nodes</var> into a node</a>.
 
- <li><p>If <var>viablePreviousSibling</var> is non-null, set it to
- <var>viablePreviousSibling</var>'s <a>next sibling</a>, and to <var>parent</var>'s
- <a>first child</a> otherwise.
+ <li><p>If <var>viablePreviousSibling</var> is non-null, set <var>node</var> to
+ <var>viablePreviousSibling</var>'s <a>next sibling</a>. Otherwise, set <var>node</var>
+ to <var>parent</var>'s <a>first child</a>.
 
  <li><p><a>Pre-insert</a> <var>node</var> into <var>parent</var> before
  <var>viablePreviousSibling</var>.


### PR DESCRIPTION
Before:

If viablePreviousSibling is non-null, set it to viablePreviousSibling’s
next sibling, and to parent’s first child otherwise.

After:

If viablePreviousSibling is non-null, set node to viablePreviousSibling’s
next sibling. Otherwise, set node to parent’s first child.