### PR TITLE
Make two loops to adopt a node

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4633,16 +4633,13 @@ a <var>document</var>, run these steps:
  <li><p>If <var>node</var>'s <a>parent</a> is not null, <a>remove</a> <var>node</var> from its
  <a>parent</a>.
 
- <li>
-  <p>For each <var>descendant</var> in <var>node</var>'s <a>inclusive descendants</a>, in
-  <a>tree order</a>, run these substeps:
+ <li><p>For each <var>descendant</var> in <var>node</var>'s <a>inclusive descendants</a>, in
+ <a>tree order</a>, set <var>descendant</var>'s <a>node document</a> to <var>document</var>.
+ <!--AttrExodus as well as any associated {{Attr}} nodes-->
 
-  <ol>
-   <li><p>Set <var>descendant</var>'s <a>node document</a> to <var>document</var>.
-   <!--AttrExodus as well as any associated {{Attr}} nodes-->
-
-   <li><p>Run the <a>adopting steps</a> with <var>descendant</var> and <var>oldDocument</var>.
-  </ol>
+ <li><p>For each <var>descendant</var> in <var>node</var>'s <a>inclusive descendants</a>, in
+ <a>tree order</a>, run the <a>adopting steps</a> with <var>descendant</var> and
+ <var>oldDocument</var>.
 </ol>
 
 The

--- a/dom.html
+++ b/dom.html
@@ -2420,13 +2420,9 @@ a <var>document</var>, run these steps:</p>
     <li>
      <p>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. </p>
     <li>
-     <p>For each <var>descendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendants</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run these substeps: </p>
-     <ol>
-      <li>
-       <p>Set <var>descendant</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. </p>
-      <li>
-       <p>Run the <a data-link-type="dfn" href="#concept-node-adopt-ext">adopting steps</a> with <var>descendant</var> and <var>oldDocument</var>. </p>
-     </ol>
+     <p>For each <var>descendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendants</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, set <var>descendant</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. </p>
+    <li>
+     <p>For each <var>descendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendants</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run the <a data-link-type="dfn" href="#concept-node-adopt-ext">adopting steps</a> with <var>descendant</var> and <var>oldDocument</var>. </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-adoptnode">adoptNode(<var>node</var>)<a class="self-link" href="#dom-document-adoptnode"></a></dfn> method must run these steps:</p>
    <ol>


### PR DESCRIPTION
@Ms2ger pointed out to me that the fix introduced in #66 is less than perfect, because the unsuspecting loop over node's inclusive descendants mean running their adopting steps in a tree of which nodes are owned by two different documents.