### PR TITLE
Do not remove child from its parent when replacing a node by itself

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1600,6 +1600,14 @@ steps:
  <var>node</var> into <var>parent</var>'s
  <a>node document</a>.
 
+ <li>Let <var>removedNodes</var> be the empty list.
+
+ <li>If <var>child</var>'s parent is not null, set <var>removedNodes</var> to a list
+  solely containing <var>child</var> and remove <var>child</var> from its <var>parent</var>
+  with the <i>suppress observers flag</i> set.
+
+  <p class="note no-backref">The above can only be false if <var>child</var> is <var>node</var>.
+
  <li><a>Remove</a> <var>child</var>
  from its <var>parent</var> with the
  <i>suppress observers flag</i> set.
@@ -1614,7 +1622,7 @@ steps:
  the <i>suppress observers flag</i> set.
 
  <li><a>Queue a mutation record</a> of "<code>childList</code>" for target
- <var>parent</var> with addedNodes <var>nodes</var>, removedNodes a list solely containing
+ <var>parent</var> with addedNodes <var>nodes</var>, removedNodes <var>removedNodes</var>
  <var>child</var>, nextSibling <var>reference child</var>, and previousSibling
  <var>previousSibling</var>.
 

--- a/dom.html
+++ b/dom.html
@@ -982,11 +982,16 @@ steps:</p>
     <li>
      <p>Let <var>previousSibling</var> be <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>. </p>
     <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
+    <li>Let <var>removedNodes</var> be the empty list. 
+    <li>
+     If <var>child</var>’s parent is not null, set <var>removedNodes</var> to a list
+  solely containing <var>child</var> and remove <var>child</var> from its <var>parent</var> with the <i>suppress observers flag</i> set. 
+     <p class="note no-backref" role="note">The above can only be false if <var>child</var> is <var>node</var>. </p>
     <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>child</var> from its <var>parent</var> with the <i>suppress observers flag</i> set. 
     <li>Let <var>nodes</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a list containing solely <var>node</var> otherwise. 
     <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var> with
  the <i>suppress observers flag</i> set. 
-    <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>childList</code>" for target <var>parent</var> with addedNodes <var>nodes</var>, removedNodes a list solely containing <var>child</var>, nextSibling <var>reference child</var>, and previousSibling <var>previousSibling</var>. 
+    <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>childList</code>" for target <var>parent</var> with addedNodes <var>nodes</var>, removedNodes <var>removedNodes</var> <var>child</var>, nextSibling <var>reference child</var>, and previousSibling <var>previousSibling</var>. 
     <li>Return <var>child</var>. 
    </ol>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-replace-all">replace all<a class="self-link" href="#concept-node-replace-all"></a></dfn> with a <var>node</var> within a <var>parent</var>, run these steps:</p>


### PR DESCRIPTION
If the replacing node is the replaced child, the node doesn't need and
shouldn't be adopted into the parent's document because it removes it from
the parent, which is already done in the very next step.

The adoption step is made conditional and not the removing one to not
artificially increase the number of mutation records being queued during
the replacing as a whole.