### PR TITLE
Add some manual dfns to Elements. Fixes #96.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -11,7 +11,7 @@ No Editor: true
 !Commits: <a href=https://twitter.com/thedomstandard>@thedomstandard</a>
 Logo: https://resources.whatwg.org/logo-dom.svg
 Abstract: DOM defines a platform-neutral model for events and node trees.
-Ignored Terms: EmptyString, Array, Elements, Document
+Ignored Terms: EmptyString, Array, Document
 Ignored Vars: p, documentFragment, ev, oldParent, em, processingInstruction, obj, tree, removedNode, C, *, intersects, collapsed
 Boilerplate: omit conformance, omit feedback-header
 </pre>
@@ -1803,7 +1803,7 @@ steps:
 
 <p class="note no-backref">The
 {{NonElementParentNode/getElementById()}} method is not
-on <a>elements</a> for compatibility with older versions of
+on <a for="/">elements</a> for compatibility with older versions of
 jQuery. If a time comes where that version of jQuery has disappeared, we might be able to
 support it.
 
@@ -1879,7 +1879,7 @@ Element implements ParentNode;
 
 <dl class=domintro>
  <dt><code><var>collection</var> = <var>node</var> . {{ParentNode/children}}</code>
- <dd>Returns the <a>child</a> <a>elements</a>.
+ <dd>Returns the <a>child</a> <a for="/">elements</a>.
 
  <dt><code><var>element</var> = <var>node</var> . {{ParentNode/firstElementChild}}</code>
  <dd>Returns the first <a>child</a> that is an <a for="/">element</a>, and null otherwise.
@@ -1957,7 +1957,7 @@ that is an <a for="/">element</a>, and null otherwise.
 
 The
 <dfn attribute for=ParentNode>childElementCount</dfn>
-attribute must return the number of <a>children</a> of the <a>context object</a> that are <a>elements</a>.
+attribute must return the number of <a>children</a> of the <a>context object</a> that are <a for="/">elements</a>.
 
 The
 <dfn method for=ParentNode>prepend(<var>nodes</var>)</dfn>
@@ -2172,9 +2172,9 @@ these steps:
 <h4 id=element-collections>Collections: {{Elements}}</h4>
 
 <pre class='idl' data-no-idl>
-class Elements extends Array {
-  Element? query(DOMString relativeSelectors);
-  Elements queryAll(DOMString relativeSelectors);
+class <dfn interface>Elements</dfn> extends Array {
+  Element? <dfn method for=Elements lt="query(DOMString relativeSelectors)">query</dfn>(DOMString relativeSelectors);
+  Elements <dfn method for=Elements lt="queryAll(DOMString relativeSelectors)">queryAll</dfn>(DOMString relativeSelectors);
 };
 </pre>
 
@@ -2184,7 +2184,7 @@ Array subclassing</a> and <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?i
 
 {{Elements}} is a subclass of {{Array}} with two additional methods. It replaces the need
 for {{HTMLCollection}} and {{NodeList}}. (If <a>nodes</a> need to be represented rather
-than <a>elements</a> a simple {{Array}} can be used.)
+than <a for="/">elements</a> a simple {{Array}} can be used.)
 </div>
 
 <dl class=domintro>
