### PR TITLE
Run the adopting steps recursively

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4637,14 +4637,17 @@ a <var>document</var>, run these steps:
  <a>remove</a> <var>node</var> from
  its <a>parent</a>.
 
- <li>Set <var>node</var>'s
- <a>inclusive descendants</a>'s
- <a>node document</a> to <var>document</var>.
- <!--AttrExodus as well as any associated {{Attr}} nodes-->
+ <li>
+  For each <var>descendant</var> in <var>nodes</var>'s <a>inclusive descendants</a>, in
+  <a>tree order</a>, run these substeps:
 
- <li>Run any <a>adopting steps</a> defined for
- <var>node</var> in <a>other applicable specifications</a> and pass
- <var>node</var> and <var>oldDocument</var> as parameters.
+  <ol>
+   <li>Set <var>descendant</var>'s <a>node document</a> to <var>document</var>.
+   <!--AttrExodus as well as any associated {{Attr}} nodes-->
+
+   <li>Run the <a>adopting steps</a> with node <var>descendant</var> and oldDocument
+   <var>oldDocument</var>.
+  </ol>
 </ol>
 
 The

--- a/dom.html
+++ b/dom.html
@@ -2418,8 +2418,12 @@ a <var>document</var>, run these steps:</p>
     <li>Let <var>oldDocument</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
     <li>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from
  its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>Set <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendants</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. 
-    <li>Run any <a data-link-type="dfn" href="#concept-node-adopt-ext">adopting steps</a> defined for <var>node</var> in <a data-link-type="dfn" href="#other-applicable-specifications">other applicable specifications</a> and pass <var>node</var> and <var>oldDocument</var> as parameters. 
+    <li>
+      For each <var>descendant</var> in <var>nodes</var>’s <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendants</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run these substeps: 
+     <ol>
+      <li>Set <var>descendant</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. 
+      <li>Run the <a data-link-type="dfn" href="#concept-node-adopt-ext">adopting steps</a> with node <var>descendant</var> and oldDocument <var>oldDocument</var>. 
+     </ol>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-adoptnode">adoptNode(<var>node</var>)<a class="self-link" href="#dom-document-adoptnode"></a></dfn> method must run these steps:</p>
    <ol>

--- a/dom.html
+++ b/dom.html
@@ -67,9 +67,9 @@
  </head>
  <body class="h-entry status-LS">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a></p>
+   <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-08-25">25 August 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-09-03">3 September 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:
@@ -211,14 +211,14 @@
   </div>
   <main>
    <p></p>
-   <script async="" src="https://resources.whatwg.org/file-issue.js"></script>
+<script async="" src="https://resources.whatwg.org/file-issue.js"></script>
    <h2 class="no-num heading settled" id="goals"><span class="content">Goals</span></h2>
    <p>This specification standardizes the DOM. It does so as follows:</p>
    <ol>
     <li>
-     <p>By consolidating <cite>DOM Level 3 Core</cite><a data-link-type="biblio" href="#biblio-dom-level-3-core">[DOM-Level-3-Core]</a>, <cite>Element Traversal</cite><a data-link-type="biblio" href="#biblio-elementtraversal">[ELEMENTTRAVERSAL]</a>, <cite>Selectors API Level 2</cite><a data-link-type="biblio" href="#biblio-selectors-api2">[SELECTORS-API2]</a>, the
-  "DOM Event Architecture" and "Basic Event Interfaces" chapters of <cite>DOM Level 3 Events</cite><a data-link-type="biblio" href="#biblio-uievents-20031107">[uievents-20031107]</a> (specific types of events do not
-  belong in the DOM Standard), and <cite>DOM Level 2 Traversal and Range</cite><a data-link-type="biblio" href="#biblio-dom-level-2-traversal-range">[DOM-Level-2-Traversal-Range]</a>, and: </p>
+     <p>By consolidating <cite>DOM Level 3 Core</cite> <a data-link-type="biblio" href="#biblio-dom-level-3-core">[DOM-Level-3-Core]</a>, <cite>Element Traversal</cite> <a data-link-type="biblio" href="#biblio-elementtraversal">[ELEMENTTRAVERSAL]</a>, <cite>Selectors API Level 2</cite> <a data-link-type="biblio" href="#biblio-selectors-api2">[SELECTORS-API2]</a>, the
+  "DOM Event Architecture" and "Basic Event Interfaces" chapters of <cite>DOM Level 3 Events</cite> <a data-link-type="biblio" href="#biblio-uievents-20031107">[uievents-20031107]</a> (specific types of events do not
+  belong in the DOM Standard), and <cite>DOM Level 2 Traversal and Range</cite> <a data-link-type="biblio" href="#biblio-dom-level-2-traversal-range">[DOM-Level-2-Traversal-Range]</a>, and: </p>
      <ul class="brief">
       <li>Aligning them with the JavaScript ecosystem where possible. 
       <li>Aligning them with existing implementations. 
@@ -229,7 +229,7 @@
  specified as part of the DOM Standard. </p>
     <li>
      <p>By defining a replacement for the "Mutation Events" and
-  "Mutation Name Event Types" chapters of <cite>DOM Level 3 Events</cite><a data-link-type="biblio" href="#biblio-uievents-20031107">[uievents-20031107]</a> as the old model
+  "Mutation Name Event Types" chapters of <cite>DOM Level 3 Events</cite> <a data-link-type="biblio" href="#biblio-uievents-20031107">[uievents-20031107]</a> as the old model
   was problematic. </p>
      <p class="note no-backref" role="note">The old model is expected to be removed from implementations
   in due course. </p>
@@ -265,7 +265,7 @@ out of memory, or to work around platform-specific limitations. </p>
    <p>The IDL fragments in this specification must be interpreted as
 required for conforming IDL fragments, as described in the Web IDL
 specification. <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a></p>
-   <p>Some of the terms used in this specification are defined in <cite>Encoding</cite>, <cite>Selectors</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and <cite>Namespaces in XML</cite>. <a data-link-type="biblio" href="#biblio-encoding">[ENCODING]</a><a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a><a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a><a data-link-type="biblio" href="#biblio-xml">[XML]</a><a data-link-type="biblio" href="#biblio-xml-names">[XML-NAMES]</a></p>
+   <p>Some of the terms used in this specification are defined in <cite>Encoding</cite>, <cite>Selectors</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and <cite>Namespaces in XML</cite>. <a data-link-type="biblio" href="#biblio-encoding">[ENCODING]</a> <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> <a data-link-type="biblio" href="#biblio-webidl">[WEBIDL]</a> <a data-link-type="biblio" href="#biblio-xml">[XML]</a> <a data-link-type="biblio" href="#biblio-xml-names">[XML-NAMES]</a></p>
    <h3 class="heading settled" data-level="1.2" id="extensibility"><span class="secno">1.2. </span><span class="content">Extensibility</span><a class="self-link" href="#extensibility"></a></h3>
    <p>Vendor-specific proprietary extensions to this specification are
 strongly discouraged. Authors must not use such extensions, as
@@ -305,11 +305,11 @@ first <a data-link-type="dfn" href="#concept-tree-child">child</a> or null if it
    <p>The <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" id="concept-tree-last-child">last child<a class="self-link" href="#concept-tree-last-child"></a></dfn> of an object is its
 last <a data-link-type="dfn" href="#concept-tree-child">child</a> or null if it has no <a data-link-type="dfn" href="#concept-tree-child">children</a>.</p>
    <p>The <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" id="concept-tree-previous-sibling">previous sibling<a class="self-link" href="#concept-tree-previous-sibling"></a></dfn> of an
-object is its first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> or null if it has no <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a>.</p>
+object is its first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> or null if it has no <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a>.</p>
    <p>The <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" id="concept-tree-next-sibling">next sibling<a class="self-link" href="#concept-tree-next-sibling"></a></dfn> of an
-object is its first <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> or null if it has no <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a>.</p>
+object is its first <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> or null if it has no <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a>.</p>
    <p>The <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" id="concept-tree-index">index<a class="self-link" href="#concept-tree-index"></a></dfn> of an object is its number
-of <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><a data-link-type="dfn" href="#concept-tree-sibling">siblings</a>.</p>
+of <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a>.</p>
    <h3 class="heading settled" data-level="2.2" id="strings"><span class="secno">2.2. </span><span class="content">Strings</span><a class="self-link" href="#strings"></a></h3>
    <p>Comparing two strings in a <dfn data-dfn-type="dfn" data-export="" data-lt="case-sensitive|case-sensitively" id="case_sensitive">case-sensitive<a class="self-link" href="#case_sensitive"></a></dfn> manner means
 comparing them exactly, code point for code point.</p>
@@ -356,17 +356,17 @@ corresponding characters in the range U+0061 to U+007A, inclusive.</p>
 return value.</p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-ordered-set-serializer">ordered set serializer<a class="self-link" href="#concept-ordered-set-serializer"></a></dfn> takes a <var>set</var> and returns the concatenation of the strings in <var>set</var>, separated from each other by U+0020.</p>
    <h3 class="heading settled" data-level="2.4" id="selectors"><span class="secno">2.4. </span><span class="content">Selectors</span><a class="self-link" href="#selectors"></a></h3>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="match-a-relative-selectors-string">match a relative selectors string<a class="self-link" href="#match-a-relative-selectors-string"></a></dfn><var>relativeSelectors</var> against a <var>set</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" id="match-a-relative-selectors-string">match a relative selectors string<a class="self-link" href="#match-a-relative-selectors-string"></a></dfn> <var>relativeSelectors</var> against a <var>set</var>, run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-relative-selector">parse a relative selector</a> from <var>relativeSelectors</var> against <var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-relative-selector">parse a relative selector</a> from <var>relativeSelectors</var> against <var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
     <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
-    <li>Return the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a><var>s</var> using <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope elements</a><var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>Return the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a> <var>s</var> using <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope elements</a> <var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="scope_match-a-selectors-string">scope-match a selectors string<a class="self-link" href="#scope_match-a-selectors-string"></a></dfn><var>selectors</var> against a <var>node</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" id="scope_match-a-selectors-string">scope-match a selectors string<a class="self-link" href="#scope_match-a-selectors-string"></a></dfn> <var>selectors</var> against a <var>node</var>, run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a><var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
     <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
-    <li>Return the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a><var>s</var> against <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> using <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scoping-root">scoping root</a><var>node</var> and
+    <li>Return the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a> <var>s</var> against <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> using <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scoping-root">scoping root</a> <var>node</var> and
  scoping method <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope_filtered">scope-filtered</a>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. 
    </ol>
    <p class="note" role="note">Support for namespaces within selectors is not planned and will not be
@@ -384,7 +384,7 @@ added. </p>
 run these steps:</p>
    <ol>
     <li>If <var>namespace</var> is the empty string, set it to null. 
-    <li><a data-link-type="dfn" href="#validate">Validate</a><var>qualifiedName</var>. Rethrow any exceptions. 
+    <li><a data-link-type="dfn" href="#validate">Validate</a> <var>qualifiedName</var>. Rethrow any exceptions. 
     <li>Let <var>prefix</var> be null. 
     <li>Let <var>localName</var> be <var>qualifiedName</var>. 
     <li>If <var>qualifiedName</var> contains a "<code>:</code>" (U+003E), then split the
@@ -416,7 +416,7 @@ passed as argument to <a data-link-type="dfn" href="#concept-event-listener">eve
 object to which the <a data-link-type="dfn" href="#concept-event">event</a> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> (<var>obj</var> above).</p>
    <p>Now while typically <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent as
 the result of user interaction or the completion of some task, applications
-can <a data-link-type="dfn" href="#concept-event-dispatch">dispatch</a><a data-link-type="dfn" href="#concept-event">events</a> themselves, commonly known as
+can <a data-link-type="dfn" href="#concept-event-dispatch">dispatch</a> <a data-link-type="dfn" href="#concept-event">events</a> themselves, commonly known as
 synthetic events:</p>
 <pre class="lang-javascript highlight"><span class="c1">// add an appropriate event listener</span>
 <span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"cat"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span> <span class="nx">process</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">detail</span><span class="p">)</span> <span class="p">})</span>
@@ -429,15 +429,15 @@ sometimes also used to let an application control what happens next in an
 operation. For instance as part of form submission an <a data-link-type="dfn" href="#concept-event">event</a> whose <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is
 "<code>submit</code>" is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>. If this <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> method is
 invoked, form submission will be terminated. Applications who wish to make
-use of this functionality through <a data-link-type="dfn" href="#concept-event">events</a><a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the application
+use of this functionality through <a data-link-type="dfn" href="#concept-event">events</a> <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the application
 (synthetic events) can make use of the return value of the <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-dispatchevent">dispatchEvent()</a></code> method:</p>
 <pre class="lang-javascript highlight"><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
   <span class="c1">// event was not canceled, time for some magic</span>
   <span class="err">…</span>
 <span class="p">}</span></pre>
-   <p>When an <a data-link-type="dfn" href="#concept-event">event</a> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to an object that <a data-link-type="dfn" href="#concept-tree-participate">participates</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> (e.g. an <a data-link-type="dfn" href="#concept-element">element</a>), it can reach <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> on that object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> too. First all object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a><a data-link-type="dfn" href="#concept-event-listener">event listeners</a> whose <b>capture</b> variable is set to true are invoked, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. Second, object’s own <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked. And
+   <p>When an <a data-link-type="dfn" href="#concept-event">event</a> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to an object that <a data-link-type="dfn" href="#concept-tree-participate">participates</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> (e.g. an <a data-link-type="dfn" href="#concept-element">element</a>), it can reach <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> on that object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> too. First all object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> whose <b>capture</b> variable is set to true are invoked, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. Second, object’s own <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked. And
 finally, and only if <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> attribute value is true,
-object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a><a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked again,
+object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked again,
 but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.</p>
    <p>Lets look at an example of how <a data-link-type="dfn" href="#concept-event">events</a> work in a <a data-link-type="dfn" href="#concept-tree">tree</a>:</p>
 <pre class="lang-markup highlight"><span class="cp">&lt;!doctype html></span>
@@ -458,12 +458,12 @@ but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order
   <span class="nt">&lt;/script></span>
  <span class="nt">&lt;/body></span>
 <span class="nt">&lt;/html></span></pre>
-   <p>The <code>debug</code> function will be invoked twice. Each time the <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value will be the <code>span</code><a data-link-type="dfn" href="#concept-element">element</a>. The
+   <p>The <code>debug</code> function will be invoked twice. Each time the <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value will be the <code>span</code> <a data-link-type="dfn" href="#concept-element">element</a>. The
 first time <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute’s
 value will be the <a data-link-type="dfn" href="#concept-document">document</a>, the second
-time the <code>body</code><a data-link-type="dfn" href="#concept-element">element</a>. <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute’s value
+time the <code>body</code> <a data-link-type="dfn" href="#concept-element">element</a>. <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute’s value
 switches from <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-event-bubbling_phase">BUBBLING_PHASE</a></code>. If an <a data-link-type="dfn" href="#concept-event-listener">event listener</a> was registered for
-the <code>span</code><a data-link-type="dfn" href="#concept-element">element</a>, <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute’s value
+the <code>span</code> <a data-link-type="dfn" href="#concept-element">element</a>, <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute’s value
 would have been <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>.</p>
    <h3 class="heading settled" data-level="3.2" id="interface-event"><span class="secno">3.2. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#event">Event</a></code></span><a class="self-link" href="#interface-event"></a></h3>
 <pre class="idl">[<dfn class="idl-code" data-dfn-for="Event" data-dfn-type="constructor" data-export="" data-lt="Event(type, eventInitDict)" id="dom-event-event">Constructor<a class="self-link" href="#dom-event-event"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="Event/Event(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-event-event-type-eventinitdict-type">type<a class="self-link" href="#dom-event-event-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-eventinit">EventInit</a> <dfn class="idl-code" data-dfn-for="Event/Event(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-event-event-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-event-event-type-eventinitdict-eventinitdict"></a></dfn>),
@@ -503,45 +503,45 @@ something has occurred, e.g. that an image has completed downloading. It is
 represented by the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface or an interface that
 inherits from the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface.</p>
    <dl class="domintro">
-    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-event-event">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
+    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-event-event">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code> 
     <dd>Returns a new <var>event</var> whose <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is set to <var>type</var>. The optional <code class="idl"><a class="idl-code" data-link-type="argument" href="#dom-event-event-type-eventinitdict-eventinitdict">eventInitDict</a></code> argument
  allows for setting the <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attributes via object
  members of the same name. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code></code> 
     <dd>Returns the type of <var>event</var>, e.g.
  "<code>click</code>", "<code>hashchange</code>", or
  "<code>submit</code>". 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code></code> 
     <dd>Returns the object to which <var>event</var> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code></code> 
     <dd>Returns the object whose <a data-link-type="dfn" href="#concept-event-listener">event listener</a>’s <b>callback</b> is currently being
  invoked. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-event">event</a>’s phase, which is one of <code class="idl"><a data-link-type="idl" href="#dom-event-none">NONE</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-event-bubbling_phase">BUBBLING_PHASE</a></code>. 
-    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stoppropagation">stopPropagation</a>()</code>
+    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stoppropagation">stopPropagation</a>()</code> 
     <dd>When <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, invoking this method prevents <var>event</var> from reaching any objects other than the current object. 
-    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stopimmediatepropagation">stopImmediatePropagation</a>()</code>
+    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stopimmediatepropagation">stopImmediatePropagation</a>()</code> 
     <dd>Invoking this method prevents <var>event</var> from reaching
  any registered <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> after the current one finishes running and, when <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, also prevents <var>event</var> from reaching any
  other objects. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code></code> 
     <dd>Returns true or false depending on how <var>event</var> was initialized. True if <var>event</var> goes through its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, and false otherwise. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code></code> 
     <dd>Returns true or false depending on how <var>event</var> was initialized. Its return
  value does not always carry meaning, but true can indicate that part of the operation
  during which <var>event</var> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>, can be canceled by invoking the <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> method. 
-    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-preventdefault">preventDefault</a>()</code>
+    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-preventdefault">preventDefault</a>()</code> 
     <dd>If invoked when the <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute value is true,
  signals to the operation that caused <var>event</var> to be <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> that it needs to be
  canceled. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-defaultprevented">defaultPrevented</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-defaultprevented">defaultPrevented</a></code></code> 
     <dd>Returns true if <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> was invoked
  while the <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute
  value is true, and false otherwise. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code></code> 
     <dd>Returns true if <var>event</var> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent, and
  false otherwise. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-timestamp">timeStamp</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-timestamp">timeStamp</a></code></code> 
     <dd>Returns the creation time of <var>event</var> as the number of milliseconds that
  passed since 00:00:00 UTC on 1 January 1970. 
    </dl>
@@ -570,11 +570,11 @@ the following:</p>
    <p>Each <a data-link-type="dfn" href="#concept-event">event</a> has the following associated
 flags that are all initially unset:</p>
    <ul>
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-propagation-flag">stop propagation flag<a class="self-link" href="#stop-propagation-flag"></a></dfn>
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-immediate-propagation-flag">stop immediate propagation flag<a class="self-link" href="#stop-immediate-propagation-flag"></a></dfn>
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="canceled-flag">canceled flag<a class="self-link" href="#canceled-flag"></a></dfn>
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="initialized-flag">initialized flag<a class="self-link" href="#initialized-flag"></a></dfn>
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="dispatch-flag">dispatch flag<a class="self-link" href="#dispatch-flag"></a></dfn>
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-propagation-flag">stop propagation flag<a class="self-link" href="#stop-propagation-flag"></a></dfn> 
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-immediate-propagation-flag">stop immediate propagation flag<a class="self-link" href="#stop-immediate-propagation-flag"></a></dfn> 
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="canceled-flag">canceled flag<a class="self-link" href="#canceled-flag"></a></dfn> 
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="initialized-flag">initialized flag<a class="self-link" href="#initialized-flag"></a></dfn> 
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="dispatch-flag">dispatch flag<a class="self-link" href="#dispatch-flag"></a></dfn> 
    </ul>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="method" data-export="" id="dom-event-stoppropagation">stopPropagation()<a class="self-link" href="#dom-event-stoppropagation"></a></dfn> method must set the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="method" data-export="" id="dom-event-stopimmediatepropagation">stopImmediatePropagation()<a class="self-link" href="#dom-event-stopimmediatepropagation"></a></dfn> method must set both the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -628,12 +628,12 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
 </pre>
    <p><a data-link-type="dfn" href="#concept-event">Events</a> using the <code class="idl"><a data-link-type="idl" href="#customevent">CustomEvent</a></code> interface can be used to carry custom data.</p>
    <dl class="domintro">
-    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-customevent-customevent">CustomEvent</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
+    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-customevent-customevent">CustomEvent</a>(<var>type</var> [, <var>eventInitDict</var>])</code> 
     <dd>Works analogously to the constructor for <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> except
  that the optional <var>eventInitDict</var> argument now
  allows for setting the <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code> attribute
  too.IDL 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code></code>
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code></code> 
     <dd>Returns any custom data <var>event</var> was created with.
  Typically used for synthetic events. 
    </dl>
@@ -689,7 +689,7 @@ callback with a specific <a data-link-type="dfn" href="#concept-event">event</a>
 historical reasons. As can be seen from the definition above, an <a data-link-type="dfn" href="#concept-event-listener">event listener</a> is a more broad
 concept. </p>
    <dl class="domintro">
-    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-addeventlistener">addEventListener</a>(<var>type</var>, <var>callback</var> [, <var>capture</var> = false])</code>
+    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-addeventlistener">addEventListener</a>(<var>type</var>, <var>callback</var> [, <var>capture</var> = false])</code> 
     <dd>
       Appends an <a data-link-type="dfn" href="#concept-event-listener">event listener</a> for <a data-link-type="dfn" href="#concept-event">events</a> whose <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value
   is <var>type</var>. The <var>callback</var> argument sets the <b>callback</b> that will
@@ -699,9 +699,9 @@ concept. </p>
   When false, <b>callback</b> will not be invoked when <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute value is <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code>. Either way, <b>callback</b> will be
   invoked if <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute value is <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>. 
      <p>The <a data-link-type="dfn" href="#concept-event-listener">event listener</a> is appended to <var>target</var>’s list of <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> and is not appended if it is a duplicate, i.e. having the same <b>type</b>, <b>callback</b>, and <b>capture</b> values.</p>
-    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-removeeventlistener">removeEventListener</a>(<var>type</var>, <var>callback</var> [, <var>capture</var> = false])</code>
+    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-removeeventlistener">removeEventListener</a>(<var>type</var>, <var>callback</var> [, <var>capture</var> = false])</code> 
     <dd>Remove the <a data-link-type="dfn" href="#concept-event-listener">event listener</a> in <var>target</var>’s list of <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> with the same <var>type</var>, <var>callback</var>, and <var>capture</var>. 
-    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-dispatchevent">dispatchEvent</a>(<var>event</var>)</code>
+    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-dispatchevent">dispatchEvent</a>(<var>event</var>)</code> 
     <dd><a data-link-type="dfn" href="#concept-event-dispatch">Dispatches</a> a synthetic event <var>event</var> to <var>target</var> and returns
  true if either <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute value is false or its <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> method was not invoked, and false otherwise. 
    </dl>
@@ -806,31 +806,31 @@ applications.</p>
    <p>It is represented as follows:</p>
    <ul class="domTree">
     <li>
-     <a data-link-type="dfn" href="#concept-document">Document</a>
+      <a data-link-type="dfn" href="#concept-document">Document</a> 
      <ul>
-      <li class="t10"><a data-link-type="dfn" href="#concept-doctype">Doctype</a>: <code>html</code>
+      <li class="t10"><a data-link-type="dfn" href="#concept-doctype">Doctype</a>: <code>html</code> 
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>html</code><span class="t2"><code class="attribute name">class</code>="<code class="attribute value">e</code>"</span>
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>html</code> <span class="t2"><code class="attribute name">class</code>="<code class="attribute value">e</code>"</span> 
        <ul>
         <li class="t1">
-         <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>head</code>
+          <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>head</code> 
          <ul>
           <li class="t1">
-           <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>title</code>
+            <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>title</code> 
            <ul>
-            <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Aliens?</span>
+            <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Aliens?</span> 
            </ul>
          </ul>
-        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>⏎␣</span>
+        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>⏎␣</span> 
         <li class="t1">
-         <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>body</code>
+          <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>body</code> 
          <ul>
-          <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Why yes.⏎</span>
+          <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Why yes.⏎</span> 
          </ul>
        </ul>
      </ul>
    </ul>
-   <p>Note that, due to the magic that is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#html-parser">HTML parsing</a>, not all <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a> were turned into <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>, but the general
+   <p>Note that, due to the magic that is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#html-parser">HTML parsing</a>, not all <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a> were turned into <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>, but the general
 concept is clear. Markup goes in, a <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-type="dfn" href="#concept-node">nodes</a> comes out.</p>
    <p class="note no-backref" role="note">The most excellent <a href="http://software.hixie.ch/utilities/js/live-dom-viewer/">Live DOM Viewer</a> can be used to explore this matter in more detail. </p>
    <h3 class="heading settled" data-level="4.2" id="node-trees"><span class="secno">4.2. </span><span class="content">Node tree</span><a class="self-link" href="#node-trees"></a></h3>
@@ -839,7 +839,7 @@ or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
    <p>A <a data-link-type="dfn" href="#concept-node-tree">node tree</a> is constrained as
 follows, expressed as a relationship between the type of <a data-link-type="dfn" href="#concept-node">node</a> and its allowed <a data-link-type="dfn" href="#concept-tree-child">children</a>:</p>
    <dl>
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
     <dd>
       In <a data-link-type="dfn" href="#concept-tree-order">tree order</a>: 
      <ol>
