### PR TITLE
Queuing of mutation records looks inconsistent

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1483,30 +1483,19 @@ into a <var>parent</var> before a <var>child</var>, with an optional
  a {{DocumentFragment}} <a>node</a>, and a
  list containing solely <var>node</var> otherwise.
 
- <li>
-  If <var>node</var> is a {{DocumentFragment}}
-  <a>node</a>, <a>queue a mutation record</a>
-  of "<code>childList</code>" for <var>node</var> with removedNodes
-  <var>nodes</var>.
-
-  Note: This step intentionally does not pay attention to the
-  <i>suppress observers flag</i>.
-
  <li>If <var>node</var> is a {{DocumentFragment}}
  <a>node</a>,
  <a>remove</a> its
  <a>children</a> with the
  <i>suppress observers flag</i> set.
 
- <li>If <i>suppress observers flag</i> is unset,
- <a>queue a mutation record</a> of "<code>childList</code>" for
- <var>parent</var> with addedNodes <var>nodes</var>,
- nextSibling <var>child</var>, and previousSibling
- <var>child</var>'s
- <a>previous sibling</a>
- or <var>parent</var>'s
- <a>last child</a> if
- <var>child</var> is null.
+ <li>
+  If <var>node</var> is a {{DocumentFragment}} <a>node</a>,
+  <a>queue a mutation record</a> of "<code>childList</code>" for
+  <var>node</var> with removedNodes <var>nodes</var>.
+
+  Note: This step intentionally does not pay attention to the
+  <i>suppress observers flag</i>.
 
  <li>
   For each <var>newNode</var> in <var>nodes</var>, in
@@ -1520,6 +1509,14 @@ into a <var>parent</var> before a <var>child</var>, with an optional
    <li>Run the <a>insertion steps</a> with
    <var>newNode</var>.
   </ol>
+
+ <li>If <i>suppress observers flag</i> is unset,
+ <a>queue a mutation record</a> of "<code>childList</code>" for
+ <var>parent</var> with addedNodes <var>nodes</var>, nextSibling
+ <var>child</var>, and previousSibling <var>child</var>'s
+ <a>previous sibling</a> or <var>parent</var>'s <a>last child</a> if
+ <var>child</var> is null.
+
 </ol>
 
 
@@ -1740,29 +1737,25 @@ steps:
  <li>Let <var>oldPreviousSibling</var> be <var>node</var>'s
  <a>previous sibling</a>
 
- <li>If <i>suppress observers flag</i> is unset,
- <a>queue a mutation record</a> of "<code>childList</code>" for
- <var>parent</var> with removedNodes a list solely containing
- <var>node</var>, nextSibling <var>node</var>'s
- <a>next sibling</a>,
- and previousSibling <var>oldPreviousSibling</var>.
-
- <li>For each <a>ancestor</a>
- <var>ancestor</var> of <var>node</var>, if
- <var>ancestor</var> has any
- <a>registered observers</a> whose
- <b>options</b>'
- {{MutationObserverInit/subtree}} is true, then
- for each such <a>registered observer</a> <var>registered</var>, append a
- <a>transient registered observer</a> whose <b>observer</b> and
- <b>options</b> are identical to those of <var>registered</var> and <b>source</b>
- which is <var>registered</var> to <var>node</var>'s list of
- <a>registered observers</a>.
-
  <li>Remove <var>node</var> from its <var>parent</var>.
 
  <li>Run the <a>removing steps</a> with
  <var>node</var>, <var>parent</var>, and <var>oldPreviousSibling</var>.
+
+ <li>For each <a>inclusive ancestor</a> <var>ancestor</var> of
+ <var>parent</var>, if <var>ancestor</var> has any <a>registered observers</a>
+ whose <b>options</b>' {{MutationObserverInit/subtree}} is true, then for each
+ such <a>registered observer</a> <var>registered</var>, append a
+ <a>transient registered observer</a> whose <b>observer</b> and <b>options</b>
+ are identical to those of <var>registered</var> and <b>source</b>  which is
+ <var>registered</var> to <var>node</var>'s list of
+ <a>registered observers</a>.
+
+ <li>If <i>suppress observers flag</i> is unset,
+ <a>queue a mutation record</a> of "<code>childList</code>" for
+ <var>parent</var> with removedNodes a list solely containing <var>node</var>,
+ nextSibling <var>node</var>'s <a>next sibling</a>, and previousSibling
+ <var>oldPreviousSibling</var>.
 </ol>
 
 

--- a/dom.html
+++ b/dom.html
@@ -1997,18 +1997,6 @@ into a <var>parent</var> before a <var>child</var>, with an optional
  list containing solely <var>node</var> otherwise.
 
  
-    <li>
-  If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
-  <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a>
-  of "<code>childList</code>" for <var>node</var> with removedNodes
-  <var>nodes</var>.
-
-
-     <p class="note" role="note">Note: This step intentionally does not pay attention to the
-  <i>suppress observers flag</i>.</p>
-     
-
- 
     <li>If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
  <a data-link-type="dfn" href="#concept-node">node</a>,
  <a data-link-type="dfn" href="#concept-node-remove">remove</a> its