@@ -2300,16 +2300,16 @@ interface HTMLCollection {
 
 An {{HTMLCollection}} object is a
 <a>collection</a> of
-<a>elements</a>.
+<a for="/">elements</a>.
 
 <p class="note no-backref">{{Elements}} is the better solution for representing a
-<a>collection</a> of <a>elements</a>. {{HTMLCollection}} is an historical artifact we
+<a>collection</a> of <a for="/">elements</a>. {{HTMLCollection}} is an historical artifact we
 cannot rid the web of.
 
 <dl class=domintro>
  <dt><var>collection</var> . {{HTMLCollection/length}}
  <dd>
-  Returns the number of <a>elements</a> in
+  Returns the number of <a for="/">elements</a> in
   the <a>collection</a>.
 
  <dt><var>element</var> = <var>collection</var> . {{HTMLCollection/item(index)}}
@@ -2317,7 +2317,7 @@ cannot rid the web of.
  <dd>
   Returns the <a for="/">element</a> with index
   <var>index</var> from the <a>collection</a>.
-  The <a>elements</a> are sorted in <a>tree order</a>.
+  The <a for="/">elements</a> are sorted in <a>tree order</a>.
 
  <dt><var>element</var> = <var>collection</var> . {{namedItem(name)}}
  <dt><var>element</var> = <var>collection</var>[<var>name</var>]
@@ -3881,7 +3881,7 @@ for a <a>node</a> <var>root</var> is the
 <ol>
  <li>If <var>localName</var> is "<code>*</code>" (U+002A),
  return a {{HTMLCollection}} rooted at <var>root</var>,
- whose filter matches only <a>elements</a>.
+ whose filter matches only <a for="/">elements</a>.
 
  <li>
   Otherwise, if <var>root</var>'s
@@ -3889,7 +3889,7 @@ for a <a>node</a> <var>root</var> is the
   <a>HTML document</a>, return a {{HTMLCollection}} rooted at
   <var>root</var>, whose filter matches the following
   <a>descendant</a>
-  <a>elements</a>:
+  <a for="/">elements</a>:
 
   <ul>
    <li>Whose <a for=Element>namespace</a> is the
@@ -3906,7 +3906,7 @@ for a <a>node</a> <var>root</var> is the
  <li>Otherwise, return a {{HTMLCollection}} rooted at
  <var>root</var>, whose filter matches
  <a>descendant</a>
- <a>elements</a> whose
+ <a for="/">elements</a> whose
  <a for=Element>local name</a> is
  <var>localName</var>.
 </ol>
@@ -3929,13 +3929,13 @@ for a <a>node</a> <var>root</var> is the
  are "<code>*</code>" (U+002A), return a {{HTMLCollection}} rooted at
  <var>root</var>, whose filter matches
  <a>descendant</a>
- <a>elements</a>.
+ <a for="/">elements</a>.
 
  <li>Otherwise, if <var>namespace</var> is "<code>*</code>"
  (U+002A), return a {{HTMLCollection}} rooted at
  <var>root</var>, whose filter matches
  <a>descendant</a>
- <a>elements</a> whose
+ <a for="/">elements</a> whose
  <a for=Element>local name</a> is
  <var>localName</var>.
 
@@ -3943,14 +3943,14 @@ for a <a>node</a> <var>root</var> is the
  (U+002A), return a {{HTMLCollection}} rooted at
  <var>root</var>, whose filter matches
  <a>descendant</a>
- <a>elements</a> whose
+ <a for="/">elements</a> whose
  <a for=Element>namespace</a> is
  <var>namespace</var>.
 
  <li>Otherwise, return a {{HTMLCollection}} rooted at
  <var>root</var>, whose filter matches
  <a>descendant</a>
- <a>elements</a> whose
+ <a for="/">elements</a> whose
  <a for=Element>namespace</a> is
  <var>namespace</var> and
  <a for=Element>local name</a> is
@@ -3978,7 +3978,7 @@ for a <a>node</a> <var>root</var> is the
  <li>
   Return a {{HTMLCollection}} rooted at <var>root</var>,
   whose filter matches <a>descendant</a>
-  <a>elements</a> that have all their
+  <a for="/">elements</a> that have all their
   <a>classes</a> in <var>classes</var>.
 
   The comparisons for the <a>classes</a> must be done in an <a>ASCII case-insensitive</a>
@@ -4275,14 +4275,14 @@ attribute must return the
   If <var>localName</var> is "<code>*</code>" returns a
   {{HTMLCollection}} of all
   <a>descendant</a>
-  <a>elements</a>.
+  <a for="/">elements</a>.
 
   Otherwise, returns a {{HTMLCollection}} of all
   <a>descendant</a>
-  <a>elements</a> whose
+  <a for="/">elements</a> whose
   <a for=Element>local name</a> is
   <var>localName</var>. (Matches case-insensitively against
-  <a>elements</a> in the
+  <a for="/">elements</a> in the
   <a>HTML namespace</a> within an <a>HTML document</a>.)
 
  <dt><var>collection</var> = <var>document</var> . {{Document/getElementsByTagNameNS(namespace, localName)}}</code>
@@ -4291,25 +4291,25 @@ attribute must return the
   If <var>namespace</var> and <var>localName</var> are
   "<code>*</code>" returns a {{HTMLCollection}} of all
   <a>descendant</a>
-  <a>elements</a>.
+  <a for="/">elements</a>.
 
   If only <var>namespace</var> is "<code>*</code>" returns a
   {{HTMLCollection}} of all
   <a>descendant</a>
-  <a>elements</a> whose
+  <a for="/">elements</a> whose
   <a for=Element>local name</a> is
   <var>localName</var>.
 
   If only <var>localName</var> is "<code>*</code>" returns a
   {{HTMLCollection}} of all
   <a>descendant</a>
-  <a>elements</a> whose
+  <a for="/">elements</a> whose
   <a for=Element>namespace</a> is
   <var>namespace</var>.
 
   Otherwise, returns a {{HTMLCollection}} of all
   <a>descendant</a>
-  <a>elements</a> whose
+  <a for="/">elements</a> whose
   <a for=Element>namespace</a> is
   <var>namespace</var> and
   <a for=Element>local name</a> is
@@ -4319,7 +4319,7 @@ attribute must return the
  <dt><var>collection</var> = <var>element</var> . {{Element/getElementsByClassName(classNames)}}</code>
  <dd>
   Returns a {{HTMLCollection}} of the
-  <a>elements</a> in the object on which
+  <a for="/">elements</a> in the object on which
   the method was invoked (a <a>document</a> or
   an <a for="/">element</a>) that have all the classes
   given by <var>classNames</var>.
@@ -5110,7 +5110,7 @@ interface Element : Node {
 {{Element}} <a>nodes</a> are simply
 known as <dfn export id=concept-element lt="element">elements</dfn>.
 
-<a>Elements</a> have an associated
+<a for="/">Elements</a> have an associated
 <dfn export id=concept-element-namespace for=Element>namespace</dfn>,
 <dfn export id=concept-element-namespace-prefix for=Element>namespace prefix</dfn>, and
 <dfn export id=concept-element-local-name for=Element>local name</dfn>. When an
@@ -5121,7 +5121,7 @@ is created, its <a for=Element>namespace</a> and
 <a for=Element>namespace prefix</a> are
 null.
 
-<a>Elements</a> also have an ordered
+<a for="/">Elements</a> also have an ordered
 <dfn export id=concept-element-attribute for=Element>attribute list</dfn> exposed through a
 {{NamedNodeMap}}. Unless explicitly given when an
 <a for="/">element</a> is created, its
@@ -5356,7 +5356,7 @@ given a <var>namespace</var>, <var>localName</var>, and
 An <a for=/>element</a> can have an associated
 <dfn export for=Element id=concept-id lt="ID">unique identifier (ID)</dfn>
 
-<p class=note>Historically <a>elements</a> could have multiple identifiers e.g. by using
+<p class=note>Historically <a for="/">elements</a> could have multiple identifiers e.g. by using
 the HTML <code>id</code> <a>attribute</a> and a DTD. This specification makes <a>ID</a> a
 concept of the DOM and allows for only one per <a for="/">element</a>, given by an
 <a lt="named attribute"><code>id</code> attribute</a>.
@@ -5718,7 +5718,7 @@ method, when invoked, must run these steps:
 
  <li>Let <var>elements</var> be <a>context object</a>'s
  <a>inclusive ancestors</a> that are
- <a>elements</a>, in reverse
+ <a for="/">elements</a>, in reverse
  <a>tree order</a>.
 
  <li>For each <var>element</var> in <var>elements</var>, if


### PR DESCRIPTION
* Add `<dfn>` to the Elements interface and its methods.
* Remove "Elements" from Ignored Terms.
* Fix unrelated linking errors that were accidentally masked by the Ignored Terms entry.