@@ -849,22 +849,22 @@ follows, expressed as a relationship between the type of <a data-link-type="dfn"
       <li>Optionally one <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> node. 
       <li>Zero or more nodes each of which is either <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>. 
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>Zero or more nodes each of which is one of <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>, or <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
     <dd>None. 
    </dl>
-   <p>The <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-length">length<a class="self-link" href="#concept-node-length"></a></dfn> of a <a data-link-type="dfn" href="#concept-node">node</a><var>node</var> depends on <var>node</var>:</p>
+   <p>The <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-length">length<a class="self-link" href="#concept-node-length"></a></dfn> of a <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> depends on <var>node</var>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
     <dd>Zero. 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
     <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute
  value. 
     <dt>Any other node 
@@ -874,25 +874,25 @@ follows, expressed as a relationship between the type of <a data-link-type="dfn"
    <h4 class="heading settled" data-level="4.2.1" id="mutation-algorithms"><span class="secno">4.2.1. </span><span class="content">Mutation algorithms</span><a class="self-link" href="#mutation-algorithms"></a></h4>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-ensure-pre-insertion-validity">ensure pre-insertion validity<a class="self-link" href="#concept-node-ensure-pre-insertion-validity"></a></dfn> of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:</p>
    <ol>
-    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
     <li>If <var>child</var> is not null and its <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
-    <li>If either <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> and <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, or <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a> and <var>parent</var> is
+    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+    <li>If either <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> and <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, or <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a> and <var>parent</var> is
  not a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
     <li>
       If <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, and any of the statements below, switched
   on <var>node</var>, are true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
      <dl class="switch">
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> 
       <dd>
-        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-child">child</a>. 
-       <p>Otherwise, if <var>node</var> has one <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a> and either <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, or <var>child</var> is not null and
-    a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a><var>child</var>.</p>
-      <dt><a data-link-type="dfn" href="#concept-element">element</a>
-      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, or <var>child</var> is not null and a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a><var>child</var>. 
-      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a>
-      <dd><var>parent</var> has a <a data-link-type="dfn" href="#concept-doctype">doctype</a><a data-link-type="dfn" href="#concept-tree-child">child</a>, an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><var>child</var>, or <var>child</var> is null and <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a>. 
+        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
+       <p>Otherwise, if <var>node</var> has one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> and either <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, or <var>child</var> is not null and
+    a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>.</p>
+      <dt><a data-link-type="dfn" href="#concept-element">element</a> 
+      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, or <var>child</var> is not null and a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>. 
+      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a> 
+      <dd><var>parent</var> has a <a data-link-type="dfn" href="#concept-doctype">doctype</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>, an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>child</var>, or <var>child</var> is null and <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
      </dl>
    </ol>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-pre-insert">pre-insert<a class="self-link" href="#concept-node-pre-insert"></a></dfn> a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:</p>
@@ -901,8 +901,8 @@ follows, expressed as a relationship between the type of <a data-link-type="dfn"
     <li>Let <var>reference child</var> be <var>child</var>. 
     <li>If <var>reference child</var> is <var>node</var>, set it
  to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a><var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a><var>node</var> into <var>parent</var> before <var>reference child</var>. 
+    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>. 
     <li>Return <var>node</var>. 
    </ol>
    <p><a data-link-type="dfn" href="#other-applicable-specifications">Specifications</a> may define <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-insert-ext">insertion steps<a class="self-link" href="#concept-node-insert-ext"></a></dfn> for all or some <a data-link-type="dfn" href="#concept-node">nodes</a>. The algorithm is passed <var>newNode</var> as
@@ -910,7 +910,7 @@ indicated in the <a data-link-type="dfn" href="#concept-node-insert">insert</a> 
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-insert">insert<a class="self-link" href="#concept-node-insert"></a></dfn> a <var>node</var> into a <var>parent</var> before a <var>child</var>, with an optional <i>suppress observers flag</i>, run these steps:</p>
    <ol>
     <li>Let <var>count</var> be the number of <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>node</var> if
- it is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>,
+ it is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>,
  and one otherwise. 
     <li>
       If <var>child</var> is non-null, run these substeps: 
@@ -921,11 +921,11 @@ indicated in the <a data-link-type="dfn" href="#concept-node-insert">insert</a> 
    increase its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by <var>count</var>. 
      </ol>
     <li>Let <var>nodes</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is
- a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, and a
+ a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a
  list containing solely <var>node</var> otherwise. 
-    <li>If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a> its <a data-link-type="dfn" href="#concept-tree-child">children</a> with the <i>suppress observers flag</i> set. 
+    <li>If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a> its <a data-link-type="dfn" href="#concept-tree-child">children</a> with the <i>suppress observers flag</i> set. 
     <li>
-      If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>node</var> with removedNodes <var>nodes</var>. 
+      If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>node</var> with removedNodes <var>nodes</var>. 
      <p class="note no-backref" role="note">This step intentionally does not pay attention to the <i>suppress observers flag</i>. </p>
     <li>
       For each <var>newNode</var> in <var>nodes</var>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run these substeps: 
@@ -935,28 +935,28 @@ indicated in the <a data-link-type="dfn" href="#concept-node-insert">insert</a> 
      </ol>
     <li>If <i>suppress observers flag</i> is unset, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with addedNodes <var>nodes</var>, nextSibling <var>child</var>, and previousSibling <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> or <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>child</var> is null. 
    </ol>
-   <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-append">append<a class="self-link" href="#concept-node-append"></a></dfn> a <var>node</var> to a <var>parent</var>, <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a><var>node</var> into <var>parent</var> before null.</p>
+   <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-append">append<a class="self-link" href="#concept-node-append"></a></dfn> a <var>node</var> to a <var>parent</var>, <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> <var>node</var> into <var>parent</var> before null.</p>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-replace">replace<a class="self-link" href="#concept-node-replace"></a></dfn> a <var>child</var> with <var>node</var> within a <var>parent</var>, run these
 steps:</p>
    <ol>
-    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
     <li>If <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
-    <li>If either <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> and <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, or <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a> and <var>parent</var> is
+    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+    <li>If either <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> and <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, or <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a> and <var>parent</var> is
  not a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
     <li>
       If <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, and any of the statements below, switched
   on <var>node</var>, are true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
      <dl class="switch">
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> 
       <dd>
-        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-child">child</a>. 
-       <p>Otherwise, if <var>node</var> has one <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a> and either <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var> or a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a><var>child</var>.</p>
-      <dt><a data-link-type="dfn" href="#concept-element">element</a>
-      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var> or a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a><var>child</var>. 
-      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a>
-      <dd><var>parent</var> has a <a data-link-type="dfn" href="#concept-doctype">doctype</a><a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var>, or an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><var>child</var>. 
+        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
+       <p>Otherwise, if <var>node</var> has one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> and either <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var> or a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>.</p>
+      <dt><a data-link-type="dfn" href="#concept-element">element</a> 
+      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var> or a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>. 
+      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a> 
+      <dd><var>parent</var> has a <a data-link-type="dfn" href="#concept-doctype">doctype</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var>, or an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>child</var>. 
      </dl>
      <p class="note no-backref" role="note">The above statements differ from the <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> algorithm. </p>
     <li>Let <var>reference child</var> be <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
@@ -964,22 +964,22 @@ steps:</p>
  to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
     <li>
      <p>Let <var>previousSibling</var> be <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>. </p>
-    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a><var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a><var>child</var> from its <var>parent</var> with the <i>suppress observers flag</i> set. 
-    <li>Let <var>nodes</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, and a list containing solely <var>node</var> otherwise. 
-    <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a><var>node</var> into <var>parent</var> before <var>reference child</var> with
+    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>child</var> from its <var>parent</var> with the <i>suppress observers flag</i> set. 
+    <li>Let <var>nodes</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a list containing solely <var>node</var> otherwise. 
+    <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var> with
  the <i>suppress observers flag</i> set. 
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>childList</code>" for target <var>parent</var> with addedNodes <var>nodes</var>, removedNodes a list solely containing <var>child</var>, nextSibling <var>reference child</var>, and previousSibling <var>previousSibling</var>. 
     <li>Return <var>child</var>. 
    </ol>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-replace-all">replace all<a class="self-link" href="#concept-node-replace-all"></a></dfn> with a <var>node</var> within a <var>parent</var>, run these steps:</p>
    <ol>
-    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-adopt">adopt</a><var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
+    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-adopt">adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
     <li>Let <var>removedNodes</var> be <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
     <li>Let <var>addedNodes</var> be the empty list if <var>node</var> is
- null, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, and a list containing <var>node</var> otherwise. 
+ null, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a list containing <var>node</var> otherwise. 
     <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> all <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, with the <i>suppress observers flag</i> set. 
-    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-insert">insert</a><var>node</var> into <var>parent</var> before null with the <i>suppress observers flag</i> set. 
+    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-insert">insert</a> <var>node</var> into <var>parent</var> before null with the <i>suppress observers flag</i> set. 
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with addedNodes <var>addedNodes</var> and
  removedNodes <var>removedNodes</var>. 
    </ol>
@@ -987,7 +987,7 @@ steps:</p>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-pre-remove">pre-remove<a class="self-link" href="#concept-node-pre-remove"></a></dfn> a <var>child</var> from a <var>parent</var>, run these steps:</p>
    <ol>
     <li>If <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a><var>child</var> from <var>parent</var>. 
+    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>child</var> from <var>parent</var>. 
     <li>Return <var>child</var>. 
    </ol>
    <p><a data-link-type="dfn" href="#other-applicable-specifications">Specifications</a> may define <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-remove-ext">removing steps<a class="self-link" href="#concept-node-remove-ext"></a></dfn> for all or some <a data-link-type="dfn" href="#concept-node">nodes</a>. The algorithm is passed <var>removedNode</var>, <var>oldParent</var>, and <var>oldPreviousSibling</var>, as indicated in the <a data-link-type="dfn" href="#concept-node-remove">remove</a> algorithm below.</p>
@@ -1003,11 +1003,11 @@ steps:</p>
     <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>index</var>, decrease its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by one. 
     <li>
      <p>For each <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object <var>iterator</var> whose <a data-link-type="dfn" href="#concept-traversal-root">root</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>, run the <a data-link-type="dfn" href="#nodeiterator-pre_removing-steps"><code>NodeIterator</code> pre-removing steps</a> given <var>node</var> and <var>iterator</var>. </p>
-    <li>Let <var>oldPreviousSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>
+    <li>Let <var>oldPreviousSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> 
     <li>Remove <var>node</var> from its <var>parent</var>. 
     <li>Run the <a data-link-type="dfn" href="#concept-node-remove-ext">removing steps</a> with <var>node</var>, <var>parent</var>, and <var>oldPreviousSibling</var>. 
-    <li>For each <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a><var>ancestor</var> of <var>parent</var>, if <var>ancestor</var> has any <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>options</b>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> is true, then for each
- such <a data-link-type="dfn" href="#registered-observer">registered observer</a><var>registered</var>, append a <a data-link-type="dfn" href="#transient-registered-observer">transient registered observer</a> whose <b>observer</b> and <b>options</b> are identical to those of <var>registered</var> and <b>source</b> which is <var>registered</var> to <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>. 
+    <li>For each <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> <var>ancestor</var> of <var>parent</var>, if <var>ancestor</var> has any <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>options</b>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> is true, then for each
+ such <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var>, append a <a data-link-type="dfn" href="#transient-registered-observer">transient registered observer</a> whose <b>observer</b> and <b>options</b> are identical to those of <var>registered</var> and <b>source</b> which is <var>registered</var> to <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>. 
     <li>If <i>suppress observers flag</i> is unset, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with removedNodes a list solely containing <var>node</var>,
  nextSibling <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>, and previousSibling <var>oldPreviousSibling</var>. 
    </ol>
@@ -1025,7 +1025,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="non
 <a data-link-type="idl-name" href="#documentfragment">DocumentFragment</a> implements <a data-link-type="idl-name" href="#nonelementparentnode">NonElementParentNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-nonelementparentnode-getelementbyid">getElementById</a>(<var>elementId</var>)</code>
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-nonelementparentnode-getelementbyid">getElementById</a>(<var>elementId</var>)</code> 
     <dd>Returns the first <a data-link-type="dfn" href="#concept-element">element</a> within <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> whose <a data-link-type="dfn" href="#concept-id">ID</a> is <var>elementId</var>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="NonElementParentNode" data-dfn-type="method" data-export="" id="dom-nonelementparentnode-getelementbyid">getElementById(<var>elementId</var>)<a class="self-link" href="#dom-nonelementparentnode-getelementbyid"></a></dfn> method must return the first <a data-link-type="dfn" href="#concept-element">element</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, within <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>, whose <a data-link-type="dfn" href="#concept-id">ID</a> is <var>elementId</var>, and null if there is no
@@ -1037,7 +1037,7 @@ run these steps:</p>
     <li>
      <p>Let <var>node</var> be null. </p>
     <li>
-     <p>Replace each string in <var>nodes</var> with a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is the string. </p>
+     <p>Replace each string in <var>nodes</var> with a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is the string. </p>
     <li>
      <p>If <var>nodes</var> contains one <a data-link-type="dfn" href="#concept-node">node</a>, set <var>node</var> to that <a data-link-type="dfn" href="#concept-node">node</a>. </p>
     <li>
@@ -1067,55 +1067,55 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="par
 <a data-link-type="idl-name" href="#element">Element</a> implements <a data-link-type="idl-name" href="#parentnode">ParentNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>collection</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-children">children</a></code></code>
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-child">child</a><a data-link-type="dfn" href="#concept-element">elements</a>. 
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-firstelementchild">firstElementChild</a></code></code>
+    <dt><code><var>collection</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-children">children</a></code></code> 
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-child">child</a> <a data-link-type="dfn" href="#concept-element">elements</a>. 
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-firstelementchild">firstElementChild</a></code></code> 
     <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-lastelementchild">lastElementChild</a></code></code>
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-lastelementchild">lastElementChild</a></code></code> 
     <dd>Returns the last <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-prepend">prepend</a>(<var>nodes</var>)</code>
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-prepend">prepend</a>(<var>nodes</var>)</code> 
     <dd>
-      Inserts <var>nodes</var> before the <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>. 
+      Inserts <var>nodes</var> before the <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-append">append</a>(<var>nodes</var>)</code>
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-append">append</a>(<var>nodes</var>)</code> 
     <dd>
-      Inserts <var>nodes</var> after the <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>. 
+      Inserts <var>nodes</var> after the <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-query">query</a>(<var>relativeSelectors</var>)</code>
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-query">query</a>(<var>relativeSelectors</var>)</code> 
     <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> that is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node</var> that
   matches <var>relativeSelectors</var>. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryall">queryAll</a>(<var>relativeSelectors</var>)</code>
-    <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>node</var> that
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryall">queryAll</a>(<var>relativeSelectors</var>)</code> 
+    <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>node</var> that
   match <var>relativeSelectors</var>. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselector">querySelector</a>(<var>selectors</var>)</code>
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselector">querySelector</a>(<var>selectors</var>)</code> 
     <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> that is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node</var> that
   matches <var>selectors</var>. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselectorall">querySelectorAll</a>(<var>selectors</var>)</code>
-    <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>node</var> that
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselectorall">querySelectorAll</a>(<var>selectors</var>)</code> 
+    <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>node</var> that
   match <var>selectors</var>. 
    </dl>
-   <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-children">children<a class="self-link" href="#dom-parentnode-children"></a></dfn> attribute must return an <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code><a data-link-type="dfn" href="#concept-collection">collection</a> rooted at the <a data-link-type="dfn" href="#context-object">context object</a> matching only <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-child">children</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-children">children<a class="self-link" href="#dom-parentnode-children"></a></dfn> attribute must return an <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> <a data-link-type="dfn" href="#concept-collection">collection</a> rooted at the <a data-link-type="dfn" href="#context-object">context object</a> matching only <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">children</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-firstelementchild">firstElementChild<a class="self-link" href="#dom-parentnode-firstelementchild"></a></dfn> attribute must return the first <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-lastelementchild">lastElementChild<a class="self-link" href="#dom-parentnode-lastelementchild"></a></dfn> attribute must return the last <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-childelementcount">childElementCount<a class="self-link" href="#dom-parentnode-childelementcount"></a></dfn> attribute must return the number of <a data-link-type="dfn" href="#concept-tree-child">children</a> of the <a data-link-type="dfn" href="#context-object">context object</a> that are <a data-link-type="dfn" href="#concept-element">elements</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" data-lt="prepend(nodes...)|prepend(nodes)" id="dom-parentnode-prepend">prepend(<var>nodes</var>)<a class="self-link" href="#dom-parentnode-prepend"></a></dfn> method must run these steps:</p>
    <ol>
     <li>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a><var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a> before the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a> before the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" data-lt="append(nodes...)|append(nodes)" id="dom-parentnode-append">append(<var>nodes</var>)<a class="self-link" href="#dom-parentnode-append"></a></dfn> method must run these steps:</p>
    <ol>
     <li>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>node</var> to the <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>node</var> to the <a data-link-type="dfn" href="#context-object">context object</a>. 
    </ol>
-   <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" id="dom-parentnode-query"><code>query(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-parentnode-query"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a><var>relativeSelectors</var> against
+   <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" id="dom-parentnode-query"><code>query(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-parentnode-query"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a> <var>relativeSelectors</var> against
 a set consisting of <a data-link-type="dfn" href="#context-object">context object</a>, and null if the result is an empty list.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" id="dom-parentnode-queryall"><code>queryAll(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-parentnode-queryall"></a></dfn> method, when invoked, must return an <code class="idl"><a data-link-type="idl">Elements</a></code> array initialized with the result of
-running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a><var>relativeSelectors</var> against
+running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a> <var>relativeSelectors</var> against
 a set consisting of <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" id="dom-parentnode-queryselector"><code>querySelector(<var>selectors</var>)</code><a class="self-link" href="#dom-parentnode-queryselector"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#scope_match-a-selectors-string">scope-match a selectors string</a><var>selectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>, and null if the result is an empty list otherwise.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" id="dom-parentnode-queryselector"><code>querySelector(<var>selectors</var>)</code><a class="self-link" href="#dom-parentnode-queryselector"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#scope_match-a-selectors-string">scope-match a selectors string</a> <var>selectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>, and null if the result is an empty list otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" id="dom-parentnode-queryselectorall"><code>querySelectorAll(<var>selectors</var>)</code><a class="self-link" href="#dom-parentnode-queryselectorall"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-collection-static">static</a> result of
-running <a data-link-type="dfn" href="#scope_match-a-selectors-string">scope-match a selectors string</a><var>selectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+running <a data-link-type="dfn" href="#scope_match-a-selectors-string">scope-match a selectors string</a> <var>selectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <h4 class="heading settled" data-level="4.2.4" id="interface-nondocumenttypechildnode"><span class="secno">4.2.4. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#nondocumenttypechildnode">NonDocumentTypeChildNode</a></code></span><a class="self-link" href="#interface-nondocumenttypechildnode"></a></h4>
    <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-nextelementsibling">nextElementSibling</a></code> attributes have been removed from <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> nodes for compatibility
 reasons. If these additions are deemed compatible enough in the future, they could be
@@ -1130,16 +1130,16 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="non
 <a data-link-type="idl-name" href="#characterdata">CharacterData</a> implements <a data-link-type="idl-name" href="#nondocumenttypechildnode">NonDocumentTypeChildNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling</a></code></code>
-    <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling</a></code></code> 
+    <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that
  is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-nextelementsibling">nextElementSibling</a></code></code>
-    <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-nextelementsibling">nextElementSibling</a></code></code> 
+    <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that
  is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
    </dl>
-   <p>The <dfn class="idl-code" data-dfn-for="NonDocumentTypeChildNode" data-dfn-type="attribute" data-export="" id="dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling<a class="self-link" href="#dom-nondocumenttypechildnode-previouselementsibling"></a></dfn> attribute must return the first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>,
+   <p>The <dfn class="idl-code" data-dfn-for="NonDocumentTypeChildNode" data-dfn-type="attribute" data-export="" id="dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling<a class="self-link" href="#dom-nondocumenttypechildnode-previouselementsibling"></a></dfn> attribute must return the first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>,
 and null otherwise.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="NonDocumentTypeChildNode" data-dfn-type="attribute" data-export="" id="dom-nondocumenttypechildnode-nextelementsibling">nextElementSibling<a class="self-link" href="#dom-nondocumenttypechildnode-nextelementsibling"></a></dfn> attribute must return the first <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>,
+   <p>The <dfn class="idl-code" data-dfn-for="NonDocumentTypeChildNode" data-dfn-type="attribute" data-export="" id="dom-nondocumenttypechildnode-nextelementsibling">nextElementSibling<a class="self-link" href="#dom-nondocumenttypechildnode-nextelementsibling"></a></dfn> attribute must return the first <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>,
 and null otherwise.</p>
    <h4 class="heading settled" data-level="4.2.5" id="interface-childnode"><span class="secno">4.2.5. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#childnode">ChildNode</a></code></span><a class="self-link" href="#interface-childnode"></a></h4>
 <pre class="idl">[NoInterfaceObject,
@@ -1155,22 +1155,22 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="chi
 <a data-link-type="idl-name" href="#characterdata">CharacterData</a> implements <a data-link-type="idl-name" href="#childnode">ChildNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-before">before(nodes)</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-before">before(nodes)</a></code></code> 
     <dd>
       Inserts <var>nodes</var> just before <var>node</var>,
-  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>. 
+  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-after">after(nodes)</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-after">after(nodes)</a></code></code> 
     <dd>
       Inserts <var>nodes</var> just after <var>node</var>,
-  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>. 
+  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-replacewith">replaceWith(nodes)</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-replacewith">replaceWith(nodes)</a></code></code> 
     <dd>
       Replaces <var>node</var> with <var>nodes</var>, while
-  replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>. 
+  replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-remove">remove()</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-remove">remove()</a></code></code> 
     <dd>Removes <var>node</var>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="ChildNode" data-dfn-type="method" data-export="" data-lt="before(nodes...)|before(nodes)" id="dom-childnode-before"><code>before(<var>nodes</var>)</code><a class="self-link" href="#dom-childnode-before"></a></dfn> method, when
@@ -1181,13 +1181,13 @@ invoked, must run these steps:</p>
     <li>
      <p>If <var>parent</var> is null, terminate these steps. </p>
     <li>
-     <p>Let <var>viablePreviousSibling</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> not in <var>nodes</var>, and null otherwise. </p>
+     <p>Let <var>viablePreviousSibling</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> not in <var>nodes</var>, and null otherwise. </p>
     <li>
      <p>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>. </p>
     <li>
      <p>If <var>viablePreviousSibling</var> is non-null, set it to <var>viablePreviousSibling</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>, and to <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> otherwise. </p>
     <li>
-     <p><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a><var>node</var> into <var>parent</var> before <var>viablePreviousSibling</var>. </p>
+     <p><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into <var>parent</var> before <var>viablePreviousSibling</var>. </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="ChildNode" data-dfn-type="method" data-export="" data-lt="after(nodes...)|after(nodes)" id="dom-childnode-after"><code>after(<var>nodes</var>)</code><a class="self-link" href="#dom-childnode-after"></a></dfn> method, when
 invoked, must run these steps:</p>
@@ -1197,11 +1197,11 @@ invoked, must run these steps:</p>
     <li>
      <p>If <var>parent</var> is null, terminate these steps. </p>
     <li>
-     <p>Let <var>viableNextSibling</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s first <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> not in <var>nodes</var>, and null otherwise. </p>
+     <p>Let <var>viableNextSibling</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s first <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> not in <var>nodes</var>, and null otherwise. </p>
     <li>
      <p>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>. </p>
     <li>
-     <p><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a><var>node</var> into <var>parent</var> before <var>viableNextSibling</var>. </p>
+     <p><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into <var>parent</var> before <var>viableNextSibling</var>. </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="ChildNode" data-dfn-type="method" data-export="" data-lt="replaceWith(nodes...)|replaceWith(nodes)" id="dom-childnode-replacewith"><code>replaceWith(<var>nodes</var>)</code><a class="self-link" href="#dom-childnode-replacewith"></a></dfn> method,
 when invoked, must run these steps:</p>
@@ -1211,14 +1211,14 @@ when invoked, must run these steps:</p>
     <li>
      <p>If <var>parent</var> is null, terminate these steps. </p>
     <li>
-     <p>Let <var>viableNextSibling</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s first <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> not in <var>nodes</var>, and null otherwise. </p>
+     <p>Let <var>viableNextSibling</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s first <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> not in <var>nodes</var>, and null otherwise. </p>
     <li>
      <p>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>. </p>
     <li>
      <p>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is <var>parent</var>, <a data-link-type="dfn" href="#concept-node-replace">replace</a> the <a data-link-type="dfn" href="#context-object">context object</a> with <var>node</var> within <var>parent</var>. </p>
      <p class="note" role="note"><a data-link-type="dfn" href="#context-object">Context object</a> could have been inserted into <var>node</var>. </p>
     <li>
-     <p>Otherwise, <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a><var>node</var> into <var>parent</var> before <var>viableNextSibling</var>. </p>
+     <p>Otherwise, <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> <var>node</var> into <var>parent</var> before <var>viableNextSibling</var>. </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="ChildNode" data-dfn-type="method" data-export="" id="dom-childnode-remove"><code>remove()</code><a class="self-link" href="#dom-childnode-remove"></a></dfn> method, when invoked, must run
 these steps:</p>
@@ -1241,15 +1241,15 @@ for <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollect
 than <a data-link-type="dfn" href="#concept-element">elements</a> a simple <code class="idl"><a data-link-type="idl">Array</a></code> can be used.)</p>
    </div>
    <dl class="domintro">
-    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-query">query(relativeSelectors)</a></code></code>
+    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-query">query(relativeSelectors)</a></code></code> 
     <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> that is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>elements</var> that
   matches <var>relativeSelectors</var>. 
