### PR TITLE
Fix queuing of mutation records when removing a node from its parent

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1725,6 +1725,8 @@ steps:
  <li>Let <var>oldPreviousSibling</var> be <var>node</var>'s
  <a>previous sibling</a>
 
+ <li>Let <var>oldNextSibling</var> be <var>node</var>'s <a>next sibling</a>.
+
  <li>Remove <var>node</var> from its <var>parent</var>.
 
  <li>Run the <a>removing steps</a> with
@@ -1742,7 +1744,7 @@ steps:
  <li>If <i>suppress observers flag</i> is unset,
  <a>queue a mutation record</a> of "<code>childList</code>" for
  <var>parent</var> with removedNodes a list solely containing <var>node</var>,
- nextSibling <var>node</var>'s <a>next sibling</a>, and previousSibling
+ nextSibling <var>oldNextSibling</var>, and previousSibling
  <var>oldPreviousSibling</var>.
 </ol>
 

--- a/dom.html
+++ b/dom.html
@@ -69,7 +69,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-11-25">25 November 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-11-27">27 November 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:
@@ -1021,12 +1021,13 @@ steps:</p>
     <li>
      <p>For each <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object <var>iterator</var> whose <a data-link-type="dfn" href="#concept-traversal-root">root</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>, run the <a data-link-type="dfn" href="#nodeiterator-pre-removing-steps"><code>NodeIterator</code> pre-removing steps</a> given <var>node</var> and <var>iterator</var>. </p>
     <li>Let <var>oldPreviousSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> 
+    <li>Let <var>oldNextSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
     <li>Remove <var>node</var> from its <var>parent</var>. 
     <li>Run the <a data-link-type="dfn" href="#concept-node-remove-ext">removing steps</a> with <var>node</var>, <var>parent</var>, and <var>oldPreviousSibling</var>. 
     <li>For each <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> <var>ancestor</var> of <var>parent</var>, if <var>ancestor</var> has any <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>options</b>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> is true, then for each
  such <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var>, append a <a data-link-type="dfn" href="#transient-registered-observer">transient registered observer</a> whose <b>observer</b> and <b>options</b> are identical to those of <var>registered</var> and <b>source</b> which is <var>registered</var> to <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>. 
     <li>If <i>suppress observers flag</i> is unset, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with removedNodes a list solely containing <var>node</var>,
- nextSibling <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>, and previousSibling <var>oldPreviousSibling</var>. 
+ nextSibling <var>oldNextSibling</var>, and previousSibling <var>oldPreviousSibling</var>. 
    </ol>
    <h4 class="heading settled" data-level="4.2.2" id="interface-nonelementparentnode"><span class="secno">4.2.2. </span><span class="content">Interface <code>NonElementParentNode</code></span><a class="self-link" href="#interface-nonelementparentnode"></a></h4>
    <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="#dom-nonelementparentnode-getelementbyid">getElementById()</a></code> method is not


### PR DESCRIPTION
The old next sibling of the node needs to be stored somewhere before removing
the node from its parent.