@@ -2016,15 +2004,15 @@ into a <var>parent</var> before a <var>child</var>, with an optional
  <i>suppress observers flag</i> set.
 
  
-    <li>If <i>suppress observers flag</i> is unset,
- <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for
- <var>parent</var> with addedNodes <var>nodes</var>,
- nextSibling <var>child</var>, and previousSibling
- <var>child</var>’s
- <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>
- or <var>parent</var>’s
- <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if
- <var>child</var> is null.
+    <li>
+  If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>,
+  <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for
+  <var>node</var> with removedNodes <var>nodes</var>.
+
+
+     <p class="note" role="note">Note: This step intentionally does not pay attention to the
+  <i>suppress observers flag</i>.</p>
+     
 
  
     <li>
@@ -2044,6 +2032,15 @@ into a <var>parent</var> before a <var>child</var>, with an optional
   
      </ol>
      
+
+ 
+    <li>If <i>suppress observers flag</i> is unset,
+ <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for
+ <var>parent</var> with addedNodes <var>nodes</var>, nextSibling
+ <var>child</var>, and previousSibling <var>child</var>’s
+ <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> or <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if
+ <var>child</var> is null.
+
 </ol>
 
 
@@ -2317,32 +2314,28 @@ steps:</p>
  <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>
 
  
-    <li>If <i>suppress observers flag</i> is unset,
- <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for
- <var>parent</var> with removedNodes a list solely containing
- <var>node</var>, nextSibling <var>node</var>’s
- <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>,
- and previousSibling <var>oldPreviousSibling</var>.
-
- 
-    <li>For each <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a>
- <var>ancestor</var> of <var>node</var>, if
- <var>ancestor</var> has any
- <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose
- <b>options</b>'
- <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> is true, then
- for each such <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var>, append a
- <a data-link-type="dfn" href="#transient-registered-observer">transient registered observer</a> whose <b>observer</b> and
- <b>options</b> are identical to those of <var>registered</var> and <b>source</b>
- which is <var>registered</var> to <var>node</var>’s list of
- <a data-link-type="dfn" href="#registered-observer">registered observers</a>.
-
- 
     <li>Remove <var>node</var> from its <var>parent</var>.
 
  
     <li>Run the <a data-link-type="dfn" href="#concept-node-remove-ext">removing steps</a> with
  <var>node</var>, <var>parent</var>, and <var>oldPreviousSibling</var>.
+
+ 
+    <li>For each <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> <var>ancestor</var> of
+ <var>parent</var>, if <var>ancestor</var> has any <a data-link-type="dfn" href="#registered-observer">registered observers</a>
+ whose <b>options</b>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> is true, then for each
+ such <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var>, append a
+ <a data-link-type="dfn" href="#transient-registered-observer">transient registered observer</a> whose <b>observer</b> and <b>options</b>
+ are identical to those of <var>registered</var> and <b>source</b>  which is
+ <var>registered</var> to <var>node</var>’s list of
+ <a data-link-type="dfn" href="#registered-observer">registered observers</a>.
+
+ 
+    <li>If <i>suppress observers flag</i> is unset,
+ <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for
+ <var>parent</var> with removedNodes a list solely containing <var>node</var>,
+ nextSibling <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>, and previousSibling
+ <var>oldPreviousSibling</var>.
 </ol>
 
 


### PR DESCRIPTION
To [replace](https://dom.spec.whatwg.org/#concept-node-replace) a *child* with *node* within a parent, the mutation record is queued after the removal of *child* and insertion of *node*:
<ol start=11>
<li><strong>Remove</strong> child from its parent with the suppress observers flag set.
<li>Let nodes be node’s children if node is a DocumentFragment node, and a list containing solely node otherwise.
<li><strong>Insert</strong> node into parent before reference child with the suppress observers flag set.
<li><strong>Queue a mutation record</strong> of "childList" for target parent with addedNodes nodes, removedNodes a list solely containing child, nextSibling reference child, and previousSibling previousSibling.
</ol>

That behaviour is the same to [replace all](https://dom.spec.whatwg.org/#concept-node-replace-all) a node within a parent:
<ol start=4>
<li><strong>Remove</strong> all parent’s children, in tree order, with the suppress observers flag set.
<li>If node is not null, <strong>insert</strong> node into parent before null with the suppress observers flag set.
<li><strong>Queue a mutation record</strong> of "childList" for parent with addedNodes addedNodes and removedNodes removedNodes.
</ol>

But for example, to [insert](https://dom.spec.whatwg.org/#concept-node-replace-all) a node into a parent before a child, mutation records are queued before the actual mutations:
<ol start=4>
<li>If node is a DocumentFragment node, <strong>queue a mutation record</strong> of "childList" for node with removedNodes nodes.
<li>If node is a DocumentFragment node, <strong>remove</strong> its children with the suppress observers flag set.
</ol>

Shouldn't all mutation records be queued after the tree was mutated? I understand that because micro tasks are used it doesn't matter much, but the ordering inconsistency makes it look like it actually matters.