-    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-queryall">queryAll(relativeSelectors)</a></code></code>
-    <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a><a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>elements</var> that
+    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-queryall">queryAll(relativeSelectors)</a></code></code> 
+    <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>elements</var> that
   match <var>relativeSelectors</var>. 
    </dl>
-   <p>The <dfn class="idl-code" data-dfn-for="Elements" data-dfn-type="method" data-export="" id="dom-elements-query"><code>query(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-elements-query"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a><var>relativeSelectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>, and null if the result is an empty list.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="Elements" data-dfn-type="method" data-export="" id="dom-elements-queryall"><code>queryAll(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-elements-queryall"></a></dfn> method, when invoked, must return the result of running <code class="lang-javascript highlight"><span class="k">this</span><span class="p">.</span><span class="nx">constructor</span></code> with the result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a><var>relativeSelectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Elements" data-dfn-type="method" data-export="" id="dom-elements-query"><code>query(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-elements-query"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a> <var>relativeSelectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>, and null if the result is an empty list.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Elements" data-dfn-type="method" data-export="" id="dom-elements-queryall"><code>queryAll(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-elements-queryall"></a></dfn> method, when invoked, must return the result of running <code class="lang-javascript highlight"><span class="k">this</span><span class="p">.</span><span class="nx">constructor</span></code> with the result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a> <var>relativeSelectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <h4 class="heading settled" data-level="4.2.7" id="old-style-collections"><span class="secno">4.2.7. </span><span class="content">Old-style collections: <code class="idl"><a data-link-type="idl" href="#nodelist">NodeList</a></code> and <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code></span><a class="self-link" href="#old-style-collections"></a></h4>
    <p>A <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-collection">collection<a class="self-link" href="#concept-collection"></a></dfn> is an object that
 represents a lists of DOM nodes. A <a data-link-type="dfn" href="#concept-collection">collection</a> can be either <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" data-local-lt="live" data-lt="live collection" id="concept-collection-live">live<a class="self-link" href="#concept-collection-live"></a></dfn> or <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" data-lt="static collection" id="concept-collection-static">static<a class="self-link" href="#concept-collection-static"></a></dfn>. Unless otherwise stated,
@@ -1273,9 +1273,9 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="nod
 };
 </pre>
    <dl class="domintro">
-    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-length">length</a></code>
+    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-length">length</a></code> 
     <dd> Returns the number of <a data-link-type="dfn" href="#concept-node">nodes</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>. 
-    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-item">item(index)</a></code>
+    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-item">item(index)</a></code> 
     <dt><var>element</var> = <var>collection</var>[<var>index</var>] 
     <dd> Returns the <a data-link-type="dfn" href="#concept-node">node</a> with index <var>index</var> from the <a data-link-type="dfn" href="#concept-collection">collection</a>. The <a data-link-type="dfn" href="#concept-node">nodes</a> are sorted in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
    </dl>
@@ -1285,7 +1285,7 @@ there are no <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-
     <p>The <dfn class="idl-code" data-dfn-for="NodeList" data-dfn-type="attribute" data-export="" id="dom-nodelist-length">length<a class="self-link" href="#dom-nodelist-length"></a></dfn> attribute must
 return the number of nodes <a data-link-type="dfn" href="#represented-by-the-collection">represented by the collection</a>.</p>
     <p>The <dfn class="idl-code" data-dfn-for="NodeList" data-dfn-type="method" data-export="" id="dom-nodelist-item"><code>item(<var>index</var>)</code><a class="self-link" href="#dom-nodelist-item"></a></dfn> method must return
-the <var>index</var><sup>th</sup><a data-link-type="dfn" href="#concept-node">node</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>. If there is no <var>index</var><sup>th</sup><a data-link-type="dfn" href="#concept-node">node</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>, then the method must
+the <var>index</var><sup>th</sup> <a data-link-type="dfn" href="#concept-node">node</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>. If there is no <var>index</var><sup>th</sup> <a data-link-type="dfn" href="#concept-node">node</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>, then the method must
 return null.</p>
    </div>
    <h5 class="heading settled" data-level="4.2.7.2" id="interface-htmlcollection"><span class="secno">4.2.7.2. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code></span><a class="self-link" href="#interface-htmlcollection"></a></h5>
@@ -1300,14 +1300,14 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="htm
    <p class="note no-backref" role="note"><code class="idl"><a data-link-type="idl">Elements</a></code> is the better solution for representing a <a data-link-type="dfn" href="#concept-collection">collection</a> of <a data-link-type="dfn" href="#concept-element">elements</a>. <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> is an historical artifact we
 cannot rid the web of. </p>
    <dl class="domintro">
-    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-length">length</a></code>
+    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-length">length</a></code> 
     <dd> Returns the number of <a data-link-type="dfn" href="#concept-element">elements</a> in
   the <a data-link-type="dfn" href="#concept-collection">collection</a>. 
-    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-item">item(index)</a></code>
+    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-item">item(index)</a></code> 
     <dt><var>element</var> = <var>collection</var>[<var>index</var>] 
     <dd> Returns the <a data-link-type="dfn" href="#concept-element">element</a> with index <var>index</var> from the <a data-link-type="dfn" href="#concept-collection">collection</a>.
   The <a data-link-type="dfn" href="#concept-element">elements</a> are sorted in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
-    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-nameditem">namedItem(name)</a></code>
+    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-nameditem">namedItem(name)</a></code> 
     <dt><var>element</var> = <var>collection</var>[<var>name</var>] 
     <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> with <a data-link-type="dfn" href="#concept-id">ID</a> or name <var>name</var> from the collection. 
    </dl>
@@ -1316,18 +1316,18 @@ cannot rid the web of. </p>
 there are no <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a>.</p>
     <p>The <dfn class="idl-code" data-dfn-for="HTMLCollection" data-dfn-type="attribute" data-export="" id="dom-htmlcollection-length">length<a class="self-link" href="#dom-htmlcollection-length"></a></dfn> attribute
 must return the number of nodes <a data-link-type="dfn" href="#represented-by-the-collection">represented by the collection</a>.</p>
-    <p>The <dfn class="idl-code" data-dfn-for="HTMLCollection" data-dfn-type="method" data-export="" id="dom-htmlcollection-item">item(<var>index</var>)<a class="self-link" href="#dom-htmlcollection-item"></a></dfn> method must return the <var>index</var><sup>th</sup><a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>. If there is no <var>index</var><sup>th</sup><a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>, then the method must return null.</p>
+    <p>The <dfn class="idl-code" data-dfn-for="HTMLCollection" data-dfn-type="method" data-export="" id="dom-htmlcollection-item">item(<var>index</var>)<a class="self-link" href="#dom-htmlcollection-item"></a></dfn> method must return the <var>index</var><sup>th</sup> <a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>. If there is no <var>index</var><sup>th</sup> <a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>, then the method must return null.</p>
     <p>The <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-names">supported property names</a>, all <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-unenumerable">unenumerable</a>,
 are the values from the list returned by these steps:</p>
     <ol>
      <li>Let <var>result</var> be an empty list. 
      <li>
-       For each <var>element</var><a data-link-type="dfn" href="#represented-by-the-collection">represented by the collection</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run these substeps: 
+       For each <var>element</var> <a data-link-type="dfn" href="#represented-by-the-collection">represented by the collection</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run these substeps: 
       <ol>
        <li>If <var>element</var> has an <a data-link-type="dfn" href="#concept-id">ID</a> which is neither the empty string nor is
    in <var>result</var>, append <var>element</var>’s <a data-link-type="dfn" href="#concept-id">ID</a> to <var>result</var>. 
        <li>If <var>element</var> is in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> a <a data-link-type="dfn" href="#concept-named-attribute"><code>name</code> attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-value">value</a> is neither the
-   empty string nor is in <var>result</var>, append <var>element</var>’s <a data-link-type="dfn" href="#concept-named-attribute"><code>name</code> attribute</a><a data-link-type="dfn" href="#concept-attribute-value">value</a> to <var>result</var>. 
+   empty string nor is in <var>result</var>, append <var>element</var>’s <a data-link-type="dfn" href="#concept-named-attribute"><code>name</code> attribute</a> <a data-link-type="dfn" href="#concept-attribute-value">value</a> to <var>result</var>. 
       </ol>
      <li>Return <var>result</var>. 
     </ol>
@@ -1359,7 +1359,7 @@ are the values from the list returned by these steps:</p>
     <li>Let <var>notify list</var> be a copy of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar_origin-browsing-contexts">unit of related similar-origin browsing contexts</a>'
  list of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> objects. 
     <li>
-      For each <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object <var>mo</var> in <var>notify list</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#execute-a-compound-microtask-subtask">execute a compound microtask subtask</a> to run these steps: <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
+      For each <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object <var>mo</var> in <var>notify list</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#execute-a-compound-microtask-subtask">execute a compound microtask subtask</a> to run these steps: <a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
      <ol>
       <li>Let <var>queue</var> be a copy of <var>mo</var>’s <a data-link-type="dfn" href="#concept-MO-queue">record queue</a>. 
       <li>Empty <var>mo</var>’s <a data-link-type="dfn" href="#concept-MO-queue">record queue</a>. 
@@ -1402,13 +1402,13 @@ to the <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-typ
     <li>A list of <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code> objects called the <dfn data-dfn-for="MutationObserver" data-dfn-type="dfn" data-export="" id="concept-MO-queue">record queue<a class="self-link" href="#concept-MO-queue"></a></dfn> that is initially empty. 
    </ul>
    <dl class="domintro">
-    <dt><code><var>observer</var> = new <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-mutationobserver">MutationObserver(callback)</a></code></code>
+    <dt><code><var>observer</var> = new <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-mutationobserver">MutationObserver(callback)</a></code></code> 
     <dd>Constructs a <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object and sets its <a data-link-type="dfn" href="#concept-MO-callback">callback</a> to <var>callback</var>. The <var>callback</var> is invoked with a
  list of <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code> objects as first argument and the
  constructed <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object as second argument. It is
  invoked after <a data-link-type="dfn" href="#concept-node">nodes</a> registered with the <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe()</a></code> method, are
  mutated. 
-    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe(target, options)</a></code></code>
+    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe(target, options)</a></code></code> 
     <dd>
       Instructs the user agent to observe a given <var>target</var> (a <a data-link-type="dfn" href="#concept-node">node</a>) and report any mutations based on
   the criteria given by <var>options</var> (an object). 
@@ -1416,34 +1416,34 @@ to the <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-typ
   observation options via object members. These are the object members that
   can be used:</p>
      <dl>
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code> 
       <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> are to be observed. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> 
       <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-attribute">attributes</a> are to be observed. Can be omitted if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> and/or <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is
    specified. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> 
       <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> are to be observed. Can be omitted if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is specified. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> 
       <dd>Set to true if mutations to not just <var>target</var>, but
    also <var>target</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> are to be
    observed. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> 
       <dd>Set to true if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is true or omitted
-   and <var>target</var>’s <a data-link-type="dfn" href="#concept-attribute">attribute</a><a data-link-type="dfn" href="#concept-attribute-value">value</a> before the mutation
+   and <var>target</var>’s <a data-link-type="dfn" href="#concept-attribute">attribute</a> <a data-link-type="dfn" href="#concept-attribute-value">value</a> before the mutation
    needs to be recorded. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> 
       <dd>Set to true if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is set to true or omitted and <var>target</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> before the mutation
    needs to be recorded. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code>
-      <dd>Set to a list of <a data-link-type="dfn" href="#concept-attribute">attribute</a><a data-link-type="dfn" href="#concept-attribute-local-name">local names</a> (without <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>) if not all <a data-link-type="dfn" href="#concept-attribute">attribute</a> mutations need to be
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> 
+      <dd>Set to a list of <a data-link-type="dfn" href="#concept-attribute">attribute</a> <a data-link-type="dfn" href="#concept-attribute-local-name">local names</a> (without <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>) if not all <a data-link-type="dfn" href="#concept-attribute">attribute</a> mutations need to be
    observed and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is true
    or omitted. 
      </dl>
-    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-disconnect">disconnect()</a></code></code>
+    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-disconnect">disconnect()</a></code></code> 
     <dd>Stops <var>observer</var> from observing any mutations.
  Until the <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe()</a></code> method
  is used again, <var>observer</var>’s <a data-link-type="dfn" href="#concept-MO-callback">callback</a> will not be invoked. 
-    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-takerecords">takeRecords()</a></code></code>
+    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-takerecords">takeRecords()</a></code></code> 
     <dd>Empties the <a data-link-type="dfn" href="#concept-MO-queue">record queue</a> and
  returns what was in there. 
    </dl>
@@ -1455,14 +1455,14 @@ of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationOb
     <li>If either <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
  and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is omitted, set <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> to true. 
     <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is present and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is omitted, set <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> to true. 
-    <li>If none of <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+    <li>If none of <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code> <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
     <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> is true
  and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
     <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
  and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
     <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is true and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
     <li>
-      For each <a data-link-type="dfn" href="#registered-observer">registered observer</a><var>registered</var> in <var>target</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>observer</b> is
+      For each <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var> in <var>target</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>observer</b> is
   the <a data-link-type="dfn" href="#context-object">context object</a>: 
      <ol>
       <li>Remove all <a data-link-type="dfn" href="#transient-registered-observer">transient registered observers</a> whose <b>source</b> is <var>registered</var>. 
@@ -1471,7 +1471,7 @@ of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationOb
     <li>Otherwise, add a new <a data-link-type="dfn" href="#registered-observer">registered observer</a> to <var>target</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a> with the <a data-link-type="dfn" href="#context-object">context object</a> as the <b>observer</b> and <var>options</var> as the <b>options</b>,
  and add <var>target</var> to <a data-link-type="dfn" href="#context-object">context object</a>’s list of <a data-link-type="dfn" href="#concept-node">nodes</a> on which it is registered. 
    </ol>
-   <p>The <dfn class="idl-code" data-dfn-for="MutationObserver" data-dfn-type="method" data-export="" id="dom-mutationobserver-disconnect">disconnect()<a class="self-link" href="#dom-mutationobserver-disconnect"></a></dfn> method must, for each <a data-link-type="dfn" href="#concept-node">node</a><var>node</var> in the <a data-link-type="dfn" href="#context-object">context object</a>’s list of <a data-link-type="dfn" href="#concept-node">nodes</a>, remove any <a data-link-type="dfn" href="#registered-observer">registered observer</a> on <var>node</var> for which the <a data-link-type="dfn" href="#context-object">context object</a> is the <b>observer</b>, and also
+   <p>The <dfn class="idl-code" data-dfn-for="MutationObserver" data-dfn-type="method" data-export="" id="dom-mutationobserver-disconnect">disconnect()<a class="self-link" href="#dom-mutationobserver-disconnect"></a></dfn> method must, for each <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> in the <a data-link-type="dfn" href="#context-object">context object</a>’s list of <a data-link-type="dfn" href="#concept-node">nodes</a>, remove any <a data-link-type="dfn" href="#registered-observer">registered observer</a> on <var>node</var> for which the <a data-link-type="dfn" href="#context-object">context object</a> is the <b>observer</b>, and also
 empty <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-MO-queue">record queue</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MutationObserver" data-dfn-type="method" data-export="" id="dom-mutationobserver-takerecords">takeRecords()<a class="self-link" href="#dom-mutationobserver-takerecords"></a></dfn> method must return a copy of the <a data-link-type="dfn" href="#concept-MO-queue">record queue</a> and then empty the <a data-link-type="dfn" href="#concept-MO-queue">record queue</a>.</p>
    <h4 class="heading settled" data-level="4.3.2" id="queueing-a-mutation-record"><span class="secno">4.3.2. </span><span class="content">Queuing a mutation record</span><a class="self-link" href="#queueing-a-mutation-record"></a></h4>
@@ -1527,31 +1527,31 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mut
 };
 </pre>
    <dl class="domintro">
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code></code> 
     <dd>Returns "<code>attributes</code>" if it was an <a data-link-type="dfn" href="#concept-attribute">attribute</a> mutation.
- "<code>characterData</code>" if it was a mutation to a <code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code><a data-link-type="dfn" href="#concept-node">node</a>. And
+ "<code>characterData</code>" if it was a mutation to a <code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. And
  "<code>childList</code>" if it was a mutation to the <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-type="dfn" href="#concept-node">nodes</a>. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-target">target</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-target">target</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-node">node</a> the mutation
  affected, depending on the <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code>.
  For "<code>attributes</code>", it is the <a data-link-type="dfn" href="#concept-element">element</a> whose <a data-link-type="dfn" href="#concept-attribute">attribute</a> changed. For
- "<code>characterData</code>", it is the <code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code><a data-link-type="dfn" href="#concept-node">node</a>. For "<code>childList</code>",
+ "<code>characterData</code>", it is the <code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. For "<code>childList</code>",
  it is the <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-child">children</a> changed. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-addednodes">addedNodes</a></code></code>
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-removednodes">removedNodes</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-addednodes">addedNodes</a></code></code> 
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-removednodes">removedNodes</a></code></code> 
     <dd>Return the <a data-link-type="dfn" href="#concept-node">nodes</a> added and removed
  respectively. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-previoussibling">previousSibling</a></code></code>
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-nextsibling">nextSibling</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-previoussibling">previousSibling</a></code></code> 
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-nextsibling">nextSibling</a></code></code> 
     <dd>Return the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous</a> and <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> respectively
  of the added or removed <a data-link-type="dfn" href="#concept-node">nodes</a>, and null otherwise. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributename">attributeName</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributename">attributeName</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> of the
  changed <a data-link-type="dfn" href="#concept-attribute">attribute</a>, and null otherwise. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributenamespace">attributeNamespace</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributenamespace">attributeNamespace</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> of the
  changed <a data-link-type="dfn" href="#concept-attribute">attribute</a>, and null otherwise. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-oldvalue">oldValue</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-oldvalue">oldValue</a></code></code> 
     <dd>The return value depends on <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code>. For
  "<code>attributes</code>", it is the <a data-link-type="dfn" href="#concept-attribute-value">value</a> of the
  changed <a data-link-type="dfn" href="#concept-attribute">attribute</a> before the change.
@@ -1632,109 +1632,109 @@ that is a <a data-link-type="dfn" href="#concept-document">document</a>.</p>
    <p class="note no-backref" role="note">A <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> can be changed by the <a data-link-type="dfn" href="#concept-node-adopt">adopt</a> algorithm. </p>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code></code> 
     <dd>
       Returns the type of <var>node</var>, represented by a number from the following list: 
      <dl>
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-element_node">ELEMENT_NODE</a></code></code> (1) 
       <dd><var>node</var> is an <a data-link-type="dfn" href="#concept-element">element</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-text_node">TEXT_NODE</a></code></code> (3) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE</a></code></code> (7) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-comment_node">COMMENT_NODE</a></code></code> (8) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_node">DOCUMENT_NODE</a></code></code> (9) 
       <dd><var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_type_node">DOCUMENT_TYPE_NODE</a></code></code> (10) 
       <dd><var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_fragment_node">DOCUMENT_FRAGMENT_NODE</a></code></code> (11) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
      </dl>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodename">nodeName</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodename">nodeName</a></code></code> 
     <dd>
       Returns a string appropriate for the type of <var>node</var>, as
   follows: 
      <dl>
-      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
       <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value. 
-      <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
       <dd>"<code>#text</code>". 
-      <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
       <dd>Its <a data-link-type="dfn" href="#concept-PI-target">target</a>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
       <dd>"<code>#comment</code>". 
-      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
       <dd>"<code>#document</code>". 
-      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
       <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
       <dd>"<code>#document-fragment</code>". 
      </dl>
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nodetype">nodeType<a class="self-link" href="#dom-node-nodetype"></a></dfn> attribute’s getter, when invoked, must return
 the first matching statement, switching on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-element_node">ELEMENT_NODE<a class="self-link" href="#dom-node-element_node"></a></dfn> (1) 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-text_node">TEXT_NODE<a class="self-link" href="#dom-node-text_node"></a></dfn> (3); 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE<a class="self-link" href="#dom-node-processing_instruction_node"></a></dfn> (7); 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-comment_node">COMMENT_NODE<a class="self-link" href="#dom-node-comment_node"></a></dfn> (8); 
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_node">DOCUMENT_NODE<a class="self-link" href="#dom-node-document_node"></a></dfn> (9); 
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_type_node">DOCUMENT_TYPE_NODE<a class="self-link" href="#dom-node-document_type_node"></a></dfn> (10); 
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_fragment_node">DOCUMENT_FRAGMENT_NODE<a class="self-link" href="#dom-node-document_fragment_node"></a></dfn> (11). 
    </dl>
    <p></p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nodename">nodeName<a class="self-link" href="#dom-node-nodename"></a></dfn> attribute’s getter, when invoked, must return
 the first matching statement, switching on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value. 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dd>"<code>#text</code>". 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dd>Its <a data-link-type="dfn" href="#concept-PI-target">target</a>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
     <dd>"<code>#comment</code>". 
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
     <dd>"<code>#document</code>". 
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
     <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
     <dd>"<code>#document-fragment</code>". 
    </dl>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-baseuri">baseURI</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-baseuri">baseURI</a></code></code> 
     <dd>Returns <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>’s <a data-link-type="dfn" href="#concept-document-base-url">base URL</a>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-baseuri"><code>baseURI</code><a class="self-link" href="#dom-node-baseuri"></a></dfn> attribute’s getter must return <a data-link-type="dfn" href="#concept-node-document">node document</a>’s <a data-link-type="dfn" href="#concept-document-base-url">base URL</a>.</p>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-ownerdocument">ownerDocument</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-ownerdocument">ownerDocument</a></code></code> 
     <dd> Returns the <a data-link-type="dfn" href="#concept-node-document">node document</a>.
   Returns null for <a data-link-type="dfn" href="#concept-document">documents</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentnode">parentNode</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentnode">parentNode</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentelement">parentElement</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentelement">parentElement</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#parent-element">parent element</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-haschildnodes">hasChildNodes()</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-haschildnodes">hasChildNodes()</a></code></code> 
     <dd>Returns whether <var>node</var> has <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-childnodes">childNodes</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-childnodes">childNodes</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-firstchild">firstChild</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-firstchild">firstChild</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-lastchild">lastChild</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-lastchild">lastChild</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-tree-last-child">last child</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-previoussibling">previousSibling</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-previoussibling">previousSibling</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nextsibling">nextSibling</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nextsibling">nextSibling</a></code></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
    </dl>
    <div class="impl">
@@ -1758,9 +1758,9 @@ All <a data-link-type="dfn" href="#concept-node">nodes</a> have a <a data-link-t
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nodevalue">nodeValue<a class="self-link" href="#dom-node-nodevalue"></a></dfn> attribute
 must return the following, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
     <dt>Any other node 
     <dd>Null. 
@@ -1769,9 +1769,9 @@ must return the following, depending on the <a data-link-type="dfn" href="#conte
 on setting, if the new value is null, act as if it was the empty string
 instead, and then do as described below, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dd><a data-link-type="dfn" href="#concept-CD-replace">Replace data</a> with node <a data-link-type="dfn" href="#context-object">context object</a>, offset 0, count <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value, and
  data new value. 
     <dt>Any other node 
@@ -1779,13 +1779,13 @@ instead, and then do as described below, depending on the <a data-link-type="dfn
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-textcontent">textContent<a class="self-link" href="#dom-node-textcontent"></a></dfn> attribute must return the following, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>The concatenation of <a data-link-type="dfn" href="#concept-CD-data">data</a> of all
- the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+ the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
     <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
     <dt>Any other node 
     <dd>Null. 
@@ -1794,18 +1794,18 @@ instead, and then do as described below, depending on the <a data-link-type="dfn
 on setting, if the new value is null, act as if it was the empty string
 instead, and then do as described below, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>
      <ol>
       <li>Let <var>node</var> be null. 
       <li>If new value is not the empty string, set <var>node</var> to
-   a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is new value. 
+   a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is new value. 
       <li><a data-link-type="dfn" href="#concept-node-replace-all">Replace all</a> with <var>node</var> within the <a data-link-type="dfn" href="#context-object">context object</a>. 
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
     <dd><a data-link-type="dfn" href="#concept-CD-replace">Replace data</a> with node <a data-link-type="dfn" href="#context-object">context object</a>, offset 0, count <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value, and
  data new value. 
     <dt>Any other node 
@@ -1813,18 +1813,18 @@ instead, and then do as described below, depending on the <a data-link-type="dfn
    </dl>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-normalize">normalize()</a></code>()</code>
-    <dd>Removes <a data-link-type="dfn" href="#concept-node-empty">empty</a><code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a> and concatenates
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-normalize">normalize()</a></code>()</code> 
+    <dd>Removes <a data-link-type="dfn" href="#concept-node-empty">empty</a> <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> and concatenates
  the <a data-link-type="dfn" href="#concept-CD-data">data</a> of remaining <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> into the first of their <a data-link-type="dfn" href="#concept-node">nodes</a>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-normalize">normalize()<a class="self-link" href="#dom-node-normalize"></a></dfn> method
 must run these steps:</p>
-   <p>For each <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
+   <p>For each <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <ol>
-    <li>Let <var>node</var> be the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-descendant">descendant</a>. 
+    <li>Let <var>node</var> be the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a>. 
     <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value. 
-    <li>If <var>length</var> is zero, <a data-link-type="dfn" href="#concept-node-remove">remove</a><var>node</var> and
- continue with the next <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>, if any. 
+    <li>If <var>length</var> is zero, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> and
+ continue with the next <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, if any. 
     <li>Let <var>data</var> be the concatenation of the <a data-link-type="dfn" href="#concept-CD-data">data</a> of <var>node</var>’s <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> (excluding itself), in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
     <li><a data-link-type="dfn" href="#concept-CD-replace">Replace data</a> with node <var>node</var>, offset <var>length</var>,
  count 0, and data <var>data</var>. 
