### PR TITLE
Use Boilerplate: omit feedback-header to remove redundant GitHub link

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -12,7 +12,7 @@ No Editor: true
 Logo: https://resources.whatwg.org/logo-dom.svg
 Abstract: DOM defines a platform-neutral model for events and node trees.
 Ignored Terms: EmptyString, Array, Elements, Document
-Boilerplate: omit conformance
+Boilerplate: omit conformance, omit feedback-header
 </pre>
 
 <!--

--- a/dom.html
+++ b/dom.html
@@ -69,7 +69,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-09-16">16 September 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-09-17">17 September 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:


### PR DESCRIPTION
This makes the output when running bikeshed locally match the current
dom.html output.