@@ -1839,13 +1839,13 @@ must run these steps:</p>
       <li>Add <var>current node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value to <var>length</var>. 
       <li>Set <var>current node</var> to its <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
      </ol>
-    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a><var>node</var>’s <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> (excluding itself), in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>node</var>’s <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> (excluding itself), in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
    </ol>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-node-clonenode">cloneNode([<var>deep</var> = false])</a></code>
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-node-clonenode">cloneNode([<var>deep</var> = false])</a></code> 
     <dd>Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-isequalnode">isEqualNode(otherNode)</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-isequalnode">isEqualNode(otherNode)</a></code></code> 
     <dd>Returns whether <var>node</var> and <var>otherNode</var> have the same properties. 
    </dl>
    <div class="impl">
@@ -1861,14 +1861,14 @@ run these steps:</p>
      <li>
       <p>Let <var>copy</var> be a <a data-link-type="dfn" href="#concept-node">node</a> that implements the same interfaces as <var>node</var>, and fulfills these additional requirements, switching on <var>node</var>: </p>
       <dl class="switch">
-       <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
        <dd>
         <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-document-encoding">encoding</a>, <a data-link-type="dfn" href="#concept-document-content-type">content type</a>, <a data-link-type="dfn" href="#concept-document-url">URL</a>, <a data-link-type="dfn" href="#concept-document-type">type</a>,
     and <a data-link-type="dfn" href="#concept-document-mode">mode</a>, to those of <var>node</var>. </p>
-       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
        <dd>
         <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-doctype-name">name</a>, <a data-link-type="dfn" href="#concept-doctype-publicid">public ID</a>, and <a data-link-type="dfn" href="#concept-doctype-systemid">system ID</a>, to those of <var>node</var>. </p>
-       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
        <dd>
         <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>, and <a data-link-type="dfn" href="#concept-element-local-name">local name</a>, to those of <var>node</var>. </p>
         <p>For each <var>attribute</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, in order, run these substeps: </p>
@@ -1879,12 +1879,12 @@ run these steps:</p>
           <p>Set <var>copyAttribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, <a data-link-type="dfn" href="#concept-attribute-name">name</a>,
      and <a data-link-type="dfn" href="#concept-attribute-value">value</a>, to those of <var>attribute</var>. </p>
          <li>
-          <p><a data-link-type="dfn" href="#concept-element-attributes-append">Append</a><var>copyAttribute</var> to <var>copy</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. </p>
+          <p><a data-link-type="dfn" href="#concept-element-attributes-append">Append</a> <var>copyAttribute</var> to <var>copy</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. </p>
         </ol>
-       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
        <dd>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>, to that of <var>node</var>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
        <dd>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-PI-target">target</a> and <a data-link-type="dfn" href="#concept-CD-data">data</a> to
    those of <var>node</var>. 
        <dt>Any other node 
@@ -1899,34 +1899,34 @@ run these steps:</p>
     <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" data-lt="cloneNode(deep)|cloneNode()" id="dom-node-clonenode"><code>cloneNode(<var>deep</var>)</code><a class="self-link" href="#dom-node-clonenode"></a></dfn> method, when
 invoked, must return a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, with
 the <i>clone children flag</i> set if <var>deep</var> is true.</p>
-    <p>A <a data-link-type="dfn" href="#concept-node">node</a><var>A</var><dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-equals">equals<a class="self-link" href="#concept-node-equals"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a><var>B</var> if all of the following conditions are true:</p>
+    <p>A <a data-link-type="dfn" href="#concept-node">node</a> <var>A</var> <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-equals">equals<a class="self-link" href="#concept-node-equals"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a> <var>B</var> if all of the following conditions are true:</p>
     <ul>
      <li><var>A</var> and <var>B</var>’s <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code> attribute value is identical. 
      <li>
        The following are also equal, depending on <var>A</var>: 
       <dl class="switch">
-       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
        <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>, <a data-link-type="dfn" href="#concept-doctype-publicid">public ID</a>, and <a data-link-type="dfn" href="#concept-doctype-systemid">system ID</a>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
        <dd> Its <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a>, and its
     number of <a data-link-type="dfn" href="#concept-attribute">attributes</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
        <dd>Its <a data-link-type="dfn" href="#concept-PI-target">target</a> and <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
-       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
        <dd>Its <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
        <dt>Any other node 
        <dd>— 
       </dl>
      <li>If <var>A</var> is an <a data-link-type="dfn" href="#concept-element">element</a>, each <a data-link-type="dfn" href="#concept-attribute">attribute</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> has an <a data-link-type="dfn" href="#concept-attribute">attribute</a> with the same <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, and <a data-link-type="dfn" href="#concept-attribute-value">value</a> in <var>B</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
      <li><var>A</var> and <var>B</var> have the same number of <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
-     <li>Each <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>A</var><a data-link-type="dfn" href="#concept-node-equals">equals</a> the <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>B</var> at the identical <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
+     <li>Each <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>A</var> <a data-link-type="dfn" href="#concept-node-equals">equals</a> the <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>B</var> at the identical <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
     </ul>
-    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-isequalnode">isEqualNode(<var>otherNode</var>)<a class="self-link" href="#dom-node-isequalnode"></a></dfn> method must return true if <var>node</var> is not null and <a data-link-type="dfn" href="#context-object">context object</a><a data-link-type="dfn" href="#concept-node-equals">equals</a><var>otherNode</var>, and false otherwise.</p>
+    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-isequalnode">isEqualNode(<var>otherNode</var>)<a class="self-link" href="#dom-node-isequalnode"></a></dfn> method must return true if <var>node</var> is not null and <a data-link-type="dfn" href="#context-object">context object</a> <a data-link-type="dfn" href="#concept-node-equals">equals</a> <var>otherNode</var>, and false otherwise.</p>
    </div>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-comparedocumentposition">compareDocumentPosition(other)</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-comparedocumentposition">compareDocumentPosition(other)</a></code></code> 
     <dd>
       Returns a bitmask indicating the position of <var>other</var> relative to <var>node</var>. These are the bits that can be set: 
      <dl>
@@ -1934,15 +1934,15 @@ the <i>clone children flag</i> set if <var>deep</var> is true.</p>
       <dd>Set when <var>node</var> and <var>other</var> are not in the
    same <a data-link-type="dfn" href="#concept-tree">tree</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code></code> (2) 
-      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><var>node</var>. 
+      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>node</var>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code></code> (4) 
-      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-following">following</a><var>node</var>. 
+      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node</var>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code></code> (8) 
       <dd>Set when <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>node</var>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code></code> (16, 10 in hexadecimal) 
       <dd>Set when <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node</var>. 
      </dl>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-contains">contains(other)</a></code></code>
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-contains">contains(other)</a></code></code> 
     <dd>Returns true if <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>node</var>, and false otherwise. 
    </dl>
    <p>These are the constants <code class="idl"><a data-link-type="idl" href="#dom-node-comparedocumentposition">compareDocumentPosition()</a></code> returns as mask:</p>
@@ -1969,7 +1969,7 @@ the <i>clone children flag</i> set if <var>deep</var> is true.</p>
   implementations <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span></code> can be used. </p>
     <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
     <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
-    <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
+    <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
     <li>Return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-contains">contains(<var>other</var>)<a class="self-link" href="#dom-node-contains"></a></dfn> method must return true if <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of
@@ -1979,7 +1979,7 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
    <ol>
     <li>If <var>element</var>’s <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is not
  null, return its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>. 
-    <li>If <var>element</var><a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is
+    <li>If <var>element</var> <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is
  "<code>xmlns</code>" and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>namespace</var>, then return <var>element</var>’s first
  such <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>. 
     <li>If <var>element</var>’s <a data-link-type="dfn" href="#parent-element">parent element</a> is not null,
@@ -1988,7 +1988,7 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="locate-a-namespace">locate a namespace<a class="self-link" href="#locate-a-namespace"></a></dfn> for a <var>node</var> using <var>prefix</var> depends on <var>node</var>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>
      <ol>
       <li>If its <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is
@@ -2004,15 +2004,15 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
       <li>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> on
    its <a data-link-type="dfn" href="#parent-element">parent element</a> using <var>prefix</var>. 
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
     <dd>
      <ol>
       <li>If its <a data-link-type="dfn" href="#document-element">document element</a> is null, return null. 
       <li>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> on
    its <a data-link-type="dfn" href="#document-element">document element</a> using <var>prefix</var>. 
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
     <dd>Return null. 
     <dt>Any other node 
     <dd>
@@ -2028,13 +2028,13 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
     <li>
       Otherwise it depends on the <a data-link-type="dfn" href="#context-object">context object</a>: 
      <dl class="switch">
-      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
       <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for the node using <var>namespace</var>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
       <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#document-element">document element</a>, if that is not null, and null
    otherwise. 
-      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
       <dd>Return null. 
       <dt>Any other node 
       <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#parent-element">parent element</a>, or if that is null, null. 
@@ -2053,44 +2053,44 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
     <li>Return true if <var>defaultNamespace</var> is the same as <var>namespace</var>, and false otherwise. 
    </ol>
    <hr>
-   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-insertbefore">insertBefore(<var>node</var>, <var>child</var>)<a class="self-link" href="#dom-node-insertbefore"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-pre-insert">pre-inserting</a><var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a> before <var>child</var>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-appendchild">appendChild(<var>node</var>)<a class="self-link" href="#dom-node-appendchild"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-append">appending</a><var>node</var> to
+   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-insertbefore">insertBefore(<var>node</var>, <var>child</var>)<a class="self-link" href="#dom-node-insertbefore"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-pre-insert">pre-inserting</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a> before <var>child</var>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-appendchild">appendChild(<var>node</var>)<a class="self-link" href="#dom-node-appendchild"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-append">appending</a> <var>node</var> to
 the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-replacechild">replaceChild(<var>node</var>, <var>child</var>)<a class="self-link" href="#dom-node-replacechild"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-replace">replacing</a><var>child</var> with <var>node</var> within the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-removechild">removeChild(<var>child</var>)<a class="self-link" href="#dom-node-removechild"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-pre-remove">pre-removing</a><var>child</var> from the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-replacechild">replaceChild(<var>node</var>, <var>child</var>)<a class="self-link" href="#dom-node-replacechild"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-replace">replacing</a> <var>child</var> with <var>node</var> within the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-removechild">removeChild(<var>child</var>)<a class="self-link" href="#dom-node-removechild"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-pre-remove">pre-removing</a> <var>child</var> from the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <hr>
-   <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getElementsByTagName">list of elements with local name <var>localName</var><a class="self-link" href="#concept-getElementsByTagName"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a><var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getElementsByTagName">list of elements with local name <var>localName</var><a class="self-link" href="#concept-getElementsByTagName"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a> <var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
    <ol>
     <li>If <var>localName</var> is "<code>*</code>" (U+002A),
  return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>,
  whose filter matches only <a data-link-type="dfn" href="#concept-element">elements</a>. 
     <li>
-      Otherwise, if <var>root</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches the following <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a>: 
+      Otherwise, if <var>root</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches the following <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>: 
      <ul>
-      <li>Whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var><a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. 
+      <li>Whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var> <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. 
       <li>Whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <em>not</em> the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
      </ul>
-    <li>Otherwise, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
+    <li>Otherwise, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
    </ol>
    <p>When invoked with the same argument, the same <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> object may be returned as returned by an earlier call.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getElementsByTagNameNS">list of elements with namespace <var>namespace</var> and local name <var>localName</var><a class="self-link" href="#concept-getElementsByTagNameNS"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a><var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getElementsByTagNameNS">list of elements with namespace <var>namespace</var> and local name <var>localName</var><a class="self-link" href="#concept-getElementsByTagNameNS"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a> <var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
    <ol>
     <li>If <var>namespace</var> is the empty string, set it to null. 
-    <li>If both <var>namespace</var> and <var>localName</var> are "<code>*</code>" (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a>. 
+    <li>If both <var>namespace</var> and <var>localName</var> are "<code>*</code>" (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>. 
     <li>Otherwise, if <var>namespace</var> is "<code>*</code>"
- (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
+ (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
     <li>Otherwise, if <var>localName</var> is "<code>*</code>"
- (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var>. 
-    <li>Otherwise, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
+ (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var>. 
+    <li>Otherwise, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
    </ol>
    <p>When invoked with the same arguments, the same <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> object may be returned as returned by an earlier call.</p>
-   <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getElementsByClassName">list of elements with class names <var>classNames</var><a class="self-link" href="#concept-getElementsByClassName"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a><var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
+   <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getElementsByClassName">list of elements with class names <var>classNames</var><a class="self-link" href="#concept-getElementsByClassName"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a> <var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
    <ol>
     <li> Let <var>classes</var> be the result of running the <a data-link-type="dfn" href="#concept-ordered-set-parser">ordered set parser</a> on <var>classNames</var>. 
     <li> If <var>classes</var> is the empty set, return an empty <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code>. 
     <li>
       Return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>,
-  whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> that have all their <a data-link-type="dfn" href="#concept-class">classes</a> in <var>classes</var>. 
+  whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> that have all their <a data-link-type="dfn" href="#concept-class">classes</a> in <var>classes</var>. 
      <p>The comparisons for the <a data-link-type="dfn" href="#concept-class">classes</a> must be done in an <a data-link-type="dfn" href="#ascii-case_insensitive">ASCII case-insensitive</a> manner if <var>root</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>’s <a data-link-type="dfn" href="#concept-document-mode">mode</a> is
   "<code>quirks</code>", and in a <a data-link-type="dfn" href="#case_sensitive">case-sensitive</a> manner otherwise.</p>
    </ol>
@@ -2139,11 +2139,11 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="doc
 [Exposed=Window]
 interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="xmldocument">XMLDocument<a class="self-link" href="#xmldocument"></a></dfn> : <a data-link-type="idl-name" href="#document">Document</a> {};
 </pre>
-   <p><code class="idl"><a data-link-type="idl" href="#document">Document</a></code><a data-link-type="dfn" href="#concept-node">nodes</a> are simply
+   <p><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> are simply
 known as <dfn data-dfn-type="dfn" data-export="" data-lt="document" id="concept-document">documents<a class="self-link" href="#concept-document"></a></dfn>.</p>
-   <p>Each <a data-link-type="dfn" href="#concept-document">document</a> has an associated <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-base-url">base URL<a class="self-link" href="#concept-document-base-url"></a></dfn> (a <a data-link-type="dfn" href="#concept-document-url">URL</a>), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-encoding">encoding<a class="self-link" href="#concept-document-encoding"></a></dfn> (an <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#encoding">encoding</a>), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-content-type">content type<a class="self-link" href="#concept-document-content-type"></a></dfn> (a string), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-url">URL<a class="self-link" href="#concept-document-url"></a></dfn> (a <a data-link-type="dfn" href="#concept-document-url">URL</a>), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-type">type<a class="self-link" href="#concept-document-type"></a></dfn> ("<code>xml</code>" or "<code>html</code>"), and <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-mode">mode<a class="self-link" href="#concept-document-mode"></a></dfn> ("<code>no-quirks</code>", "<code>quirks</code>", or "<code>limited-quirks</code>"). <a data-link-type="biblio" href="#biblio-encoding">[ENCODING]</a><a data-link-type="biblio" href="#biblio-url">[URL]</a></p>
+   <p>Each <a data-link-type="dfn" href="#concept-document">document</a> has an associated <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-base-url">base URL<a class="self-link" href="#concept-document-base-url"></a></dfn> (a <a data-link-type="dfn" href="#concept-document-url">URL</a>), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-encoding">encoding<a class="self-link" href="#concept-document-encoding"></a></dfn> (an <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#encoding">encoding</a>), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-content-type">content type<a class="self-link" href="#concept-document-content-type"></a></dfn> (a string), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-url">URL<a class="self-link" href="#concept-document-url"></a></dfn> (a <a data-link-type="dfn" href="#concept-document-url">URL</a>), <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-type">type<a class="self-link" href="#concept-document-type"></a></dfn> ("<code>xml</code>" or "<code>html</code>"), and <dfn data-dfn-for="Document" data-dfn-type="dfn" data-export="" id="concept-document-mode">mode<a class="self-link" href="#concept-document-mode"></a></dfn> ("<code>no-quirks</code>", "<code>quirks</code>", or "<code>limited-quirks</code>"). <a data-link-type="biblio" href="#biblio-encoding">[ENCODING]</a> <a data-link-type="biblio" href="#biblio-url">[URL]</a></p>
    <p>Unless stated otherwise, a <a data-link-type="dfn" href="#concept-document">document</a>’s <a data-link-type="dfn" href="#concept-document-base-url">base URL</a> is
-"<code>about:blank</code>", <a data-link-type="dfn" href="#concept-document-encoding">encoding</a> is the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_8">utf-8</a><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#encoding">encoding</a>, <a data-link-type="dfn" href="#concept-document-content-type">content type</a> is
+"<code>about:blank</code>", <a data-link-type="dfn" href="#concept-document-encoding">encoding</a> is the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_8">utf-8</a> <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#encoding">encoding</a>, <a data-link-type="dfn" href="#concept-document-content-type">content type</a> is
 "<code>application/xml</code>", <a data-link-type="dfn" href="#concept-document-url">URL</a> is "<code>about:blank</code>", <a data-link-type="dfn" href="#concept-document-type">type</a> is "<code>xml</code>", and its <a data-link-type="dfn" href="#concept-document-mode">mode</a> is "<code>no-quirks</code>".</p>
    <p>Unless stated otherwise, a <a data-link-type="dfn" href="#concept-document">document</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is a globally unique identifier
 and its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> of that <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
@@ -2151,7 +2151,7 @@ and its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/bro
    <p>A <a data-link-type="dfn" href="#concept-document">document</a> is said to be in <dfn data-dfn-type="dfn" data-export="" id="concept-document-no-quirks">no-quirks mode<a class="self-link" href="#concept-document-no-quirks"></a></dfn> if its <a data-link-type="dfn" href="#concept-document-mode">mode</a> is "<code>no-quirks</code>", <dfn data-dfn-type="dfn" data-export="" id="concept-document-quirks">quirks mode<a class="self-link" href="#concept-document-quirks"></a></dfn> if its <a data-link-type="dfn" href="#concept-document-mode">mode</a> is "<code>quirks</code>", and <dfn data-dfn-type="dfn" data-export="" id="concept-document-limited-quirks">limited-quirks mode<a class="self-link" href="#concept-document-limited-quirks"></a></dfn> if its <a data-link-type="dfn" href="#concept-document-mode">mode</a> is "<code>limited-quirks</code>".</p>
    <div class="note no-backref" role="note">
     <p>The mode is only ever changed from the default if the <a data-link-type="dfn" href="#concept-document">document</a> is created by
- the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#html-parser">HTML parser</a>, based on the presence, absence, or value of the DOCTYPE string. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
+ the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/syntax.html#html-parser">HTML parser</a>, based on the presence, absence, or value of the DOCTYPE string. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> </p>
     <p><a data-link-type="dfn" href="#concept-document-no-quirks">No-quirks mode</a> was originally known as "standards mode"
  and <a data-link-type="dfn" href="#concept-document-limited-quirks">limited-quirks mode</a> was once known as "almost standards mode". They have been
  renamed because their details are now defined by standards. (And because Ian Hickson
@@ -2159,21 +2159,21 @@ and its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/bro
    </div>
    <hr>
    <dl class="domintro">
-    <dt><code><var>document</var> = new <code class="idl"><a data-link-type="idl" href="#dom-document-document">Document()</a></code></code>
+    <dt><code><var>document</var> = new <code class="idl"><a data-link-type="idl" href="#dom-document-document">Document()</a></code></code> 
     <dd>Returns a new <a data-link-type="dfn" href="#concept-document">document</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code></code>
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code></code> 
     <dd>Returns <var>document</var>’s <code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code> object. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-url">URL</a></code></code>
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documenturi">documentURI</a></code></code>
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-url">URL</a></code></code> 
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documenturi">documentURI</a></code></code> 
     <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-url">URL</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-origin">origin</a></code></code>
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-origin">origin</a></code></code> 
     <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-compatmode">compatMode</a></code></code>
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-compatmode">compatMode</a></code></code> 
     <dd> Returns the string "<code>BackCompat</code>" if <var>document</var>’s <a data-link-type="dfn" href="#concept-document-mode">mode</a> is "<code>quirks</code>", and "<code>CSS1Compat</code>"
   otherwise. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-characterset">characterSet</a></code></code>
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-characterset">characterSet</a></code></code> 
     <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-encoding">encoding</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-contenttype">contentType</a></code></code>
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-contenttype">contentType</a></code></code> 
     <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-content-type">content type</a>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="constructor" data-export="" id="dom-document-document"><code>Document()</code><a class="self-link" href="#dom-document-document"></a></dfn> constructor
@@ -2199,79 +2199,79 @@ getter and <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribut
         <th>Name 
         <th>Compatibility name 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_8">utf-8</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_8">utf-8</a> 
         <td>"<code>UTF-8</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ibm866">ibm866</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ibm866">ibm866</a> 
         <td>"<code>IBM866</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_2">iso-8859-2</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_2">iso-8859-2</a> 
         <td>"<code>ISO-8859-2</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_3">iso-8859-3</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_3">iso-8859-3</a> 
         <td>"<code>ISO-8859-3</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_4">iso-8859-4</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_4">iso-8859-4</a> 
         <td>"<code>ISO-8859-4</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_5">iso-8859-5</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_5">iso-8859-5</a> 
         <td>"<code>ISO-8859-5</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_6">iso-8859-6</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_6">iso-8859-6</a> 
         <td>"<code>ISO-8859-6</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_7">iso-8859-7</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_7">iso-8859-7</a> 
         <td>"<code>ISO-8859-7</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_8">iso-8859-8</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_8">iso-8859-8</a> 
         <td>"<code>ISO-8859-8</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_8_i">iso-8859-8-i</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_8_i">iso-8859-8-i</a> 
         <td>"<code>ISO-8859-8-I</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_10">iso-8859-10</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_10">iso-8859-10</a> 
         <td>"<code>ISO-8859-10</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_13">iso-8859-13</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_13">iso-8859-13</a> 
         <td>"<code>ISO-8859-13</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_14">iso-8859-14</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_14">iso-8859-14</a> 
         <td>"<code>ISO-8859-14</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_15">iso-8859-15</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_15">iso-8859-15</a> 
         <td>"<code>ISO-8859-15</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_16">iso-8859-16</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_8859_16">iso-8859-16</a> 
         <td>"<code>ISO-8859-16</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#koi8_r">koi8-r</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#koi8_r">koi8-r</a> 
         <td>"<code>KOI8-R</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#koi8_u">koi8-u</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#koi8_u">koi8-u</a> 
         <td>"<code>KOI8-U</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#gbk">gbk</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#gbk">gbk</a> 
         <td>"<code>GBK</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#big5">big5</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#big5">big5</a> 
         <td>"<code>Big5</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#euc_jp">euc-jp</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#euc_jp">euc-jp</a> 
         <td>"<code>EUC-JP</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_2022_jp">iso-2022-jp</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#iso_2022_jp">iso-2022-jp</a> 
         <td>"<code>ISO-2022-JP</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#shift_jis">shift_jis</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#shift_jis">shift_jis</a> 
         <td>"<code>Shift_JIS</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#euc_kr">euc-kr</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#euc_kr">euc-kr</a> 
         <td>"<code>EUC-KR</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_16be">utf-16be</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_16be">utf-16be</a> 
         <td>"<code>UTF-16BE</code>" 
        <tr>
-        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_16le">utf-16le</a>
+        <td><a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf_16le">utf-16le</a> 
         <td>"<code>UTF-16LE</code>" 
      </table>
     <li>Return <var>name</var>. 
@@ -2279,24 +2279,24 @@ getter and <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribut
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-contenttype">contentType<a class="self-link" href="#dom-document-contenttype"></a></dfn> attribute must return the <a data-link-type="dfn" href="#concept-document-content-type">content type</a>.</p>
    <hr>
    <dl class="domintro">
-    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-doctype">doctype</a></code>
+    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-doctype">doctype</a></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-doctype">doctype</a> or null if
  there is none. 
-    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documentelement">documentElement</a></code>
+    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documentelement">documentElement</a></code> 
     <dd>Returns the <a data-link-type="dfn" href="#document-element">document element</a>. 
-    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagname">getElementsByTagName(localName)</a></code>
+    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagname">getElementsByTagName(localName)</a></code> 
     <dd>
-      If <var>localName</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a>. 
-     <p>Otherwise, returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. (Matches case-insensitively against <a data-link-type="dfn" href="#concept-element">elements</a> in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> within an <a data-link-type="dfn" href="#html-document">HTML document</a>.)</p>
-    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagnamens">getElementsByTagNameNS(namespace, localName)</a></code>
+      If <var>localName</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>. 
+     <p>Otherwise, returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. (Matches case-insensitively against <a data-link-type="dfn" href="#concept-element">elements</a> in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> within an <a data-link-type="dfn" href="#html-document">HTML document</a>.)</p>
+    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagnamens">getElementsByTagNameNS(namespace, localName)</a></code> 
     <dd>
       If <var>namespace</var> and <var>localName</var> are
-  "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a>. 
-     <p>If only <var>namespace</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.</p>
-     <p>If only <var>localName</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var>.</p>
-     <p>Otherwise, returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a><a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.</p>
-    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbyclassname">getElementsByClassName(classNames)</a></code>
-    <dt><var>collection</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-getelementsbyclassname">getElementsByClassName(classNames)</a></code>
+  "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>. 
+     <p>If only <var>namespace</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.</p>
+     <p>If only <var>localName</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var>.</p>
+     <p>Otherwise, returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.</p>
+    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbyclassname">getElementsByClassName(classNames)</a></code> 
+    <dt><var>collection</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-getelementsbyclassname">getElementsByClassName(classNames)</a></code> 
     <dd> Returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of the <a data-link-type="dfn" href="#concept-element">elements</a> in the object on which
   the method was invoked (a <a data-link-type="dfn" href="#concept-document">document</a> or
   an <a data-link-type="dfn" href="#concept-element">element</a>) that have all the classes
@@ -2327,13 +2327,13 @@ that are in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a
    </div>
    <hr>
    <dl class="domintro">
-    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelement">createElement(localName)</a></code>
+    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelement">createElement(localName)</a></code> 
     <dd>
-      Returns an <a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> with <var>localName</var> as <a data-link-type="dfn" href="#concept-element-local-name">local name</a>. (In an <a data-link-type="dfn" href="#html-document">HTML document</a><var>localName</var> is lowercased.) 
+      Returns an <a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> with <var>localName</var> as <a data-link-type="dfn" href="#concept-element-local-name">local name</a>. (In an <a data-link-type="dfn" href="#html-document">HTML document</a> <var>localName</var> is lowercased.) 
      <p>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown.</p>
-    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS(namespace, qualifiedName)</a></code>
+    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS(namespace, qualifiedName)</a></code> 
     <dd>
-      Returns an <a data-link-type="dfn" href="#concept-element">element</a> with <a data-link-type="dfn" href="#concept-element-namespace">namespace</a><var>namespace</var>. Its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> will
+      Returns an <a data-link-type="dfn" href="#concept-element">element</a> with <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> <var>namespace</var>. Its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> will
   be everything before "<code>:</code>" (U+003E) in <var>qualifiedName</var> or null. Its <a data-link-type="dfn" href="#concept-element-local-name">local name</a> will be
   everything after "<code>:</code>" (U+003E) in <var>qualifiedName</var> or <var>qualifiedName</var>. 
      <p>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown.</p>
@@ -2347,20 +2347,20 @@ that are in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a
       <li><var>namespace</var> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a> and
    neither <var>qualifiedName</var> nor <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>". 
      </ul>
-    <dt><var>documentFragment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createdocumentfragment">createDocumentFragment()</a></code>
-    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
-    <dt><var>text</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createtextnode">createTextNode(data)</a></code>
-    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
-    <dt><var>comment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createcomment">createComment(data)</a></code>
-    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
-    <dt><var>processingInstruction</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createprocessinginstruction">createProcessingInstruction(target, data)</a></code>
-    <dd> Returns a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-PI-target">target</a> is <var>target</var> and <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>.
+    <dt><var>documentFragment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createdocumentfragment">createDocumentFragment()</a></code> 
+    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
+    <dt><var>text</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createtextnode">createTextNode(data)</a></code> 
+    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
+    <dt><var>comment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createcomment">createComment(data)</a></code> 
+    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
+    <dt><var>processingInstruction</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createprocessinginstruction">createProcessingInstruction(target, data)</a></code> 
+    <dd> Returns a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-PI-target">target</a> is <var>target</var> and <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>.
   If <var>target</var> does not match the <code><a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown.
   If <var>data</var> contains "<code>?></code>" an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown. 
    </dl>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-element-interface">element interface<a class="self-link" href="#concept-element-interface"></a></dfn> for any <var>name</var> and <var>namespace</var> is <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, unless
 stated otherwise.</p>
-   <p class="note no-backref" role="note">The HTML Standard will e.g. define that for <code>html</code> and the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement">HTMLHtmlElement</a></code> interface is used. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
+   <p class="note no-backref" role="note">The HTML Standard will e.g. define that for <code>html</code> and the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement">HTMLHtmlElement</a></code> interface is used. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> </p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createelement">createElement(<var>localName</var>)<a class="self-link" href="#dom-document-createelement"></a></dfn> method must run the these steps:</p>
    <ol>
     <li>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
@@ -2377,11 +2377,11 @@ stated otherwise.</p>
     <li>Return a new <a data-link-type="dfn" href="#concept-element">element</a> that implements <var>interface</var>,
  with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to <var>namespace</var>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> set to <var>prefix</var>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set to <var>localName</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>. 
    </ol>
-   <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createdocumentfragment">createDocumentFragment()<a class="self-link" href="#dom-document-createdocumentfragment"></a></dfn> method must return a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createtextnode">createTextNode(<var>data</var>)<a class="self-link" href="#dom-document-createtextnode"></a></dfn> method must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createdocumentfragment">createDocumentFragment()<a class="self-link" href="#dom-document-createdocumentfragment"></a></dfn> method must return a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createtextnode">createTextNode(<var>data</var>)<a class="self-link" href="#dom-document-createtextnode"></a></dfn> method must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p class="note no-backref" role="note">No check is performed that <var>data</var> consists of
 characters that match the <a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Char">Char</a> production. </p>
-   <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcomment">createComment(<var>data</var>)<a class="self-link" href="#dom-document-createcomment"></a></dfn> method must return a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcomment">createComment(<var>data</var>)<a class="self-link" href="#dom-document-createcomment"></a></dfn> method must return a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p class="note no-backref" role="note">No check is performed that <var>data</var> consists of
 characters that match the <a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Char">Char</a> production
 or that it contains two adjacent hyphens or ends with a hyphen. </p>
@@ -2390,18 +2390,18 @@ or that it contains two adjacent hyphens or ends with a hyphen. </p>
     <li>If <var>target</var> does not match the <code><a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
     <li>If <var>data</var> contains the string
  "<code>?></code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
-    <li>Return a new <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code><a data-link-type="dfn" href="#concept-node">node</a>, with <a data-link-type="dfn" href="#concept-PI-target">target</a> set to <var>target</var>, <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>data</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li>Return a new <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with <a data-link-type="dfn" href="#concept-PI-target">target</a> set to <var>target</var>, <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>data</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>. 
    </ol>
    <p class="note no-backref" role="note">No check is performed that <var>target</var> contains
 "<code>xml</code>" or "<code>:</code>", or that <var>data</var> contains characters that match the <a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Char">Char</a> production. </p>
    <hr>
    <dl class="domintro">
-    <dt><var>clone</var> = <var>document</var> . <a class="idl-code" data-link-type="method" href="#dom-document-importnode">importNode(<var>node</var> [, <var>deep</var> = false])</a>
+    <dt><var>clone</var> = <var>document</var> . <a class="idl-code" data-link-type="method" href="#dom-document-importnode">importNode(<var>node</var> [, <var>deep</var> = false])</a> 
     <dd>
     <dd>
       Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>. 
      <p>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a> or a <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception.</p>
-    <dt><var>node</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-adoptnode">adoptNode(node)</a></code>
+    <dt><var>node</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-adoptnode">adoptNode(node)</a></code> 
     <dd>
       Moves <var>node</var> from another <a data-link-type="dfn" href="#concept-document">document</a> and returns it. 
      <p>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> or, if <var>node</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception.</p>
@@ -2416,7 +2416,7 @@ or that it contains two adjacent hyphens or ends with a hyphen. </p>
 a <var>document</var>, run these steps:</p>
    <ol>
     <li>Let <var>oldDocument</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null, <a data-link-type="dfn" href="#concept-node-remove">remove</a><var>node</var> from
+    <li>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from
  its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
     <li>Set <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendants</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. 
     <li>Run any <a data-link-type="dfn" href="#concept-node-adopt-ext">adopting steps</a> defined for <var>node</var> in <a data-link-type="dfn" href="#other-applicable-specifications">other applicable specifications</a> and pass <var>node</var> and <var>oldDocument</var> as parameters. 
@@ -2425,7 +2425,7 @@ a <var>document</var>, run these steps:</p>
    <ol>
     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception. 
     <li>If <var>node</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a><var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a>. 
     <li>Return <var>node</var>. 
    </ol>
    <hr>
@@ -2461,7 +2461,7 @@ a <var>document</var>, run these steps:</p>
         <td rowspan="4">
        <tr>
         <td>"<code>event</code>
-        <td rowspan="3"><code class="idl"><a data-link-type="idl" href="#event">Event</a></code>
+        <td rowspan="3"><code class="idl"><a data-link-type="idl" href="#event">Event</a></code> 
        <tr>
         <td>"<code>events</code>" 
        <tr>
@@ -2469,17 +2469,17 @@ a <var>document</var>, run these steps:</p>
        <tr>
         <td>"<code>keyboardevent</code>"
         <td rowspan="2"><code class="idl"><a data-link-type="idl" href="https://dvcs.w3.org/hg/d4e/raw-file/tip/source_respec.htm#keyboard-event-interface">KeyboardEvent</a></code>
-        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a>
+        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
        <tr>
         <td>"<code>keyevents</code>" 
        <tr>
         <td>"<code>messageevent</code>"
         <td><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">MessageEvent</a></code>
-        <td><a data-link-type="biblio" href="#biblio-html">[HTML]</a>
+        <td><a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
        <tr>
         <td>"<code>mouseevent</code>"
         <td rowspan="2"><code class="idl"><a data-link-type="idl" href="https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#interface-mouseevent">MouseEvent</a></code>
-        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a>
+        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
        <tr>
         <td>"<code>mouseevents</code>" 
        <tr>
@@ -2489,7 +2489,7 @@ a <var>document</var>, run these steps:</p>
        <tr>
         <td>"<code>uievent</code>"
         <td rowspan="2"><code class="idl"><a data-link-type="idl" href="https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html#interface-uievent">UIEvent</a></code>
-        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a>
+        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
        <tr>
         <td>"<code>uievents</code>" 
      </table>
@@ -2535,23 +2535,23 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="dom
 };
 </pre>
    <dl class="domintro">
-    <dt><code><var>doctype</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-domimplementation-createdocumenttype">createDocumentType(qualifiedName, publicId, systemId)</a></code></code>
+    <dt><code><var>doctype</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-domimplementation-createdocumenttype">createDocumentType(qualifiedName, publicId, systemId)</a></code></code> 
     <dd> Returns a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, with the given <var>qualifiedName</var>, <var>publicId</var>, and <var>systemId</var>. If <var>qualifiedName</var> does not
   match the <code><a class="css" data-link-type="type" href="http://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception is thrown, and if it does not match the <code><a class="css" data-link-type="type" href="http://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception
   is thrown. 
-    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a class="idl-code" data-link-type="method" href="#dom-domimplementation-createdocument">createDocument(<var>namespace</var>, <var>qualifiedName</var> [, <var>doctype</var> = null])</a></code>
+    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a class="idl-code" data-link-type="method" href="#dom-domimplementation-createdocument">createDocument(<var>namespace</var>, <var>qualifiedName</var> [, <var>doctype</var> = null])</a></code> 
     <dd>
       Returns an <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code>, with a <a data-link-type="dfn" href="#document-element">document element</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>qualifiedName</var> and whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> (unless <var>qualifiedName</var> is the
   empty string), and with <var>doctype</var>, if it is given, as its <a data-link-type="dfn" href="#concept-doctype">doctype</a>. 
      <p>This method throws the same exceptions as the <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS()</a></code> method, when
   invoked with the same arguments.</p>
-    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a data-link-type="functionish" href="#dom-domimplementation-createhtmldocument">createHTMLDocument([<var>title</var>])</a></code>
+    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a data-link-type="functionish" href="#dom-domimplementation-createhtmldocument">createHTMLDocument([<var>title</var>])</a></code> 
     <dd> Returns a <a data-link-type="dfn" href="#concept-document">document</a>, with a basic <a data-link-type="dfn" href="#concept-tree">tree</a> already constructed including a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element, unless the <var>title</var> argument is omitted. 
    </dl>
    <div class="impl">
     <p>The <dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-createdocumenttype">createDocumentType(<var>qualifiedName</var>, <var>publicId</var>, <var>systemId</var>)<a class="self-link" href="#dom-domimplementation-createdocumenttype"></a></dfn> method must run these steps:</p>
     <ol>
-     <li><a data-link-type="dfn" href="#validate">Validate</a><var>qualifiedName</var>. Rethrow any exceptions. 
+     <li><a data-link-type="dfn" href="#validate">Validate</a> <var>qualifiedName</var>. Rethrow any exceptions. 
      <li>Return a new <a data-link-type="dfn" href="#concept-doctype">doctype</a>, with <var>qualifiedName</var> as its <a data-link-type="dfn" href="#concept-doctype-name">name</a>, <var>publicId</var> as
  its <a data-link-type="dfn" href="#concept-doctype-publicid">public ID</a>, and <var>systemId</var> as its <a data-link-type="dfn" href="#concept-doctype-systemid">system ID</a>, and with its <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the
  associated <a data-link-type="dfn" href="#concept-document">document</a> of the <a data-link-type="dfn" href="#context-object">context object</a>. 
@@ -2562,13 +2562,13 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="dom
     <ol>
      <li>
        Let <var>document</var> be a new <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code>. 
-      <p class="note no-backref" role="note">This method creates an <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code> rather than a normal <a data-link-type="dfn" href="#concept-document">document</a>. They are identical except for the addition of the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#dom-xmldocument-load">load()</a></code> method deployed content relies upon. <a data-link-type="biblio" href="#biblio-html">[HTML]</a></p>
+      <p class="note no-backref" role="note">This method creates an <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code> rather than a normal <a data-link-type="dfn" href="#concept-document">document</a>. They are identical except for the addition of the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#dom-xmldocument-load">load()</a></code> method deployed content relies upon. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> </p>
      <li>Let <var>element</var> be null. 
      <li>If <var>qualifiedName</var> is not the empty string, set <var>element</var> to the result of invoking the <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS()</a></code> method
  with the arguments <var>namespace</var> and <var>qualifiedName</var> on <var>document</var>. Rethrow any exceptions. 
-     <li>If <var>doctype</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a><var>doctype</var> to <var>document</var>. 
-     <li>If <var>element</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a><var>element</var> to <var>document</var>. 
-     <li><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
+     <li>If <var>doctype</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>doctype</var> to <var>document</var>. 
+     <li>If <var>element</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>element</var> to <var>document</var>. 
+     <li><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
      <li>Return <var>document</var>. 
     </ol>
     <p>The <dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" data-lt="createHTMLDocument(title)|createHTMLDocument()" id="dom-domimplementation-createhtmldocument"><code>createHTMLDocument(<var>title</var>)</code><a class="self-link" href="#dom-domimplementation-createhtmldocument"></a></dfn> method, when invoked, must run these steps:</p>
@@ -2582,11 +2582,11 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="dom
        If the <var>title</var> argument is not omitted: 
       <ol>
        <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> element created earlier. 
-       <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>, with its <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>title</var> (which could be the empty string), to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element created
+       <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with its <a data-link-type="dfn" href="#concept-CD-data">data</a> set to <var>title</var> (which could be the empty string), to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element created
    earlier. 
       </ol>
      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-body-element">body</a></code> element in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code> element created earlier. 
-     <li><var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
+     <li><var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
      <li>Return <var>doc</var>. 
     </ol>
     <p>The <dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-hasfeature"><code>hasFeature()</code><a class="self-link" href="#dom-domimplementation-hasfeature"></a></dfn> method, when
@@ -2603,16 +2603,16 @@ returns true) so that old pages don’t stop working. </p>
 interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="documentfragment">DocumentFragment<a class="self-link" href="#documentfragment"></a></dfn> : <a data-link-type="idl-name" href="#node">Node</a> {
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a> can have an
+   <p>A <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> can have an
 associated <a data-link-type="dfn" href="#concept-element">element</a> named <dfn data-dfn-for="DocumentFragment" data-dfn-type="dfn" data-export="" id="concept-DocumentFragment-host">host<a class="self-link" href="#concept-DocumentFragment-host"></a></dfn>.</p>
    <p>An object <var>A</var> is a <dfn data-dfn-type="dfn" data-export="" id="concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor<a class="self-link" href="#concept-tree-host-including-inclusive-ancestor"></a></dfn> of an object <var>B</var>, if either <var>A</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>B</var>, or if <var>B</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> has an associated <a data-link-type="dfn" href="#concept-DocumentFragment-host">host</a> and <var>A</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>B</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>’s <a data-link-type="dfn" href="#concept-DocumentFragment-host">host</a>.</p>
-   <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-DocumentFragment-host">host</a> concept is useful for HTML’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">template</a></code> element and the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webcomponents/spec/shadow/#the-shadowroot-interface">ShadowRoot</a></code> object and impacts the <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> and <a data-link-type="dfn" href="#concept-node-replace">replace</a> algorithms. </p>
+   <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-DocumentFragment-host">host</a> concept is useful for HTML’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">template</a></code> element and the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webcomponents/spec/shadow/#the-shadowroot-interface">ShadowRoot</a></code> object and impacts the <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> and <a data-link-type="dfn" href="#concept-node-replace">replace</a> algorithms. </p>
    <dl class="domintro">
-    <dt><code><var>tree</var> = new <code class="idl"><a data-link-type="idl" href="#dom-documentfragment-documentfragment">DocumentFragment()</a></code></code>
-    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
+    <dt><code><var>tree</var> = new <code class="idl"><a data-link-type="idl" href="#dom-documentfragment-documentfragment">DocumentFragment()</a></code></code> 
+    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="DocumentFragment" data-dfn-type="constructor" data-export="" id="dom-documentfragment-documentfragment">DocumentFragment()<a class="self-link" href="#dom-documentfragment-documentfragment"></a></dfn> constructor
-must return a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
+must return a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
    <h3 class="heading settled" data-level="4.7" id="interface-documenttype"><span class="secno">4.7. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code></span><a class="self-link" href="#interface-documenttype"></a></h3>
 <pre class="idl">[Exposed=Window]
 interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="documenttype">DocumentType<a class="self-link" href="#documenttype"></a></dfn> : <a data-link-type="idl-name" href="#node">Node</a> {
@@ -2621,7 +2621,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="doc
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dom-documenttype-systemid">systemId</a>;
 };
 </pre>
-   <p><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code><a data-link-type="dfn" href="#concept-node">nodes</a> are
+   <p><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> are
 simply known as <dfn data-dfn-type="dfn" data-export="" data-lt="doctype" id="concept-doctype">doctypes<a class="self-link" href="#concept-doctype"></a></dfn>.</p>
    <p><a data-link-type="dfn" href="#concept-doctype">Doctypes</a> have an associated <dfn data-dfn-for="DocumentType" data-dfn-type="dfn" data-export="" id="concept-doctype-name">name<a class="self-link" href="#concept-doctype-name"></a></dfn>, <dfn data-dfn-for="DocumentType" data-dfn-type="dfn" data-export="" id="concept-doctype-publicid">public ID<a class="self-link" href="#concept-doctype-publicid"></a></dfn>, and <dfn data-dfn-for="DocumentType" data-dfn-type="dfn" data-export="" id="concept-doctype-systemid">system ID<a class="self-link" href="#concept-doctype-systemid"></a></dfn>.</p>
    <p>When a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is created, its <a data-link-type="dfn" href="#concept-doctype-name">name</a> is always given. Unless
@@ -2667,23 +2667,23 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="ele
   <a data-link-type="idl-name" href="#htmlcollection">HTMLCollection</a> <a class="idl-code" data-link-type="method" href="#dom-element-getelementsbytagnamens">getElementsByTagNameNS</a>(DOMString? <dfn class="idl-code" data-dfn-for="Element/getElementsByTagNameNS(namespace, localName)" data-dfn-type="argument" data-export="" id="dom-element-getelementsbytagnamens-namespace-localname-namespace">namespace<a class="self-link" href="#dom-element-getelementsbytagnamens-namespace-localname-namespace"></a></dfn>, DOMString <dfn class="idl-code" data-dfn-for="Element/getElementsByTagNameNS(namespace, localName)" data-dfn-type="argument" data-export="" id="dom-element-getelementsbytagnamens-namespace-localname-localname">localName<a class="self-link" href="#dom-element-getelementsbytagnamens-namespace-localname-localname"></a></dfn>);
   <a data-link-type="idl-name" href="#htmlcollection">HTMLCollection</a> <a class="idl-code" data-link-type="method" href="#dom-element-getelementsbyclassname">getElementsByClassName</a>(DOMString <dfn class="idl-code" data-dfn-for="Element/getElementsByClassName(classNames)" data-dfn-type="argument" data-export="" id="dom-element-getelementsbyclassname-classnames-classnames">classNames<a class="self-link" href="#dom-element-getelementsbyclassname-classnames-classnames"></a></dfn>);
 };</pre>
-   <p><code class="idl"><a data-link-type="idl" href="#element">Element</a></code><a data-link-type="dfn" href="#concept-node">nodes</a> are simply
+   <p><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> are simply
 known as <dfn data-dfn-type="dfn" data-export="" data-lt="element" id="concept-element">elements<a class="self-link" href="#concept-element"></a></dfn>.</p>
    <p><a data-link-type="dfn" href="#concept-element">Elements</a> have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-namespace">namespace<a class="self-link" href="#concept-element-namespace"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-namespace-prefix">namespace prefix<a class="self-link" href="#concept-element-namespace-prefix"></a></dfn>, and <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-local-name">local name<a class="self-link" href="#concept-element-local-name"></a></dfn>. When an <a data-link-type="dfn" href="#concept-element">element</a> is created, its <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is always given.
 Unless explicitly given when an <a data-link-type="dfn" href="#concept-element">element</a> is created, its <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> and <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> are
 null.</p>
-   <p><a data-link-type="dfn" href="#concept-element">Elements</a> also have an ordered <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-attribute">attribute list<a class="self-link" href="#concept-element-attribute"></a></dfn> exposed through a <code class="idl"><a data-link-type="idl" href="#namednodemap">NamedNodeMap</a></code>. Unless explicitly given when an <a data-link-type="dfn" href="#concept-element">element</a> is created, its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> is empty. An <a data-link-type="dfn" href="#concept-element">element</a><dfn data-dfn-type="dfn" data-export="" data-lt="has an attribute" id="concept-element-attribute-has">has<a class="self-link" href="#concept-element-attribute-has"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a><var>A</var> if <var>A</var> is in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>.</p>
+   <p><a data-link-type="dfn" href="#concept-element">Elements</a> also have an ordered <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-attribute">attribute list<a class="self-link" href="#concept-element-attribute"></a></dfn> exposed through a <code class="idl"><a data-link-type="idl" href="#namednodemap">NamedNodeMap</a></code>. Unless explicitly given when an <a data-link-type="dfn" href="#concept-element">element</a> is created, its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> is empty. An <a data-link-type="dfn" href="#concept-element">element</a> <dfn data-dfn-type="dfn" data-export="" data-lt="has an attribute" id="concept-element-attribute-has">has<a class="self-link" href="#concept-element-attribute-has"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>A</var> if <var>A</var> is in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>.</p>
    <p>This specification uses and <a data-link-type="dfn" href="#other-applicable-specifications">applicable specifications</a> can use the hooks an <dfn data-dfn-type="dfn" data-export="" id="attribute-is-set">attribute is set<a class="self-link" href="#attribute-is-set"></a></dfn>, an <dfn data-dfn-type="dfn" data-export="" id="attribute-is-changed">attribute is changed<a class="self-link" href="#attribute-is-changed"></a></dfn>, an <dfn data-dfn-type="dfn" data-export="" id="attribute-is-added">attribute is added<a class="self-link" href="#attribute-is-added"></a></dfn>, and an <dfn data-dfn-type="dfn" data-export="" id="attribute-is-removed">attribute is removed<a class="self-link" href="#attribute-is-removed"></a></dfn>, for
 further processing of the <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>.</p>
-   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="change an attribute" id="concept-element-attributes-change">change<a class="self-link" href="#concept-element-attributes-change"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a><var>attribute</var> from an <a data-link-type="dfn" href="#concept-element">element</a><var>element</var> to <var>value</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="change an attribute" id="concept-element-attributes-change">change<a class="self-link" href="#concept-element-attributes-change"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attribute</var> from an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var> to <var>value</var>, run these steps:</p>
    <ol>
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>attributes</code>"
  for <var>element</var> with name <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, namespace <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, and oldValue <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
     <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a> to <var>value</var>. 
     <li>An <a data-link-type="dfn" href="#attribute-is-set">attribute is set</a> and an <a data-link-type="dfn" href="#attribute-is-changed">attribute is changed</a>. 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="append an attribute" id="concept-element-attributes-append">append<a class="self-link" href="#concept-element-attributes-append"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a><var>attribute</var> to
-an <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>,
+   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="append an attribute" id="concept-element-attributes-append">append<a class="self-link" href="#concept-element-attributes-append"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attribute</var> to
+an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>,
 run these steps:</p>
    <ol>
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>attributes</code>"
@@ -2693,7 +2693,7 @@ run these steps:</p>
     <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to <var>element</var>. 
     <li>An <a data-link-type="dfn" href="#attribute-is-set">attribute is set</a> and an <a data-link-type="dfn" href="#attribute-is-added">attribute is added</a>. 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="remove an attribute" id="concept-element-attributes-remove">remove<a class="self-link" href="#concept-element-attributes-remove"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a><var>attribute</var> from an <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>,
+   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="remove an attribute" id="concept-element-attributes-remove">remove<a class="self-link" href="#concept-element-attributes-remove"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attribute</var> from an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>,
 run these steps:</p>
    <ol>
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>attributes</code>"
@@ -2703,18 +2703,18 @@ run these steps:</p>
     <li>An <a data-link-type="dfn" href="#attribute-is-removed">attribute is removed</a>. 
    </ol>
    <hr>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-get-by-name">get an attribute by name<a class="self-link" href="#concept-element-attributes-get-by-name"></a></dfn> given a <var>name</var> and <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-get-by-name">get an attribute by name<a class="self-link" href="#concept-element-attributes-get-by-name"></a></dfn> given a <var>name</var> and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
    <ol>
     <li>If <var>element</var> is in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and its <a data-link-type="dfn" href="#concept-node-document">node document</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, let <var>name</var> be <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. 
     <li>Return the first <a data-link-type="dfn" href="#concept-attribute">attribute</a> in <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> whose <a data-link-type="dfn" href="#concept-attribute-name">name</a> is <var>name</var>, and null
  otherwise. 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-get-by-namespace">get an attribute by namespace and local name<a class="self-link" href="#concept-element-attributes-get-by-namespace"></a></dfn> given a <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-get-by-namespace">get an attribute by namespace and local name<a class="self-link" href="#concept-element-attributes-get-by-namespace"></a></dfn> given a <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
    <ol>
     <li>If <var>namespace</var> is the empty string, set it to null. 
     <li>Return the <a data-link-type="dfn" href="#concept-attribute">attribute</a> in <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, if any, and null otherwise. 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-set">set an attribute<a class="self-link" href="#concept-element-attributes-set"></a></dfn> given an <a data-link-type="dfn" href="#concept-attribute">attribute</a><var>attr</var>, <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>, and an optional <i>namespace and local name flag</i>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-set">set an attribute<a class="self-link" href="#concept-element-attributes-set"></a></dfn> given an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attr</var>, <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, and an optional <i>namespace and local name flag</i>, run these steps:</p>
    <ol>
     <li>If <var>attr</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is
  neither null nor <var>element</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#inuseattributeerror">InUseAttributeError</a></code>. 
@@ -2726,11 +2726,11 @@ run these steps:</p>
   working with <a data-link-type="dfn" href="#concept-attribute">attributes</a> in this way. </p>
     <li>If <var>oldAttr</var> is <var>attr</var>, return <var>attr</var>. 
     <li>If <var>oldAttr</var> is non-null, <a data-link-type="dfn" href="#concept-element-attributes-remove">remove</a> it from <var>element</var>. 
-    <li><a data-link-type="dfn" href="#concept-element-attributes-append">Append</a><var>attr</var> to <var>element</var>. 
+    <li><a data-link-type="dfn" href="#concept-element-attributes-append">Append</a> <var>attr</var> to <var>element</var>. 
     <li>Return <var>oldAttr</var>. 
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-set-value">set an attribute value<a class="self-link" href="#concept-element-attributes-set-value"></a></dfn> for
-an <a data-link-type="dfn" href="#concept-element">element</a><var>element</var> using a <var>localName</var> and <var>value</var>, and an optional <var>name</var>, <var>prefix</var>, and <var>namespace</var>, run these steps:</p>
+an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var> using a <var>localName</var> and <var>value</var>, and an optional <var>name</var>, <var>prefix</var>, and <var>namespace</var>, run these steps:</p>
    <ol>
     <li>If <var>name</var> is not given, set it to <var>localName</var>. 
     <li>If <var>prefix</var> is not given, set it to null. 
@@ -2738,15 +2738,15 @@ an <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>
     <li>Let <var>attribute</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and <var>element</var>. 
     <li>If <var>attribute</var> is null, create an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is <var>prefix</var>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, <a data-link-type="dfn" href="#concept-attribute-name">name</a> is <var>name</var>,
  and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, and then <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to <var>element</var> and terminate these steps. 
-    <li><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a><var>attribute</var> from <var>element</var> to <var>value</var>. 
+    <li><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a> <var>attribute</var> from <var>element</var> to <var>value</var>. 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-remove-by-name">remove an attribute by name<a class="self-link" href="#concept-element-attributes-remove-by-name"></a></dfn> given a <var>name</var> and <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-remove-by-name">remove an attribute by name<a class="self-link" href="#concept-element-attributes-remove-by-name"></a></dfn> given a <var>name</var> and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
    <ol>
     <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-name">getting an attribute</a> given <var>name</var> and <var>element</var>. 
     <li>If <var>attr</var> is non-null, <a data-link-type="dfn" href="#concept-element-attributes-remove">remove</a> it from <var>element</var>. 
     <li>Return <var>attr</var>. 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-remove-by-namespace">remove an attribute by namespace and local name<a class="self-link" href="#concept-element-attributes-remove-by-namespace"></a></dfn> given a <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-remove-by-namespace">remove an attribute by namespace and local name<a class="self-link" href="#concept-element-attributes-remove-by-namespace"></a></dfn> given a <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
    <ol>
     <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and <var>element</var>. 
     <li>If <var>attr</var> is non-null, <a data-link-type="dfn" href="#concept-element-attributes-remove">remove</a> it from <var>element</var>. 
@@ -2755,7 +2755,7 @@ an <a data-link-type="dfn" href="#concept-element">element</a><var>element</var>
    <hr>
    <p>An <a data-link-type="dfn" href="#concept-element">element</a> can have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" data-lt="ID" id="concept-id">unique identifier (ID)<a class="self-link" href="#concept-id"></a></dfn></p>
    <p class="note" role="note">Historically <a data-link-type="dfn" href="#concept-element">elements</a> could have multiple identifiers e.g. by using
-the HTML <code>id</code><a data-link-type="dfn" href="#concept-attribute">attribute</a> and a DTD. This specification makes <a data-link-type="dfn" href="#concept-id">ID</a> a
+the HTML <code>id</code> <a data-link-type="dfn" href="#concept-attribute">attribute</a> and a DTD. This specification makes <a data-link-type="dfn" href="#concept-id">ID</a> a
 concept of the DOM and allows for only one per <a data-link-type="dfn" href="#concept-element">element</a>, given by an <a data-link-type="dfn" href="#concept-named-attribute"><code>id</code> attribute</a>. </p>
    <p>An <a data-link-type="dfn" href="#concept-element">element</a> has an associated <code class="idl"><a data-link-type="idl" href="#domtokenlist">DOMTokenList</a></code> object. The <code class="idl"><a data-link-type="idl" href="#domtokenlist">DOMTokenList</a></code> object’s associated <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <code>class</code> and its associated ordered set of tokens is called the <a data-link-type="dfn" href="#concept-element">element</a>’s <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" data-lt="class" id="concept-class">classes<a class="self-link" href="#concept-class"></a></dfn>.</p>
    <p>When an <a data-link-type="dfn" href="#concept-element">element</a> is created that <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-named-attribute"><code>id</code> attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-value">value</a> is not the empty string or
@@ -2766,7 +2766,7 @@ string, set the <a data-link-type="dfn" href="#concept-element">element</a>’s 
 when an <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-named-attribute"><code>class</code> attribute</a> is <a data-link-type="dfn" href="#attribute-is-set">set</a>, set the <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-class">classes</a> to the new <a data-link-type="dfn" href="#concept-attribute-value">value</a>, <a data-link-type="dfn" href="#concept-ordered-set-parser">parsed</a>.</p>
    <p>When an <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-named-attribute"><code>class</code> attribute</a> is <a data-link-type="dfn" href="#attribute-is-removed">removed</a>, set the <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-class">classes</a> to the empty set.</p>
    <p class="note no-backref" role="note">While this specification defines user agent processing
-requirements for <code>id</code> and <code>class</code><a data-link-type="dfn" href="#concept-attribute">attributes</a> on any <a data-link-type="dfn" href="#concept-element">element</a>, it makes no claims as to whether
+requirements for <code>id</code> and <code>class</code> <a data-link-type="dfn" href="#concept-attribute">attributes</a> on any <a data-link-type="dfn" href="#concept-element">element</a>, it makes no claims as to whether
 using them is conforming or not. </p>
    <hr>
    <p>A <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of type <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> is known as a <dfn data-dfn-type="dfn" data-export="" id="parent-element">parent element<a class="self-link" href="#parent-element"></a></dfn>. If the <a data-link-type="dfn" href="#concept-node">node</a> has a <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of a different type, its <a data-link-type="dfn" href="#parent-element">parent element</a> is null.</p>
@@ -2776,13 +2776,13 @@ such <a data-link-type="dfn" href="#concept-element">element</a>. </p>
    <p>When an <a data-link-type="dfn" href="#concept-element">element</a> or one of its <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> is the <a data-link-type="dfn" href="#document-element">document element</a>, it is <dfn data-dfn-type="dfn" data-export="" id="in-a-document">in a document<a class="self-link" href="#in-a-document"></a></dfn>.</p>
    <hr>
    <dl class="domintro">
-    <dt><var>namespace</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-namespaceuri">namespaceURI</a></code>
+    <dt><var>namespace</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-namespaceuri">namespaceURI</a></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>. 
-    <dt><var>prefix</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-prefix">prefix</a></code>
+    <dt><var>prefix</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-prefix">prefix</a></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>. 
-    <dt><var>localName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-localname">localName</a></code>
+    <dt><var>localName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-localname">localName</a></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-element-local-name">local name</a>. 
-    <dt><var>qualifiedName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code>
+    <dt><var>qualifiedName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> 
     <dd>If <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is not
  null, returns the concatenation of <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>,
  "<code>:</code>", and <a data-link-type="dfn" href="#concept-element-local-name">local name</a>. Otherwise it
@@ -2841,7 +2841,7 @@ otherwise.</p>
     <li>Let <var>attribute</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-name">getting an attribute</a> given <var>name</var> and the <a data-link-type="dfn" href="#context-object">context object</a>. 
     <li>If <var>attribute</var> is null, create an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>name</var> and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, and then terminate these
  steps. 
-    <li><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a><var>attribute</var> from <a data-link-type="dfn" href="#context-object">context object</a> to <var>value</var>. 
+    <li><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a> <var>attribute</var> from <a data-link-type="dfn" href="#context-object">context object</a> to <var>value</var>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setattributens">setAttributeNS(<var>namespace</var>, <var>name</var>, <var>value</var>)<a class="self-link" href="#dom-element-setattributens"></a></dfn> method must run these steps:</p>
    <ol>
@@ -2853,12 +2853,12 @@ otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-hasattribute">hasAttribute(<var>name</var>)<a class="self-link" href="#dom-element-hasattribute"></a></dfn> method must run these steps:</p>
    <ol>
     <li>If the <a data-link-type="dfn" href="#context-object">context object</a> is in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and its <a data-link-type="dfn" href="#concept-node-document">node document</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, let <var>name</var> be <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. 
-    <li>Return true if the <a data-link-type="dfn" href="#context-object">context object</a><a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-name">name</a> is <var>name</var>, and false otherwise. 
+    <li>Return true if the <a data-link-type="dfn" href="#context-object">context object</a> <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-name">name</a> is <var>name</var>, and false otherwise. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-hasattributens">hasAttributeNS(<var>namespace</var>, <var>localName</var>)<a class="self-link" href="#dom-element-hasattributens"></a></dfn> method must run these steps:</p>
    <ol>
     <li>If <var>namespace</var> is the empty string, set it to null. 
-    <li>Return true if the <a data-link-type="dfn" href="#context-object">context object</a><a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, and false otherwise. 
+    <li>Return true if the <a data-link-type="dfn" href="#context-object">context object</a> <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, and false otherwise. 
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-getattributenode">getAttributeNode(<var>name</var>)<a class="self-link" href="#dom-element-getattributenode"></a></dfn> method, when invoked, must return the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-name">getting an attribute</a> given <var>name</var> and the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
@@ -2868,31 +2868,31 @@ otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-removeattributenode">removeAttributeNode(<var>attr</var>)<a class="self-link" href="#dom-element-removeattributenode"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
     <li>If <var>attr</var> is not in <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-element-attributes-remove">Remove</a><var>attr</var> from <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li><a data-link-type="dfn" href="#concept-element-attributes-remove">Remove</a> <var>attr</var> from <a data-link-type="dfn" href="#context-object">context object</a>. 
     <li>Return <var>attr</var>. 
    </ol>
    <hr>
    <dl class="domintro">
-    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-closest">closest(selectors)</a></code></code>
+    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-closest">closest(selectors)</a></code></code> 
     <dd>Returns the first (starting at <var>element</var>) <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> that matches <var>selectors</var>, and null otherwise. 
-    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-matches">matches(selectors)</a></code></code>
+    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-matches">matches(selectors)</a></code></code> 
     <dd>Returns true if matching <var>selectors</var> against <var>element</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> yields <var>element</var>, and false otherwise. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-closest"><code>closest(<var>selectors</var>)</code><a class="self-link" href="#dom-element-closest"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
     <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
     <li>Let <var>elements</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestors</a> that are <a data-link-type="dfn" href="#concept-element">elements</a>, in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
-    <li>For each <var>element</var> in <var>elements</var>, if <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">match a selector against an element</a>, using <var>s</var>, <var>element</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope element</a><a data-link-type="dfn" href="#context-object">context object</a>,
- returns success, return <var>element</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>For each <var>element</var> in <var>elements</var>, if <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">match a selector against an element</a>, using <var>s</var>, <var>element</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope element</a> <a data-link-type="dfn" href="#context-object">context object</a>,
+ returns success, return <var>element</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
     <li>Return null. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-matches"><code>matches(<var>selectors</var>)</code><a class="self-link" href="#dom-element-matches"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
     <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
-    <li>Return true if the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">match a selector against an element</a>, using <var>s</var>, <var>element</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope element</a><a data-link-type="dfn" href="#context-object">context object</a>,
- returns success, and false otherwise. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>Return true if the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">match a selector against an element</a>, using <var>s</var>, <var>element</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope element</a> <a data-link-type="dfn" href="#context-object">context object</a>,
+ returns success, and false otherwise. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-getelementsbytagname">getElementsByTagName(<var>localName</var>)<a class="self-link" href="#dom-element-getelementsbytagname"></a></dfn> method must return the <a data-link-type="dfn" href="#concept-getElementsByTagName">list of elements with local name <var>localName</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
@@ -3003,7 +3003,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="cha
 };
 </pre>
    <p class="note" role="note"><code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code> is an abstract interface and does
-not exist as <a data-link-type="dfn" href="#concept-node">node</a>. It is used by <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>, and <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>. </p>
+not exist as <a data-link-type="dfn" href="#concept-node">node</a>. It is used by <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>, and <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. </p>
    <p>Each <a data-link-type="dfn" href="#concept-node">node</a> inheriting from the <code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code> interface has an associated mutable string
 called <dfn data-dfn-for="CharacterData, Text, Comment, ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-CD-data">data<a class="self-link" href="#concept-CD-data"></a></dfn>.</p>
    <p>To <dfn data-dfn-for="CharacterData, Text, Comment, ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-CD-replace">replace data<a class="self-link" href="#concept-CD-replace"></a></dfn> of node <var>node</var> with offset <var>offset</var>, count <var>count</var>, and data <var>data</var>, run these steps:</p>
@@ -3014,10 +3014,10 @@ called <dfn data-dfn-for="CharacterData, Text, Comment, ProcessingInstruction" d
  than <var>length</var> let <var>count</var> be <var>length</var> minus <var>offset</var>. 
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>characterData</code>"
  for <var>node</var> with oldValue <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
-    <li>Insert <var>data</var> into <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> after <var>offset</var><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>. 
+    <li>Insert <var>data</var> into <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> after <var>offset</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>. 
     <li>Let <var>delete offset</var> be <var>offset</var> plus
  the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>. 
-    <li>Starting from <var>delete offset</var><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>, remove <var>count</var><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
+    <li>Starting from <var>delete offset</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>, remove <var>count</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
     <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> to <var>offset</var>. 
     <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> to <var>offset</var>. 
     <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>, then decrease it by <var>count</var>. 
@@ -3029,9 +3029,9 @@ called <dfn data-dfn-for="CharacterData, Text, Comment, ProcessingInstruction" d
     <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value. 
     <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
     <li>If <var>offset</var> plus <var>count</var> is
- greater than <var>length</var>, return a string whose value is the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from the <var>offset</var><sup>th</sup><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> to the end of <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>, and then
+ greater than <var>length</var>, return a string whose value is the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from the <var>offset</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> to the end of <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>, and then
  terminate these steps. 
-    <li>Return a string whose value is the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from the <var>offset</var><sup>th</sup><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> to the <var>offset</var>+<var>count</var><sup>th</sup><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> in <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
+    <li>Return a string whose value is the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from the <var>offset</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> to the <var>offset</var>+<var>count</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> in <var>node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="CharacterData" data-dfn-type="attribute" data-export="" id="dom-characterdata-data">data<a class="self-link" href="#dom-characterdata-data"></a></dfn> attribute
 must return <a data-link-type="dfn" href="#concept-CD-data">data</a>, and on setting, must <a data-link-type="dfn" href="#concept-CD-replace">replace data</a> with node <a data-link-type="dfn" href="#context-object">context object</a> offset 0, count <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value, and data
@@ -3052,27 +3052,27 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="tex
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dom-text-wholetext">wholeText</a>;
 };</pre>
    <dl class="domintro">
-    <dt><code><var>text</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-text-text">Text([<var>data</var> = ""])</a></code>
-    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
-    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-splittext">splitText(offset)</a></code></code>
-    <dd>Splits <a data-link-type="dfn" href="#concept-CD-data">data</a> at the given <var>offset</var> and returns the remainder as <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
-    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-wholetext">wholeText</a></code></code>
-    <dd>Returns the combined <a data-link-type="dfn" href="#concept-CD-data">data</a> of all direct <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-sibling">siblings</a>. 
+    <dt><code><var>text</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-text-text">Text([<var>data</var> = ""])</a></code> 
+    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
+    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-splittext">splitText(offset)</a></code></code> 
+    <dd>Splits <a data-link-type="dfn" href="#concept-CD-data">data</a> at the given <var>offset</var> and returns the remainder as <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
+    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-wholetext">wholeText</a></code></code> 
+    <dd>Returns the combined <a data-link-type="dfn" href="#concept-CD-data">data</a> of all direct <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Text" data-dfn-type="constructor" data-export="" id="dom-text-text">Text(<var>data</var>)<a class="self-link" href="#dom-text-text"></a></dfn> constructor
-must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
-   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="split a Text node" id="concept-Text-split">split<a class="self-link" href="#concept-Text-split"></a></dfn> a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a><var>node</var> with offset <var>offset</var>, run these steps:</p>
+must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="split a Text node" id="concept-Text-split">split<a class="self-link" href="#concept-Text-split"></a></dfn> a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> with offset <var>offset</var>, run these steps:</p>
    <ol>
     <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value. 
     <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
     <li>Let <var>count</var> be <var>length</var> minus <var>offset</var>. 
     <li>Let <var>new data</var> be the result of <a data-link-type="dfn" href="#concept-CD-substring">substringing data</a> with node <var>node</var>, offset <var>offset</var>, and count <var>count</var>. 
-    <li>Let <var>new node</var> be a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>, with the same <a data-link-type="dfn" href="#concept-node-document">node document</a> as <var>node</var>. Set <var>new node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> to <var>new data</var>. 
+    <li>Let <var>new node</var> be a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with the same <a data-link-type="dfn" href="#concept-node-document">node document</a> as <var>node</var>. Set <var>new node</var>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> to <var>new data</var>. 
     <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
     <li>
       If <var>parent</var> is not null, run these substeps: 
      <ol>
-      <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a><var>new node</var> into <var>parent</var> before <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
+      <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>new node</var> into <var>parent</var> before <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-start-node">start node</a> to <var>new node</var> and decrease its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by <var>offset</var>. 
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-end-node">end node</a> to <var>new node</var> and decrease its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by <var>offset</var>. 
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is equal to
@@ -3092,7 +3092,7 @@ must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Text" data-dfn-type="method" data-export="" id="dom-text-splittext">splitText(<var>offset</var>)<a class="self-link" href="#dom-text-splittext"></a></dfn> method must <a data-link-type="dfn" href="#concept-Text-split">split</a> the <a data-link-type="dfn" href="#context-object">context object</a> with offset <var>offset</var>.</p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="contiguous-text-nodes">contiguous <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> nodes<a class="self-link" href="#contiguous-text-nodes"></a></dfn> of a node are the node
-itself, the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node (if any) and its <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a>, and the <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node (if any) and its <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a>,
+itself, the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node (if any) and its <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a>, and the <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node (if any) and its <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a>,
 avoiding any duplicates.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Text" data-dfn-type="attribute" data-export="" id="dom-text-wholetext">wholeText<a class="self-link" href="#dom-text-wholetext"></a></dfn> attribute must return a concatenation of the <a data-link-type="dfn" href="#concept-CD-data">data</a> of the <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.</p>
    <h3 class="heading settled" data-level="4.11" id="interface-processinginstruction"><span class="secno">4.11. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code></span><a class="self-link" href="#interface-processinginstruction"></a></h3>
@@ -3100,7 +3100,7 @@ avoiding any duplicates.</p>
 interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="processinginstruction">ProcessingInstruction<a class="self-link" href="#processinginstruction"></a></dfn> : <a data-link-type="idl-name" href="#characterdata">CharacterData</a> {
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dom-processinginstruction-target">target</a>;
 };</pre>
-   <p><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code><a data-link-type="dfn" href="#concept-node">nodes</a> have an associated <dfn data-dfn-for="ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-PI-target">target<a class="self-link" href="#concept-PI-target"></a></dfn>.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> have an associated <dfn data-dfn-for="ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-PI-target">target<a class="self-link" href="#concept-PI-target"></a></dfn>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ProcessingInstruction" data-dfn-type="attribute" data-export="" id="dom-processinginstruction-target">target<a class="self-link" href="#dom-processinginstruction-target"></a></dfn> attribute must return the <a data-link-type="dfn" href="#concept-PI-target">target</a>.</p>
    <h3 class="heading settled" data-level="4.12" id="interface-comment"><span class="secno">4.12. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code></span><a class="self-link" href="#interface-comment"></a></h3>
 <pre class="idl">[<a class="idl-code" data-link-type="constructor" href="#dom-comment-comment">Constructor</a>(optional DOMString <dfn class="idl-code" data-dfn-for="Comment/Comment(data)" data-dfn-type="argument" data-export="" id="dom-comment-comment-data-data">data<a class="self-link" href="#dom-comment-comment-data-data"></a></dfn> = ""),
@@ -3109,10 +3109,10 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="com
 };
 </pre>
    <dl class="domintro">
-    <dt><code><var>comment</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-comment-comment">Comment([<var>data</var> = ""])</a></code>
-    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
+    <dt><code><var>comment</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-comment-comment">Comment([<var>data</var> = ""])</a></code> 
+    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var>. 
    </dl>
-   <p>The <dfn class="idl-code" data-dfn-for="Comment" data-dfn-type="constructor" data-export="" id="dom-comment-comment">Comment(<var>data</var>)<a class="self-link" href="#dom-comment-comment"></a></dfn> constructor must return a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Comment" data-dfn-type="constructor" data-export="" id="dom-comment-comment">Comment(<var>data</var>)<a class="self-link" href="#dom-comment-comment"></a></dfn> constructor must return a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-CD-data">data</a> is <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
    <h2 class="heading settled" data-level="5" id="ranges"><span class="secno">5. </span><span class="content">Ranges</span><a class="self-link" href="#ranges"></a></h2>
    <h3 class="heading settled" data-level="5.1" id="introduction-to-dom-ranges"><span class="secno">5.1. </span><span class="content"> Introduction to "DOM Ranges"</span><a class="self-link" href="#introduction-to-dom-ranges"></a></h3>
    <p>A <code class="idl"><a data-link-type="idl" href="#range">Range</a></code> object (<a data-link-type="dfn" href="#concept-range">range</a>)
@@ -3123,20 +3123,20 @@ a <a data-link-type="dfn" href="#concept-node-tree">node tree</a> between two <a
 for selecting and copying content.</p>
    <ul class="domTree">
     <li class="t1">
-     <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code>
+     <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code> 
      <ul>
-      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-ending BOM; decode as big-endian!"</span><span class="nt">></span></code>
-      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span>
+      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-ending BOM; decode as big-endian!"</span><span class="nt">></span></code> 
+      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span> 
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span></code>
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span></code> 
        <ul>
-        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span>
+        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span> 
        </ul>
-      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>!</span>
+      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>!</span> 
      </ul>
    </ul>
    <p>In the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> above, a <a data-link-type="dfn" href="#concept-range">range</a> can be used to represent the sequence
-“syndata is awes”. Assuming <var>p</var> is assigned to the <code>p</code><a data-link-type="dfn" href="#concept-element">element</a>, and <var>em</var> to the <code>em</code><a data-link-type="dfn" href="#concept-element">element</a>, this would be done as follows:</p>
+“syndata is awes”. Assuming <var>p</var> is assigned to the <code>p</code> <a data-link-type="dfn" href="#concept-element">element</a>, and <var>em</var> to the <code>em</code> <a data-link-type="dfn" href="#concept-element">element</a>, this would be done as follows:</p>
 <pre class="lang-javascript"><code class="highlight"><span class="kd">var</span> <span class="nx">range</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Range</span><span class="p">(),</span>
     <span class="nx">firstText</span> <span class="o">=</span> <span class="nx">p</span><span class="p">.</span><span class="nx">childNodes</span><span class="p">[</span><span class="mi">1</span><span class="p">],</span>
     <span class="nx">secondText</span> <span class="o">=</span> <span class="nx">em</span><span class="p">.</span><span class="nx">firstChild</span>
@@ -3201,7 +3201,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="ran
 (<a data-link-type="dfn" href="#concept-node">node</a>, <dfn data-dfn-for="boundary point" data-dfn-type="dfn" data-export="" id="concept-range-bp-offset">offset<a class="self-link" href="#concept-range-bp-offset"></a></dfn>) tuple, where <a data-link-type="dfn" href="#concept-range-bp-offset">offset</a> is a non-negative
 integer.</p>
    <p class="note no-backref" role="note">Generally speaking, a <a data-link-type="dfn" href="#concept-range-bp">boundary point</a>’s <a data-link-type="dfn" href="#concept-range-bp-offset">offset</a> will be between zero and
-the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a>’s <a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-node-length">length</a>, inclusive. Algorithms that
+the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a>’s <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-node-length">length</a>, inclusive. Algorithms that
 modify a <a data-link-type="dfn" href="#concept-tree">tree</a> (in particular the <a data-link-type="dfn" href="#concept-node-insert">insert</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a>, <a data-link-type="dfn" href="#concept-CD-replace">replace data</a>, and <a data-link-type="dfn" href="#concept-Text-split">split</a> algorithms) also modify <a data-link-type="dfn" href="#concept-range">ranges</a> associated with that <a data-link-type="dfn" href="#concept-tree">tree</a>. </p>
    <p>If the two <a data-link-type="dfn" href="#concept-node">nodes</a> of <a data-link-type="dfn" href="#concept-range-bp">boundary points</a> (<var>node A</var>, <var>offset A</var>) and
 (<var>node B</var>, <var>offset B</var>) have the same <a data-link-type="dfn" href="#concept-tree-root">root</a>, the <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-bp-position">position<a class="self-link" href="#concept-range-bp-position"></a></dfn> of the first relative to
@@ -3210,7 +3210,7 @@ as returned by the following algorithm:</p>
    <ol>
     <li>If <var>node A</var> is the same as <var>node B</var>,
  return <a data-link-type="dfn" href="#concept-range-bp-equal">equal</a> if <var>offset A</var> is the same as <var>offset B</var>, <a data-link-type="dfn" href="#concept-range-bp-before">before</a> if <var>offset A</var> is less than <var>offset B</var>, and <a data-link-type="dfn" href="#concept-range-bp-after">after</a> if <var>offset A</var> is greater than <var>offset B</var>. 
-    <li>If <var>node A</var> is <a data-link-type="dfn" href="#concept-tree-following">following</a><var>node B</var>, compute the <a data-link-type="dfn" href="#concept-range-bp-position">position</a> of
+    <li>If <var>node A</var> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node B</var>, compute the <a data-link-type="dfn" href="#concept-range-bp-position">position</a> of
  (<var>node B</var>, <var>offset B</var>) relative to
  (<var>node A</var>, <var>offset A</var>). If it is <a data-link-type="dfn" href="#concept-range-bp-before">before</a>, return <a data-link-type="dfn" href="#concept-range-bp-after">after</a>. If it is <a data-link-type="dfn" href="#concept-range-bp-after">after</a>, return <a data-link-type="dfn" href="#concept-range-bp-before">before</a>. 
     <li>
@@ -3226,29 +3226,29 @@ as returned by the following algorithm:</p>
    <p>Each <a data-link-type="dfn" href="#concept-range">range</a> has two associated <a data-link-type="dfn" href="#concept-range-bp">boundary points</a> — a <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-start">start<a class="self-link" href="#concept-range-start"></a></dfn> and <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-end">end<a class="self-link" href="#concept-range-end"></a></dfn>.</p>
    <p>For convenience, <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-start-node">start node<a class="self-link" href="#concept-range-start-node"></a></dfn> is <a data-link-type="dfn" href="#concept-range-start">start</a>’s <a data-link-type="dfn" href="#concept-node">node</a>, <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-start-offset">start offset<a class="self-link" href="#concept-range-start-offset"></a></dfn> is <a data-link-type="dfn" href="#concept-range-start">start</a>’s <a data-link-type="dfn" href="#concept-range-bp-offset">offset</a>, <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-end-node">end node<a class="self-link" href="#concept-range-end-node"></a></dfn> is <a data-link-type="dfn" href="#concept-range-end">end</a>’s <a data-link-type="dfn" href="#concept-node">node</a>,  and <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-end-offset">end offset<a class="self-link" href="#concept-range-end-offset"></a></dfn> is <a data-link-type="dfn" href="#concept-range-end">end</a>’s <a data-link-type="dfn" href="#concept-range-bp-offset">offset</a>.</p>
    <p>The <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-root">root<a class="self-link" href="#concept-range-root"></a></dfn> of a <a data-link-type="dfn" href="#concept-range">range</a> is the <a data-link-type="dfn" href="#concept-tree-root">root</a> of its <a data-link-type="dfn" href="#concept-range-start-node">start node</a>.</p>
-   <p>A <a data-link-type="dfn" href="#concept-node">node</a><var>node</var> is <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="contained">contained<a class="self-link" href="#contained"></a></dfn> in a <a data-link-type="dfn" href="#concept-range">range</a><var>range</var> if <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is
+   <p>A <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> is <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="contained">contained<a class="self-link" href="#contained"></a></dfn> in a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var> if <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is
 the same as <var>range</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, and (<var>node</var>, 0)
-is <a data-link-type="dfn" href="#concept-range-bp-after">after</a><var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a>, and (<var>node</var>, <a data-link-type="dfn" href="#concept-node-length">length</a> of <var>node</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a><var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a>.</p>
+is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a>, and (<var>node</var>, <a data-link-type="dfn" href="#concept-node-length">length</a> of <var>node</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a>.</p>
    <p>A <a data-link-type="dfn" href="#concept-node">node</a> is <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="partially-contained">partially contained<a class="self-link" href="#partially-contained"></a></dfn> in a <a data-link-type="dfn" href="#concept-range">range</a> if it is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of the <a data-link-type="dfn" href="#concept-range">range</a>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> but not its <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, or vice versa.</p>
    <div class="note" role="note">
      Some facts to better understand these definitions: 
     <ul>
-     <li>The content that one would think of as being within the <a data-link-type="dfn" href="#concept-range">range</a> consists of all <a data-link-type="dfn" href="#contained">contained</a><a data-link-type="dfn" href="#concept-node">nodes</a>, plus
-  possibly some of the contents of the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> if those are <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">nodes</a>. 
+     <li>The content that one would think of as being within the <a data-link-type="dfn" href="#concept-range">range</a> consists of all <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">nodes</a>, plus
+  possibly some of the contents of the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> if those are <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
      <li>The <a data-link-type="dfn" href="#concept-node">nodes</a> that are contained in a <a data-link-type="dfn" href="#concept-range">range</a> will generally not be contiguous,
-  because the <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of a <a data-link-type="dfn" href="#contained">contained</a><a data-link-type="dfn" href="#concept-node">node</a> will not
+  because the <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of a <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> will not
   always be <a data-link-type="dfn" href="#contained">contained</a>. 
-     <li>However, the <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of a <a data-link-type="dfn" href="#contained">contained</a><a data-link-type="dfn" href="#concept-node">node</a> are <a data-link-type="dfn" href="#contained">contained</a>, and if two <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> are <a data-link-type="dfn" href="#contained">contained</a>, so are any <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> that lie between them. 
+     <li>However, the <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of a <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> are <a data-link-type="dfn" href="#contained">contained</a>, and if two <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> are <a data-link-type="dfn" href="#contained">contained</a>, so are any <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> that lie between them. 
      <li>The <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> of a <a data-link-type="dfn" href="#concept-range">range</a> are never <a data-link-type="dfn" href="#contained">contained</a> within it. 
-     <li>The first <a data-link-type="dfn" href="#contained">contained</a><a data-link-type="dfn" href="#concept-node">node</a> (if there are any) will always be
+     <li>The first <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> (if there are any) will always be
   after the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, and the
-  last <a data-link-type="dfn" href="#contained">contained</a><a data-link-type="dfn" href="#concept-node">node</a> will
+  last <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> will
   always be equal to or before the <a data-link-type="dfn" href="#concept-range-end-node">end node</a>’s last <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a>. 
      <li>There exists a partially contained <a data-link-type="dfn" href="#concept-node">node</a> if and only if the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> are different. 
      <li>The <code class="idl"><a data-link-type="idl" href="#dom-range-commonancestorcontainer">commonAncestorContainer</a></code> attribute value is neither <a data-link-type="dfn" href="#contained">contained</a> nor <a data-link-type="dfn" href="#partially-contained">partially contained</a>. 
      <li>If the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of the <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, the common <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> will
   be the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>. Exactly one
-  of its <a data-link-type="dfn" href="#concept-tree-child">children</a> will be <a data-link-type="dfn" href="#partially-contained">partially contained</a>, and a <a data-link-type="dfn" href="#concept-tree-child">child</a> will be <a data-link-type="dfn" href="#contained">contained</a> if and only if it <a data-link-type="dfn" href="#concept-tree-preceding">precedes</a> the <a data-link-type="dfn" href="#partially-contained">partially contained</a><a data-link-type="dfn" href="#concept-tree-child">child</a>. If the <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, the opposite
+  of its <a data-link-type="dfn" href="#concept-tree-child">children</a> will be <a data-link-type="dfn" href="#partially-contained">partially contained</a>, and a <a data-link-type="dfn" href="#concept-tree-child">child</a> will be <a data-link-type="dfn" href="#contained">contained</a> if and only if it <a data-link-type="dfn" href="#concept-tree-preceding">precedes</a> the <a data-link-type="dfn" href="#partially-contained">partially contained</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. If the <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, the opposite
   holds. 
      <li>If the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is
   not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of
@@ -3260,24 +3260,24 @@ is <a data-link-type="dfn" href="#concept-range-bp-after">after</a><var>range</v
    </div>
    <hr>
    <dl class="domintro">
-    <dt><code><var>range</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-range-range">Range()</a></code>
+    <dt><code><var>range</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-range-range">Range()</a></code> 
     <dd>Returns a new <a data-link-type="dfn" href="#concept-range">range</a>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="constructor" data-export="" id="dom-range-range"><code>Range()</code><a class="self-link" href="#dom-range-range"></a></dfn> constructor must return a new <a data-link-type="dfn" href="#concept-range">range</a> with
 (global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>, 0) as its <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a>.</p>
    <hr>
    <dl class="domintro">
-    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startcontainer">startContainer</a></code>
+    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startcontainer">startContainer</a></code> 
     <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>. 
-    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startoffset">startOffset</a></code>
+    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startoffset">startOffset</a></code> 
     <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>. 
-    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endcontainer">endContainer</a></code>
+    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endcontainer">endContainer</a></code> 
     <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end-node">end node</a>. 
-    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endoffset">endOffset</a></code>
+    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endoffset">endOffset</a></code> 
     <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
-    <dt><var>collapsed</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-collapsed">collapsed</a></code>
+    <dt><var>collapsed</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-collapsed">collapsed</a></code> 
     <dd>Returns true if <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> are the same, and false otherwise. 
-    <dt><var>container</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-commonancestorcontainer">commonAncestorContainer</a></code>
+    <dt><var>container</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-commonancestorcontainer">commonAncestorContainer</a></code> 
     <dd>Returns the <a data-link-type="dfn" href="#concept-node">node</a>, furthest away from
  the <a data-link-type="dfn" href="#concept-document">document</a>, that is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of both <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a>. 
    </dl>
@@ -3346,7 +3346,7 @@ as <a data-link-type="dfn" href="#concept-range-end">end</a>, and false otherwis
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" data-lt="collapse(toStart)|collapse()" id="dom-range-collapse"><code>collapse(<var>toStart</var>)</code><a class="self-link" href="#dom-range-collapse"></a></dfn> method, when
 invoked, must if <var>toStart</var> is true, set <a data-link-type="dfn" href="#concept-range-end">end</a> to <a data-link-type="dfn" href="#concept-range-start">start</a>, and set <a data-link-type="dfn" href="#concept-range-start">start</a> to <a data-link-type="dfn" href="#concept-range-end">end</a> otherwise.</p>
-   <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-select">select<a class="self-link" href="#concept-range-select"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a><var>node</var> within a <a data-link-type="dfn" href="#concept-range">range</a><var>range</var>, run these steps:</p>
+   <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-select">select<a class="self-link" href="#concept-range-select"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> within a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
     <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
     <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code>. 
@@ -3354,7 +3354,7 @@ invoked, must if <var>toStart</var> is true, set <a data-link-type="dfn" href="#
     <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>index</var>). 
     <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>index</var> plus one). 
    </ol>
-   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-selectnode">selectNode(<var>node</var>)<a class="self-link" href="#dom-range-selectnode"></a></dfn> method must <a data-link-type="dfn" href="#concept-range-select">select</a><var>node</var> within <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-selectnode">selectNode(<var>node</var>)<a class="self-link" href="#dom-range-selectnode"></a></dfn> method must <a data-link-type="dfn" href="#concept-range-select">select</a> <var>node</var> within <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-selectnodecontents">selectNodeContents(<var>node</var>)<a class="self-link" href="#dom-range-selectnodecontents"></a></dfn> method must run these steps:</p>
    <ol>
     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code>. 
@@ -3373,7 +3373,7 @@ invoked, must if <var>toStart</var> is true, set <a data-link-type="dfn" href="#
       <li><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_end">END_TO_END</a></code>, and 
       <li><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_start">END_TO_START</a></code>, 
      </ul>
-     <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception. 
+      <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception. 
      <p></p>
     <li>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a> is not the same as <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a></code> exception. 
     <li>
@@ -3395,11 +3395,11 @@ invoked, must if <var>toStart</var> is true, set <a data-link-type="dfn" href="#
     <li>
       If the <a data-link-type="dfn" href="#concept-range-bp-position">position</a> of <var>this point</var> relative to <var>other point</var> is 
      <dl class="switch">
-      <dt><a data-link-type="dfn" href="#concept-range-bp-before">before</a>
+      <dt><a data-link-type="dfn" href="#concept-range-bp-before">before</a> 
       <dd>Return −1. 
-      <dt><a data-link-type="dfn" href="#concept-range-bp-equal">equal</a>
+      <dt><a data-link-type="dfn" href="#concept-range-bp-equal">equal</a> 
       <dd>Return 0. 
-      <dt><a data-link-type="dfn" href="#concept-range-bp-after">after</a>
+      <dt><a data-link-type="dfn" href="#concept-range-bp-after">after</a> 
       <dd>Return 1. 
      </dl>
    </ol>
@@ -3409,7 +3409,7 @@ run these steps:</p>
     <li>If <a data-link-type="dfn" href="#concept-range-start">start</a> is <a data-link-type="dfn" href="#concept-range-end">end</a>, terminate these steps. 
     <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>,
  and <var>original end offset</var> be the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively. 
-    <li>If <var>original start node</var> and <var>original end node</var> are the same, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-CD-replace">replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string, and then
+    <li>If <var>original start node</var> and <var>original end node</var> are the same, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-CD-replace">replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string, and then
  terminate these steps. 
     <li>Let <var>nodes to remove</var> be a list of all the <a data-link-type="dfn" href="#concept-node">nodes</a> that are <a data-link-type="dfn" href="#contained">contained</a> in
  the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, omitting any <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is also <a data-link-type="dfn" href="#contained">contained</a> in the <a data-link-type="dfn" href="#context-object">context object</a>. 
@@ -3424,25 +3424,25 @@ run these steps:</p>
     plus the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>reference node</var>. 
        <p class="note no-backref" role="note">If <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> were null, it would be the <a data-link-type="dfn" href="#concept-range-root">root</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, so would be an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, and we could not reach this point. </p>
      </ol>
-    <li>If <var>original start node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-CD-replace">replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>, data the empty string. 
+    <li>If <var>original start node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-CD-replace">replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>, data the empty string. 
     <li>For each <var>node</var> in <var>nodes to remove</var>,
- in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a><var>node</var> from
+ in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from
  its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>If <var>original end node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-CD-replace">replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var> and data the empty string. 
+    <li>If <var>original end node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-CD-replace">replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var> and data the empty string. 
     <li>Set <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> to
  (<var>new node</var>, <var>new offset</var>). 
    </ol>
-   <p>To <dfn data-dfn-type="dfn" data-export="" data-local-lt="extract" data-lt="extract a range" id="concept-range-extract">extract<a class="self-link" href="#concept-range-extract"></a></dfn> a <a data-link-type="dfn" href="#concept-range">range</a><var>range</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" data-local-lt="extract" data-lt="extract a range" id="concept-range-extract">extract<a class="self-link" href="#concept-range-extract"></a></dfn> a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
-    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
+    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
     <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> is its <a data-link-type="dfn" href="#concept-range-end">end</a>, return <var>fragment</var>. 
     <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively. 
     <li>
-      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
       <li>Set the <a data-link-type="dfn" href="#concept-CD-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-CD-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li><a data-link-type="dfn" href="#concept-CD-replace">Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string. 
       <li>Return <var>fragment</var>. 
      </ol>
@@ -3475,12 +3475,12 @@ run these steps:</p>
        <p class="note no-backref" role="note">If <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, it would be the <a data-link-type="dfn" href="#concept-range-root">root</a> of <var>range</var>, so would be an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, and we could not reach this point. </p>
      </ol>
     <li>
-      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
      <p class="note no-backref" role="note">In this case, <var>first partially contained child</var> is <var>original start node</var>. </p>
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
       <li>Set the <a data-link-type="dfn" href="#concept-CD-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-CD-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li><a data-link-type="dfn" href="#concept-CD-replace">Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>, and data the empty string. 
      </ol>
     <li>
@@ -3488,22 +3488,22 @@ run these steps:</p>
   null: 
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>first partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
    whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
    (<var>first partially contained child</var>, <var>first partially contained child</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a><var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>subfragment</var> to <var>clone</var>. 
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <var>subrange</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
      </ol>
-    <li>For each <var>contained child</var> in <var>contained children</var>, <a data-link-type="dfn" href="#concept-node-append">append</a><var>contained child</var> to <var>fragment</var>. 
+    <li>For each <var>contained child</var> in <var>contained children</var>, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>contained child</var> to <var>fragment</var>. 
     <li>
-      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
      <p class="note no-backref" role="note">In this case, <var>last partially contained child</var> is <var>original end node</var>. </p>
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original end node</var>. 
       <li>Set the <a data-link-type="dfn" href="#concept-CD-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-CD-substring">substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li><a data-link-type="dfn" href="#concept-CD-replace">Replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var>, and data the empty string. 
      </ol>
     <li>
@@ -3511,30 +3511,30 @@ run these steps:</p>
   null: 
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>last partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>last partially contained child</var>, 0) and whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
    (<var>original end node</var>, <var>original end offset</var>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a><var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>subfragment</var> to <var>clone</var>. 
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <var>subrange</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
      </ol>
     <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> to
  (<var>new node</var>, <var>new offset</var>). 
     <li>Return <var>fragment</var>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-extractcontents">extractContents()<a class="self-link" href="#dom-range-extractcontents"></a></dfn> method
-must return the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a><a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="clone a range" id="concept-range-clone">clone<a class="self-link" href="#concept-range-clone"></a></dfn> a <a data-link-type="dfn" href="#concept-range">range</a><var>range</var>, run these steps:</p>
+must return the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="clone a range" id="concept-range-clone">clone<a class="self-link" href="#concept-range-clone"></a></dfn> a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
-    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
+    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
     <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> is its <a data-link-type="dfn" href="#concept-range-end">end</a>, return <var>fragment</var>. 
     <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively. 
     <li>
-      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
       <li>Set the <a data-link-type="dfn" href="#concept-CD-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-CD-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li>Return <var>fragment</var>. 
      </ol>
     <li>Let <var>common ancestor</var> be <var>original start node</var>. 
@@ -3555,95 +3555,95 @@ must return the result of <a data-link-type="dfn" href="#concept-range-extract">
   partially contained. It cannot be a boundary point of a range, and it
   cannot be the ancestor of anything. </p>
     <li>
-      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
      <p class="note no-backref" role="note">In this case, <var>first partially contained child</var> is <var>original start node</var>. </p>
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
       <li>Set the <a data-link-type="dfn" href="#concept-CD-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-CD-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
      </ol>
     <li>
       Otherwise, if <var>first partially contained child</var> is not
   null: 
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>first partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
    whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
    (<var>first partially contained child</var>, <var>first partially contained child</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a><var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>subfragment</var> to <var>clone</var>. 
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
      </ol>
     <li>
       For each <var>contained child</var> in <var>contained children</var>: 
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>contained child</var> with the <i>clone children flag</i> set. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
      </ol>
     <li>
-      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
      <p class="note no-backref" role="note">In this case, <var>last partially contained child</var> is <var>original end node</var>. </p>
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original end node</var>. 
       <li>Set the <a data-link-type="dfn" href="#concept-CD-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-CD-substring">substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
      </ol>
     <li>
       Otherwise, if <var>last partially contained child</var> is not
   null: 
      <ol>
       <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>last partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>clone</var> to <var>fragment</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>last partially contained child</var>, 0) and whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
    (<var>original end node</var>, <var>original end offset</var>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a><var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>subfragment</var> to <var>clone</var>. 
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
      </ol>
     <li>Return <var>fragment</var>. 
    </ol>
-   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-clonecontents">cloneContents()<a class="self-link" href="#dom-range-clonecontents"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a><a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-insert">insert<a class="self-link" href="#concept-range-insert"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a><var>node</var> into a <a data-link-type="dfn" href="#concept-range">range</a><var>range</var>, run these steps:</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-clonecontents">cloneContents()<a class="self-link" href="#dom-range-clonecontents"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-insert">insert<a class="self-link" href="#concept-range-insert"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> into a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
     <li>
-     If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is either a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, or a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception. 
+     If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is either a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, or a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception. 
      <p></p>
     <li>Let <var>referenceNode</var> be null. 
-    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>,
- set <var>referenceNode</var> to that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>. 
+    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>,
+ set <var>referenceNode</var> to that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
     <li>Otherwise, set <var>referenceNode</var> to the <a data-link-type="dfn" href="#concept-tree-child">child</a> of <a data-link-type="dfn" href="#concept-range-start-node">start node</a> whose <a data-link-type="dfn" href="#concept-tree-index">index</a> is <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, and null if
  there is no such <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
     <li>
      Let <var>parent</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> if <var>referenceNode</var> is null, and <var>referenceNode</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> otherwise. 
      <p></p>
     <li><a data-link-type="dfn" href="#concept-node-ensure-pre-insertion-validity">Ensure pre-insertion validity</a> of <var>node</var> into <var>parent</var> before <var>referenceNode</var>. 
-    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>, set <var>referenceNode</var> to the result of <a data-link-type="dfn" href="#concept-Text-split">splitting</a> it with
+    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, set <var>referenceNode</var> to the result of <a data-link-type="dfn" href="#concept-Text-split">splitting</a> it with
  offset <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>. 
     <li>If <var>node</var> is <var>referenceNode</var>, set <var>referenceNode</var> to its <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
     <li>
      If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not
- null, <a data-link-type="dfn" href="#concept-node-remove">remove</a><var>node</var> from its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+ null, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
      <p></p>
     <li>Let <var>newOffset</var> be <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> if <var>referenceNode</var> is null,
  and <var>referenceNode</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a> otherwise. 
-    <li>Increase <var>newOffset</var> by <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, and one otherwise. 
-    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a><var>node</var> into <var>parent</var> before <var>referenceNode</var>. 
+    <li>Increase <var>newOffset</var> by <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and one otherwise. 
+    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into <var>parent</var> before <var>referenceNode</var>. 
     <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> are the same, set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to
  (<var>parent</var>, <var>newOffset</var>). 
    </ol>
-   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-insertnode">insertNode(<var>node</var>)<a class="self-link" href="#dom-range-insertnode"></a></dfn> method must <a data-link-type="dfn" href="#concept-range-insert">insert</a><var>node</var> into <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-insertnode">insertNode(<var>node</var>)<a class="self-link" href="#dom-range-insertnode"></a></dfn> method must <a data-link-type="dfn" href="#concept-range-insert">insert</a> <var>node</var> into <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-surroundcontents">surroundContents(<var>newParent</var>)<a class="self-link" href="#dom-range-surroundcontents"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>If a non-<code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in the <a data-link-type="dfn" href="#context-object">context object</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception. 
+    <li>If a non-<code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in the <a data-link-type="dfn" href="#context-object">context object</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception. 
     <li>
-     If <var>newParent</var> is a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, or <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
+     If <var>newParent</var> is a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, or <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
      <p></p>
-    <li>Let <var>fragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a><a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li>Let <var>fragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <a data-link-type="dfn" href="#context-object">context object</a>. 
     <li>If <var>newParent</var> has <a data-link-type="dfn" href="#concept-tree-child">children</a>, <a data-link-type="dfn" href="#concept-node-replace-all">replace all</a> with null within <var>newParent</var>. 
-    <li><a data-link-type="dfn" href="#concept-range-insert">Insert</a><var>newParent</var> into <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-append">Append</a><var>fragment</var> to <var>newParent</var>. 
-    <li><a data-link-type="dfn" href="#concept-range-select">Select</a><var>newParent</var> within <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li><a data-link-type="dfn" href="#concept-range-insert">Insert</a> <var>newParent</var> into <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>fragment</var> to <var>newParent</var>. 
+    <li><a data-link-type="dfn" href="#concept-range-select">Select</a> <var>newParent</var> within <a data-link-type="dfn" href="#context-object">context object</a>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-clonerange">cloneRange()<a class="self-link" href="#dom-range-clonerange"></a></dfn> method must return a new <a data-link-type="dfn" href="#concept-range">range</a> with the
 same <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> as the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
@@ -3652,10 +3652,10 @@ do nothing. <span class="note" role="note">Its functionality (disabling a <code 
 for compatibility.</span></p>
    <hr>
    <dl class="domintro">
-    <dt><var>position</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-comparepoint">comparePoint(node, offset)</a></code>
+    <dt><var>position</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-comparepoint">comparePoint(node, offset)</a></code> 
     <dd>Returns −1 if the point is before the range, 0 if the point is
  in the range, and 1 if the point is after the range. 
-    <dt><var>intersects</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-intersectsnode">intersectsNode(node)</a></code>
+    <dt><var>intersects</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-intersectsnode">intersectsNode(node)</a></code> 
     <dd>Returns whether <var>range</var> intersects <var>node</var>. 
    </dl>
    <div class="impl">
@@ -3665,7 +3665,7 @@ for compatibility.</span></p>
  different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, return false. 
      <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
      <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
-     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a><a data-link-type="dfn" href="#concept-range-start">start</a> or <a data-link-type="dfn" href="#concept-range-bp-after">after</a><a data-link-type="dfn" href="#concept-range-end">end</a>, return false. 
+     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-start">start</a> or <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-end">end</a>, return false. 
      <li>Return true. 
     </ol>
     <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-comparepoint">comparePoint(<var>node</var>, <var>offset</var>)<a class="self-link" href="#dom-range-comparepoint"></a></dfn> method must run these steps:</p>
@@ -3674,8 +3674,8 @@ for compatibility.</span></p>
  different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a></code> exception. 
      <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
      <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
-     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a><a data-link-type="dfn" href="#concept-range-start">start</a>, return −1. 
-     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a><a data-link-type="dfn" href="#concept-range-end">end</a>, return 1. 
+     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-start">start</a>, return −1. 
+     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-end">end</a>, return 1. 
      <li>Return 0. 
     </ol>
     <hr>
@@ -3685,7 +3685,7 @@ for compatibility.</span></p>
      <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
      <li>If <var>parent</var> is null, return true. 
      <li>Let <var>offset</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
-     <li>If (<var>parent</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a><a data-link-type="dfn" href="#concept-range-end">end</a> and (<var>parent</var>, <var>offset</var> + 1) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a><a data-link-type="dfn" href="#concept-range-start">start</a>, return true. 
+     <li>If (<var>parent</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-end">end</a> and (<var>parent</var>, <var>offset</var> + 1) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-start">start</a>, return true. 
      <li>Return false. 
     </ol>
    </div>
@@ -3694,23 +3694,23 @@ for compatibility.</span></p>
 these steps:</p>
    <ol>
     <li>Let <var>s</var> be the empty string. 
-    <li>If <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and it is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>, return the
- substring of that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> beginning at <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> and ending at <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
-    <li>If <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> from the <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> until the end. 
-    <li>Append to <var>s</var> the concatenation, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, of the <a data-link-type="dfn" href="#concept-CD-data">data</a> of all <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">nodes</a> that are <a data-link-type="dfn" href="#contained">contained</a> in
+    <li>If <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and it is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, return the
+ substring of that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> beginning at <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> and ending at <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
+    <li>If <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> from the <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> until the end. 
+    <li>Append to <var>s</var> the concatenation, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, of the <a data-link-type="dfn" href="#concept-CD-data">data</a> of all <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> that are <a data-link-type="dfn" href="#contained">contained</a> in
  the <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>If <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code><a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> from its start until the <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
+    <li>If <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-CD-data">data</a> from its start until the <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
     <li>Return <var>s</var>. 
    </ol>
    <hr>
    <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/DOM-Parsing/#widl-Range-createContextualFragment-DocumentFragment-DOMString-fragment">createContextualFragment()</a></code>, <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects">getClientRects()</a></code>,
-and <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">getBoundingClientRect()</a></code> methods are defined in other specifications. <a data-link-type="biblio" href="#biblio-dom-parsing">[DOM-Parsing]</a><a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a></p>
+and <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">getBoundingClientRect()</a></code> methods are defined in other specifications. <a data-link-type="biblio" href="#biblio-dom-parsing">[DOM-Parsing]</a> <a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a> </p>
    <h2 class="heading settled" data-level="6" id="traversal"><span class="secno">6. </span><span class="content">Traversal</span><a class="self-link" href="#traversal"></a></h2>
    <p><code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> and <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> objects can be used
-to filter and traverse <a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree">trees</a>.</p>
+to filter and traverse <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree">trees</a>.</p>
    <p>Each <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> and <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> object also
-has an associated <dfn data-dfn-for="traversal" data-dfn-type="dfn" data-export="" id="concept-traversal-root">root<a class="self-link" href="#concept-traversal-root"></a></dfn><a data-link-type="dfn" href="#concept-node">node</a>, <dfn data-dfn-for="traversal" data-dfn-type="dfn" data-export="" id="concept-traversal-whatToShow">whatToShow<a class="self-link" href="#concept-traversal-whatToShow"></a></dfn> bitmask, and <dfn data-dfn-for="traversal" data-dfn-type="dfn" data-export="" id="concept-traversal-filter">filter<a class="self-link" href="#concept-traversal-filter"></a></dfn> callback.</p>
-   <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-filter">filter<a class="self-link" href="#concept-node-filter"></a></dfn><var>node</var> run
+has an associated <dfn data-dfn-for="traversal" data-dfn-type="dfn" data-export="" id="concept-traversal-root">root<a class="self-link" href="#concept-traversal-root"></a></dfn> <a data-link-type="dfn" href="#concept-node">node</a>, <dfn data-dfn-for="traversal" data-dfn-type="dfn" data-export="" id="concept-traversal-whatToShow">whatToShow<a class="self-link" href="#concept-traversal-whatToShow"></a></dfn> bitmask, and <dfn data-dfn-for="traversal" data-dfn-type="dfn" data-export="" id="concept-traversal-filter">filter<a class="self-link" href="#concept-traversal-filter"></a></dfn> callback.</p>
+   <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-filter">filter<a class="self-link" href="#concept-node-filter"></a></dfn> <var>node</var> run
 these steps:</p>
    <ol>
     <li>Let <var>n</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code> attribute value minus 1. 
@@ -3741,7 +3741,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="nod
    <p class="note no-backref" role="note"><code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> objects can be created using the <code class="idl"><a data-link-type="idl" href="#dom-document-createnodeiterator">createNodeIterator()</a></code> method. </p>
    <p>Each <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object has an associated <dfn data-dfn-for="NodeIterator" data-dfn-type="dfn" data-export="" id="iterator-collection">iterator collection<a class="self-link" href="#iterator-collection"></a></dfn>, which is a <a data-link-type="dfn" href="#concept-collection">collection</a> rooted at <a data-link-type="dfn" href="#concept-traversal-root">root</a>, whose filter matches any <a data-link-type="dfn" href="#concept-node">node</a>.</p>
    <p class="note no-backref" role="note">As mentioned earlier, <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> objects have an
-associated <a data-link-type="dfn" href="#concept-traversal-root">root</a><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-traversal-whatToShow">whatToShow</a> bitmask, and <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> callback as well. </p>
+associated <a data-link-type="dfn" href="#concept-traversal-root">root</a> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-traversal-whatToShow">whatToShow</a> bitmask, and <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> callback as well. </p>
    <p>The <dfn data-dfn-type="dfn" data-noexport="" id="nodeiterator-pre_removing-steps"><code>NodeIterator</code> pre-removing steps<a class="self-link" href="#nodeiterator-pre_removing-steps"></a></dfn> given a <var>nodeIterator</var> and <var>toBeRemovedNode</var>, are as follows:</p>
    <ol>
     <li>
@@ -3751,7 +3751,7 @@ associated <a data-link-type="dfn" href="#concept-traversal-root">root</a><a dat
   substeps: </p>
      <ol>
       <li>
-       <p>Let <var>next</var> be <var>toBeRemovedNode</var>’s first <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-node">node</a> that is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>nodeIterator</var>’s <a data-link-type="dfn" href="#concept-traversal-root">root</a> and is not an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>toBeRemovedNode</var>, and null if there is no such <a data-link-type="dfn" href="#concept-node">node</a>. </p>
+       <p>Let <var>next</var> be <var>toBeRemovedNode</var>’s first <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-node">node</a> that is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>nodeIterator</var>’s <a data-link-type="dfn" href="#concept-traversal-root">root</a> and is not an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>toBeRemovedNode</var>, and null if there is no such <a data-link-type="dfn" href="#concept-node">node</a>. </p>
       <li>
        <p>If <var>next</var> is non-null, set <var>nodeIterator</var>’s <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute to <var>next</var> and terminate these steps. </p>
       <li>
@@ -3778,15 +3778,15 @@ must return <a data-link-type="dfn" href="#concept-traversal-root">root</a>.</p>
       <li>
        <dl class="switch">
         <dt>If direction is next 
-        <dd> If <var>before node</var> is false, let <var>node</var> be the first <a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-following">following</a><var>node</var> in the <span>iterator collection</span>. If
+        <dd> If <var>before node</var> is false, let <var>node</var> be the first <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node</var> in the <span>iterator collection</span>. If
       there is no such <a data-link-type="dfn" href="#concept-node">node</a> return null.
       If <var>before node</var> is true, set it to false. 
         <dt>If direction is previous 
-        <dd> If <var>before node</var> is true, let <var>node</var> be the first <a data-link-type="dfn" href="#concept-node">node</a><a data-link-type="dfn" href="#concept-tree-preceding">preceding</a><var>node</var> in the <span>iterator collection</span>. If
+        <dd> If <var>before node</var> is true, let <var>node</var> be the first <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>node</var> in the <span>iterator collection</span>. If
       there is no such <a data-link-type="dfn" href="#concept-node">node</a> return null.
       If <var>before node</var> is false, set it to true. 
        </dl>
-      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and let <var>result</var> be the return
+      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
    value. 
       <li> If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, go to the
     next step in the overall set of steps.
@@ -3819,7 +3819,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="tre
 };</pre>
    <p class="note no-backref" role="note"><code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> objects can be created using the <code class="idl"><a data-link-type="idl" href="#dom-document-createtreewalker">createTreeWalker()</a></code> method. </p>
    <p class="note no-backref" role="note">As mentioned earlier <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> objects have an
-associated <a data-link-type="dfn" href="#concept-traversal-root">root</a><a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-traversal-whatToShow">whatToShow</a> bitmask, and <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> callback. </p>
+associated <a data-link-type="dfn" href="#concept-traversal-root">root</a> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-traversal-whatToShow">whatToShow</a> bitmask, and <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> callback. </p>
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="attribute" data-export="" id="dom-treewalker-root">root<a class="self-link" href="#dom-treewalker-root"></a></dfn> attribute must
 return <a data-link-type="dfn" href="#concept-traversal-root">root</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="attribute" data-export="" id="dom-treewalker-whattoshow">whatToShow<a class="self-link" href="#dom-treewalker-whattoshow"></a></dfn> attribute must return <a data-link-type="dfn" href="#concept-traversal-whatToShow">whatToShow</a>.</p>
@@ -3834,7 +3834,7 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
       While <var>node</var> is not null and is not <a data-link-type="dfn" href="#concept-traversal-root">root</a>, run these substeps: 
      <ol>
       <li>Let <var>node</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-      <li>If <var>node</var> is not null and <a data-link-type="dfn" href="#concept-node-filter">filtering</a><var>node</var> returns <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>,
+      <li>If <var>node</var> is not null and <a data-link-type="dfn" href="#concept-node-filter">filtering</a> <var>node</var> returns <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>,
    then set the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var>, return <var>node</var>. 
      </ol>
     <li>Return null. 
@@ -3846,10 +3846,10 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
     <li>Set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> if <var>type</var> is first, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>type</var> is last. 
     <li>If <var>node</var> is null, return null. 
     <li>
-     <dfn data-dfn-type="dfn" data-export="" data-lt="Traverse children main step" id="concept-traverse-children-main">Main<a class="self-link" href="#concept-traverse-children-main"></a></dfn>:
+      <dfn data-dfn-type="dfn" data-export="" data-lt="Traverse children main step" id="concept-traverse-children-main">Main<a class="self-link" href="#concept-traverse-children-main"></a></dfn>:
   Repeat these substeps: 
      <ol>
-      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and let <var>result</var> be the return
+      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
    value. 
       <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
    the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>. 
@@ -3886,7 +3886,7 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
         While <var>sibling</var> is not null, run these subsubsteps: 
        <ol>
         <li>Set <var>node</var> to <var>sibling</var>. 
-        <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and let <var>result</var> be the return
+        <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
      value. 
         <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
      the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>. 
@@ -3895,7 +3895,7 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
        </ol>
       <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
       <li>If <var>node</var> is null or is <a data-link-type="dfn" href="#concept-traversal-root">root</a>, return null. 
-      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and if the return value is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then
+      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and if the return value is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then
    return null. 
       <li>Run these substeps again. 
      </ol>
@@ -3913,9 +3913,9 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
         While <var>sibling</var> is not null, run these subsubsteps: 
        <ol>
         <li>Set <var>node</var> to <var>sibling</var>. 
-        <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and let <var>result</var> be the return
+        <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
      value. 
-        <li>While <var>result</var> is not <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_reject">FILTER_REJECT</a></code> and <var>node</var> has a <a data-link-type="dfn" href="#concept-tree-child">child</a>, set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> and then <a data-link-type="dfn" href="#concept-node-filter">filter</a><var>node</var> and
+        <li>While <var>result</var> is not <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_reject">FILTER_REJECT</a></code> and <var>node</var> has a <a data-link-type="dfn" href="#concept-tree-child">child</a>, set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> and then <a data-link-type="dfn" href="#concept-node-filter">filter</a> <var>node</var> and
      set <var>result</var> to the return value. 
         <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
      the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>. 
@@ -3923,7 +3923,7 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
        </ol>
       <li>If <var>node</var> is <a data-link-type="dfn" href="#concept-traversal-root">root</a> or <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, return null. 
       <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and if the return value is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
+      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and if the return value is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
    the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute
    to <var>node</var> and return <var>node</var>. 
      </ol>
@@ -3941,15 +3941,15 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
     run these subsubsteps: 
        <ol>
         <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. 
-        <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and set <var>result</var> to the return
+        <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and set <var>result</var> to the return
      value. 
         <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
      the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute
      to <var>node</var> and return <var>node</var>. 
        </ol>
-      <li> If a <a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a><var>node</var> and is not <a data-link-type="dfn" href="#concept-tree-following">following</a><a data-link-type="dfn" href="#concept-traversal-root">root</a>, set <var>node</var> to the first such <a data-link-type="dfn" href="#concept-node">node</a>.
+      <li> If a <a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node</var> and is not <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-traversal-root">root</a>, set <var>node</var> to the first such <a data-link-type="dfn" href="#concept-node">node</a>.
     Otherwise, return null. 
-      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a><var>node</var> and set <var>result</var> to the return
+      <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and set <var>result</var> to the return
    value. 
       <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
    the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute
@@ -4027,28 +4027,28 @@ constants for the <a data-link-type="dfn" href="#concept-traversal-whatToShow">w
  of running the <a data-link-type="dfn" href="#concept-ordered-set-serializer">ordered set serializer</a> for <a data-link-type="dfn" href="#concept-DTL-tokens">tokens</a>. 
    </ol>
    <dl class="domintro">
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-length">length</a></code></code>
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-length">length</a></code></code> 
     <dd>Returns the number of tokens. 
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-item">item(index)</a></code></code>
-    <dt><code><var>tokenlist</var>[<var>index</var>]</code>
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-item">item(index)</a></code></code> 
+    <dt><code><var>tokenlist</var>[<var>index</var>]</code> 
     <dd>Returns the token with index <var>index</var>. 
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-contains">contains(token)</a></code></code>
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-contains">contains(token)</a></code></code> 
     <dd> Returns true if <var>token</var> is present, and false otherwise.
   Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if <var>token</var> is the empty string.
   Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if <var>token</var> contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. 
-    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-add">add(<var>tokens</var>…)</a></code>
+    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-add">add(<var>tokens</var>…)</a></code> 
     <dd> Adds all arguments passed, except those already present.
   Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if one if the arguments
   is the empty string.
   Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if one of the
   arguments contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. 
-    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-remove">remove(<var>tokens</var>…)</a></code>
+    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-remove">remove(<var>tokens</var>…)</a></code> 
     <dd> Removes arguments passed, if they are present.
   Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if one if the arguments
   is the empty string.
   Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if one of the
   arguments contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. 
-    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-toggle">toggle(<var>token</var> [, <var>force</var>])</a></code>
+    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-toggle">toggle(<var>token</var> [, <var>force</var>])</a></code> 
     <dd> If <var>force</var> is not given, "toggles" <var>token</var>, removing it if it’s present and adding it if it’s
   not. If <var>force</var> is true, adds <var>token</var> (same as <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-add">add()</a></code>).
   If <var>force</var> is false, removes <var>token</var> (same as <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-remove">remove()</a></code>).
@@ -4114,7 +4114,7 @@ numbers in the range zero to the number of tokens in <a data-link-type="dfn" hre
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#domsettabletokenlist">DOMSettableTokenList</a></code> object is equivalent to a <code class="idl"><a data-link-type="idl" href="#domtokenlist">DOMTokenList</a></code> object without an associated <a data-link-type="dfn" href="#concept-attribute">attribute</a>.</p>
    <dl class="domintro">
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domsettabletokenlist-value">value</a></code></code>
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domsettabletokenlist-value">value</a></code></code> 
     <dd> Returns the associated set as string.
   Can be set, to change the associated set via a string. 
    </dl>
@@ -4157,75 +4157,75 @@ remove all the following features. The editors welcome any data showing that
 some of these features should be reintroduced. </p>
    <p>Interfaces:</p>
    <ul class="brief">
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="cdatasection"><code>CDATASection</code><a class="self-link" href="#cdatasection"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domconfiguration"><code>DOMConfiguration</code><a class="self-link" href="#domconfiguration"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerror"><code>DOMError</code><a class="self-link" href="#domerror"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerrorhandler"><code>DOMErrorHandler</code><a class="self-link" href="#domerrorhandler"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationlist"><code>DOMImplementationList</code><a class="self-link" href="#domimplementationlist"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationsource"><code>DOMImplementationSource</code><a class="self-link" href="#domimplementationsource"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domlocator"><code>DOMLocator</code><a class="self-link" href="#domlocator"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domobject"><code>DOMObject</code><a class="self-link" href="#domobject"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domstringlist"><code>DOMStringList</code><a class="self-link" href="#domstringlist"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domuserdata"><code>DOMUserData</code><a class="self-link" href="#domuserdata"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entity"><code>Entity</code><a class="self-link" href="#entity"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entityreference"><code>EntityReference</code><a class="self-link" href="#entityreference"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="namelist"><code>NameList</code><a class="self-link" href="#namelist"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="notation"><code>Notation</code><a class="self-link" href="#notation"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="typeinfo"><code>TypeInfo</code><a class="self-link" href="#typeinfo"></a></dfn>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="userdatahandler"><code>UserDataHandler</code><a class="self-link" href="#userdatahandler"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="cdatasection"><code>CDATASection</code><a class="self-link" href="#cdatasection"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domconfiguration"><code>DOMConfiguration</code><a class="self-link" href="#domconfiguration"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerror"><code>DOMError</code><a class="self-link" href="#domerror"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerrorhandler"><code>DOMErrorHandler</code><a class="self-link" href="#domerrorhandler"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationlist"><code>DOMImplementationList</code><a class="self-link" href="#domimplementationlist"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationsource"><code>DOMImplementationSource</code><a class="self-link" href="#domimplementationsource"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domlocator"><code>DOMLocator</code><a class="self-link" href="#domlocator"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domobject"><code>DOMObject</code><a class="self-link" href="#domobject"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domstringlist"><code>DOMStringList</code><a class="self-link" href="#domstringlist"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domuserdata"><code>DOMUserData</code><a class="self-link" href="#domuserdata"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entity"><code>Entity</code><a class="self-link" href="#entity"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entityreference"><code>EntityReference</code><a class="self-link" href="#entityreference"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="namelist"><code>NameList</code><a class="self-link" href="#namelist"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="notation"><code>Notation</code><a class="self-link" href="#notation"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="typeinfo"><code>TypeInfo</code><a class="self-link" href="#typeinfo"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="userdatahandler"><code>UserDataHandler</code><a class="self-link" href="#userdatahandler"></a></dfn> 
    </ul>
    <p>Interface members:</p>
    <dl>
-    <dt><code class="idl"><a data-link-type="idl" href="#node">Node</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> 
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-issupported">isSupported<a class="self-link" href="#dom-node-issupported"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getfeature">getFeature()<a class="self-link" href="#dom-node-getfeature"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getuserdata">getUserData()<a class="self-link" href="#dom-node-getuserdata"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-setuserdata">setUserData()<a class="self-link" href="#dom-node-setuserdata"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-issamenode">isSameNode()<a class="self-link" href="#dom-node-issamenode"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-issupported">isSupported<a class="self-link" href="#dom-node-issupported"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getfeature">getFeature()<a class="self-link" href="#dom-node-getfeature"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getuserdata">getUserData()<a class="self-link" href="#dom-node-getuserdata"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-setuserdata">setUserData()<a class="self-link" href="#dom-node-setuserdata"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-issamenode">isSameNode()<a class="self-link" href="#dom-node-issamenode"></a></dfn> 
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcdatasection">createCDATASection()<a class="self-link" href="#dom-document-createcdatasection"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createentityreference">createEntityReference()<a class="self-link" href="#dom-document-createentityreference"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlencoding">xmlEncoding<a class="self-link" href="#dom-document-xmlencoding"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlstandalone">xmlStandalone<a class="self-link" href="#dom-document-xmlstandalone"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlversion">xmlVersion<a class="self-link" href="#dom-document-xmlversion"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-stricterrorchecking">strictErrorChecking<a class="self-link" href="#dom-document-stricterrorchecking"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-domconfig">domConfig<a class="self-link" href="#dom-document-domconfig"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-normalizedocument">normalizeDocument()<a class="self-link" href="#dom-document-normalizedocument"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-renamenode">renameNode()<a class="self-link" href="#dom-document-renamenode"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcdatasection">createCDATASection()<a class="self-link" href="#dom-document-createcdatasection"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createentityreference">createEntityReference()<a class="self-link" href="#dom-document-createentityreference"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlencoding">xmlEncoding<a class="self-link" href="#dom-document-xmlencoding"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlstandalone">xmlStandalone<a class="self-link" href="#dom-document-xmlstandalone"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlversion">xmlVersion<a class="self-link" href="#dom-document-xmlversion"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-stricterrorchecking">strictErrorChecking<a class="self-link" href="#dom-document-stricterrorchecking"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-domconfig">domConfig<a class="self-link" href="#dom-document-domconfig"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-normalizedocument">normalizeDocument()<a class="self-link" href="#dom-document-normalizedocument"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-renamenode">renameNode()<a class="self-link" href="#dom-document-renamenode"></a></dfn> 
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code> 
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-getfeature">getFeature()<a class="self-link" href="#dom-domimplementation-getfeature"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-getfeature">getFeature()<a class="self-link" href="#dom-domimplementation-getfeature"></a></dfn> 
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
     <dd> No longer inherits from <code class="idl"><a data-link-type="idl" href="#node">Node</a></code> and therefore completely
   changed. 
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export="" id="dom-element-schematypeinfo">schemaTypeInfo<a class="self-link" href="#dom-element-schematypeinfo"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattribute">setIdAttribute()<a class="self-link" href="#dom-element-setidattribute"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributens">setIdAttributeNS()<a class="self-link" href="#dom-element-setidattributens"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributenode">setIdAttributeNode()<a class="self-link" href="#dom-element-setidattributenode"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export="" id="dom-element-schematypeinfo">schemaTypeInfo<a class="self-link" href="#dom-element-schematypeinfo"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattribute">setIdAttribute()<a class="self-link" href="#dom-element-setidattribute"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributens">setIdAttributeNS()<a class="self-link" href="#dom-element-setidattributens"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributenode">setIdAttributeNode()<a class="self-link" href="#dom-element-setidattributenode"></a></dfn> 
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-entities">entities<a class="self-link" href="#dom-documenttype-entities"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-notations">notations<a class="self-link" href="#dom-documenttype-notations"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-internalsubset">internalSubset<a class="self-link" href="#dom-documenttype-internalsubset"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-entities">entities<a class="self-link" href="#dom-documenttype-entities"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-notations">notations<a class="self-link" href="#dom-documenttype-notations"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-internalsubset">internalSubset<a class="self-link" href="#dom-documenttype-internalsubset"></a></dfn> 
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="attribute" data-export="" id="dom-text-iselementcontentwhitespace">isElementContentWhitespace<a class="self-link" href="#dom-text-iselementcontentwhitespace"></a></dfn>
-      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="method" data-export="" id="dom-text-replacewholetext">replaceWholeText()<a class="self-link" href="#dom-text-replacewholetext"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="attribute" data-export="" id="dom-text-iselementcontentwhitespace">isElementContentWhitespace<a class="self-link" href="#dom-text-iselementcontentwhitespace"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="method" data-export="" id="dom-text-replacewholetext">replaceWholeText()<a class="self-link" href="#dom-text-replacewholetext"></a></dfn> 
      </ul>
    </dl>
    <h3 class="heading settled" data-level="8.3" id="dom-ranges-changes"><span class="secno">8.3. </span><span class="content">DOM Ranges</span><a class="self-link" href="#dom-ranges-changes"></a></h3>
@@ -4356,7 +4356,7 @@ and Ms2ger (<a href="//www.mozilla.org/">Mozilla</a>, <a href="mailto:ms2ger@gma
    <p>Per <a href="//creativecommons.org/publicdomain/zero/1.0/" rel="license">CC0</a>, to
 the extent possible under law, the editors have waived all copyright and related or
 neighboring rights to this work.</p>
-   <script id="head" src="//resources.whatwg.org/dfn.js"></script>
+<script id="head" src="//resources.whatwg.org/dfn.js"></script>
   </main>
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
@@ -5383,7 +5383,7 @@ namespace and local name localName</a><span>, in §4.4</span>
    <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-webidl"><a class="self-link" href="#biblio-webidl"></a>[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky. <a href="https://heycam.github.io/webidl/">WebIDL Level 1</a>. 4 August 2015. WD. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Cameron McCormack. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 19 April 2012. CR. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
    <dt id="biblio-cssom-view"><a class="self-link" href="#biblio-cssom-view"></a>[CSSOM-VIEW]
    <dd>Simon Pieters; Glenn Adams. <a href="http://dev.w3.org/csswg/cssom-view/">CSSOM View Module</a>. 17 December 2013. WD. URL: <a href="http://dev.w3.org/csswg/cssom-view/">http://dev.w3.org/csswg/cssom-view/</a>
    <dt id="biblio-encoding"><a class="self-link" href="#biblio-encoding"></a>[ENCODING]


### PR DESCRIPTION
When adopting a <template>'s template contents and running its own adopting steps as defined in HTML, if the adopting steps aren't recursively, any nested template won't see its template contents' owner document changed.