### PR TITLE
Remove feature detection from add() and add supports()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -8531,10 +8531,11 @@ interface DOMTokenList {
   readonly attribute unsigned long length;
   getter DOMString? item(unsigned long index);
   boolean contains(DOMString token);
-  boolean add(DOMString... tokens);
+  void add(DOMString... tokens);
   void remove(DOMString... tokens);
   boolean toggle(DOMString token, optional boolean force);
   void replace(DOMString token, DOMString newToken);
+  boolean supports(DOMString token);
   stringifier;
   iterable&lt;DOMString>;
 };
@@ -8556,7 +8557,7 @@ associated <a>attribute</a>'s <a for=Attr>local name</a>.
 
 <ol>
  <li><p>If the associated <a>attribute</a>'s <a for=Attr>local name</a> does not define
- <a>supported tokens</a>, return true.
+ <a>supported tokens</a>, <a>throw</a> a <code>TypeError</code>.
 
  <li><p>Let <var>lowercase token</var> be a copy of <var>token</var>,
  <a>converted to ASCII lowercase</a>.
@@ -8591,16 +8592,8 @@ are to:
 <a lt="named attribute"><var>associated attribute's local name</var> attribute</a> or
 associated <a for="/">element</a>'s
 <a lt="named attribute"><var>associated attribute's local name</var> attribute</a> is
-<a lt="attribute is set">set</a>, run these substeps:
-
-<ol>
- <li><p>Let <var>temporary tokens</var> be the new <a for=Attr>value</a>,
- <a lt="ordered set parser">parsed</a>.
-
- <li><p>For each <var>token</var> in <var>temporary tokens</var>, run
- <a>validation steps</a> with <var>token</var>. If the return value is true, append <var>token</var>
- to <a>tokens</a>.
-</ol>
+<a lt="attribute is set">set</a>, set <a>tokens</a> to the new <a for=Attr>value</a>,
+<a lt="ordered set parser">parsed</a>.
 
 <p>When an associated <a for="/">element</a>'s
 <a lt="named attribute"><var>associated attribute's local name</var> attribute</a> is
@@ -8623,11 +8616,10 @@ associated <a for="/">element</a>'s
 
  <dt><code><var>tokenlist</var> . <a for=DOMTokenList lt="add()">add(<var>tokens</var>&hellip;)</a></code>
  <dd>
-  <p>Adds all valid arguments passed, except those already present.
+  <p>Adds all arguments passed, except those already present.
   <p>Throws a {{SyntaxError}} exception if one if the arguments is the empty string.
   <p>Throws an {{InvalidCharacterError}} exception if one of the arguments contains any
   <a>ASCII whitespace</a>.
-  <p>Returns false if any invalid arguments passed, true otherwise.
 
  <dt><code><var>tokenlist</var> . <a for=DOMTokenList lt="remove()">remove(<var>tokens</var>&hellip;)</a></code>
  <dd>
@@ -8639,8 +8631,8 @@ associated <a for="/">element</a>'s
  <dt><code><var>tokenlist</var> . <a method for=DOMTokenList lt="toggle()">toggle(<var>token</var> [, <var>force</var>])</a></code>
  <dd>
   <p>If <var>force</var> is not given, "toggles" <var>token</var>, removing it if it's present and
-  adding it if it's not present and is valid. If <var>force</var> is true, adds <var>token</var>
-  if it is valid (same as {{add()}}). If <var>force</var> is false, removes <var>token</var> (same
+  adding it if it's not present. If <var>force</var> is true, adds <var>token</var>
+  (same as {{add()}}). If <var>force</var> is false, removes <var>token</var> (same
   as {{DOMTokenList/remove()}}).
   <p>Returns true if <var>token</var> is now present, and false otherwise.
   <p>Throws a {{SyntaxError}} exception if <var>token</var> is empty.
@@ -8652,6 +8644,12 @@ associated <a for="/">element</a>'s
   <p>Throws a {{SyntaxError}} exception if one if the arguments is the empty string.
   <p>Throws an {{InvalidCharacterError}} exception if one of the arguments contains any
   <a>ASCII whitespace</a>.
+
+ <dt><code><var>tokenlist</var> . <a method for=DOMTokenList lt="supports()">supports(<var>token</var>)</a></code>
+ <dd>
+  <p>Returns true if <var>token</var> is in the associated attribute's supported tokens. Returns
+  false otherwise.
+  <p>Throws a <code>TypeError</code> exception if the associated attribute has no supported tokens defined.
 </dl>
 
 <p>The <dfn attribute for=DOMTokenList><code>length</code></dfn> attribute' getter must return the
@@ -8698,15 +8696,10 @@ method, when invoked, must run these steps:
    {{InvalidCharacterError}} exception.
   </ol>
 
- <li>Let <var>valid</var> be true.
-
  <li><p>For each <var>token</var> in <var>tokens</var>, in given order, that is not in
- <a>tokens</a>, run <a>validation steps</a> with <var>token</var>. If the return value is false,
- set <var>valid</var> to false. Otherwise, append <var>token</var> to <a>tokens</a>.
+ <a>tokens</a>, append <var>token</var> to <a>tokens</a>.
 
  <li><p>Run the <a>update steps</a>.
-
- <li><p>Return <var>valid</var>.
 </ol>
 
 <p>The
@@ -8754,9 +8747,6 @@ method, when invoked, must run these steps:
   <ol>
    <li><p>If <var>force</var> is passed and is false, return false.
 
-   <li><p>Otherwise, run <a>validation steps</a> with <var>token</var>. If the return value is
-   false, return false.
-
    <li><p>Otherwise, append <var>token</var> to <a>tokens</a>, run the <a>update steps</a>, and
    return true.
   </ol>
@@ -8774,12 +8764,22 @@ method, when invoked, must run these steps:
  <li><p>If either <var>token</var> or <var>newToken</var> contains any <a>ASCII whitespace</a>,
  <a>throw</a> an {{InvalidCharacterError}} exception.
 
- <li><p>If <var>token</var> is not in <a>tokens</a> or running the <a>validation steps</a> for
- <var>newToken</var> return false, terminate these steps.
+ <li><p>If <var>token</var> is not in <a>tokens</a>, terminate these steps.
 
  <li><p>Replace <var>token</var> in <a>tokens</a> with <var>newToken</var>.
 
  <li><p>Run the <a>update steps</a>.
+</ol>
+
+<p>The
+<dfn method for="DOMTokenList" lt="supports(token)"><code>supports(<var>token</var>&hellip;)</code></dfn>
+method, when invoked, must run these steps:
+
+<ol>
+ <li><p>Let <var>result</var> be the return value of <a>validation steps</a> called with
+ <var>token</var>. Rethrow any exceptions.
+
+ <li><p>Return <var>result</var>.
 </ol>
 
 <p>The <dfn export for=DOMTokenList id=dom-domtokenlist-stringifier>stringification behavior</dfn>

--- a/dom.html
+++ b/dom.html
@@ -69,7 +69,7 @@
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-12-10">10 December 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2015-12-11">11 December 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>Participate:
@@ -1481,15 +1481,15 @@ append it to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/mult
 of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> objects, and then return it.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MutationObserver" data-dfn-type="method" data-export="" id="dom-mutationobserver-observe">observe(<var>target</var>, <var>options</var>)<a class="self-link" href="#dom-mutationobserver-observe"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>If either <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
- and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is omitted, set <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> to true. 
-    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is present and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is omitted, set <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> to true. 
-    <li>If none of <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code> <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
-    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> is true
- and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
-    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
- and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
-    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is true and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+    <li>If either <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
+ and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is omitted, set <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> to true. 
+    <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is present and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is omitted, set <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> to true. 
+    <li>If none of <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code> <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+    <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> is true
+ and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+    <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
+ and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+    <li>If <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is true and <var>options</var>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
     <li>
       For each <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var> in <var>target</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>observer</b> is
   the <a data-link-type="dfn" href="#context-object">context object</a>: 
@@ -1514,15 +1514,15 @@ previousSibling <var>previousSibling</var>, and nextSibling <var>nextSibling</va
       Then, for each <var>node</var> in <var>nodes</var>, and
   then for each <var>registered observer</var> (with <var>registered observer</var>’s <b>options</b> as <var>options</var>) in <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>: 
      <ol>
-      <li>If <var>node</var> is not <var>target</var> and <var>options</var>’ <code>subtree</code> is false, continue. 
-      <li>If <var>type</var> is "<code>attributes</code>" and <var>options</var>’ <code>attributes</code> is not true, continue. 
-      <li>If <var>type</var> is "<code>attributes</code>", <var>options</var>’ <code>attributeFilter</code> is present, and either <var>options</var>’ <code>attributeFilter</code> does not contain <var>name</var> or <var>namespace</var> is non-null, continue. 
-      <li>If <var>type</var> is "<code>characterData</code>" and <var>options</var>’ <code>characterData</code> is not true, continue. 
-      <li>If <var>type</var> is "<code>childList</code>" and <var>options</var>’ <code>childList</code> is false, continue. 
+      <li>If <var>node</var> is not <var>target</var> and <var>options</var>' <code>subtree</code> is false, continue. 
+      <li>If <var>type</var> is "<code>attributes</code>" and <var>options</var>' <code>attributes</code> is not true, continue. 
+      <li>If <var>type</var> is "<code>attributes</code>", <var>options</var>' <code>attributeFilter</code> is present, and either <var>options</var>' <code>attributeFilter</code> does not contain <var>name</var> or <var>namespace</var> is non-null, continue. 
+      <li>If <var>type</var> is "<code>characterData</code>" and <var>options</var>' <code>characterData</code> is not true, continue. 
+      <li>If <var>type</var> is "<code>childList</code>" and <var>options</var>' <code>childList</code> is false, continue. 
       <li>If <var>registered observer</var>’s <b>observer</b> is
    not in <var>interested observers</var>, append <var>registered observer</var>’s <b>observer</b> to <var>interested observers</var>. 
       <li>If either <var>type</var> is "<code>attributes</code>"
-   and <var>options</var>’ <code>attributeOldValue</code> is true, or <var>type</var> is "<code>characterData</code>" and <var>options</var>’ <code>characterDataOldValue</code> is true,
+   and <var>options</var>' <code>attributeOldValue</code> is true, or <var>type</var> is "<code>characterData</code>" and <var>options</var>' <code>characterDataOldValue</code> is true,
    set the paired string of <var>registered observer</var>’s <b>observer</b> in <var>interested observers</var> to <var>oldValue</var>. 
      </ol>
     <li>
@@ -4074,10 +4074,11 @@ constants for the <a data-link-type="dfn" href="#concept-traversal-whattoshow">w
   readonly attribute unsigned long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long " href="#dom-domtokenlist-length">length</a>;
   getter DOMString? <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-item">item</a>(unsigned long <dfn class="idl-code" data-dfn-for="DOMTokenList/item(index)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-item-index-index">index<a class="self-link" href="#dom-domtokenlist-item-index-index"></a></dfn>);
   boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-contains">contains</a>(DOMString <dfn class="idl-code" data-dfn-for="DOMTokenList/contains(token)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-contains-token-token">token<a class="self-link" href="#dom-domtokenlist-contains-token-token"></a></dfn>);
-  boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-add">add</a>(DOMString... <dfn class="idl-code" data-dfn-for="DOMTokenList/add(tokens...), DOMTokenList/add(tokens)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-add-tokens-tokens">tokens<a class="self-link" href="#dom-domtokenlist-add-tokens-tokens"></a></dfn>);
+  void <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-add">add</a>(DOMString... <dfn class="idl-code" data-dfn-for="DOMTokenList/add(tokens...), DOMTokenList/add(tokens)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-add-tokens-tokens">tokens<a class="self-link" href="#dom-domtokenlist-add-tokens-tokens"></a></dfn>);
   void <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-remove">remove</a>(DOMString... <dfn class="idl-code" data-dfn-for="DOMTokenList/remove(tokens...), DOMTokenList/remove(tokens)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-remove-tokens-tokens">tokens<a class="self-link" href="#dom-domtokenlist-remove-tokens-tokens"></a></dfn>);
   boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-toggle">toggle</a>(DOMString <dfn class="idl-code" data-dfn-for="DOMTokenList/toggle(token, force), DOMTokenList/toggle(token)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-toggle-token-force-token">token<a class="self-link" href="#dom-domtokenlist-toggle-token-force-token"></a></dfn>, optional boolean <dfn class="idl-code" data-dfn-for="DOMTokenList/toggle(token, force), DOMTokenList/toggle(token)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-toggle-token-force-force">force<a class="self-link" href="#dom-domtokenlist-toggle-token-force-force"></a></dfn>);
   void <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-replace">replace</a>(DOMString <dfn class="idl-code" data-dfn-for="DOMTokenList/replace(token, newToken)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-replace-token-newtoken-token">token<a class="self-link" href="#dom-domtokenlist-replace-token-newtoken-token"></a></dfn>, DOMString <dfn class="idl-code" data-dfn-for="DOMTokenList/replace(token, newToken)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-replace-token-newtoken-newtoken">newToken<a class="self-link" href="#dom-domtokenlist-replace-token-newtoken-newtoken"></a></dfn>);
+  boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-supports">supports</a>(DOMString <dfn class="idl-code" data-dfn-for="DOMTokenList/supports(token)" data-dfn-type="argument" data-export="" id="dom-domtokenlist-supports-token-token">token<a class="self-link" href="#dom-domtokenlist-supports-token-token"></a></dfn>);
   <a data-link-type="dfn" href="#dom-domtokenlist-stringifier">stringifier</a>;
   iterable&lt;DOMString>;
 };
@@ -4089,7 +4090,7 @@ associated <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <
    <p>A <code class="idl"><a data-link-type="idl" href="#domtokenlist">DOMTokenList</a></code> object’s <dfn data-dfn-for="DOMString" data-dfn-type="dfn" data-export="" id="concept-domtokenlist-validation">validation steps<a class="self-link" href="#concept-domtokenlist-validation"></a></dfn> for a given <var>token</var> are: </p>
    <ol>
     <li>
-     <p>If the associated <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> does not define <a data-link-type="dfn" href="#concept-supported-tokens">supported tokens</a>, return true. </p>
+     <p>If the associated <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> does not define <a data-link-type="dfn" href="#concept-supported-tokens">supported tokens</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. </p>
     <li>
      <p>Let <var>lowercase token</var> be a copy of <var>token</var>, <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. </p>
     <li>
@@ -4110,13 +4111,7 @@ to <a data-link-type="dfn" href="#concept-element-attributes-set-value">set an a
    </ol>
    <hr>
    <p>When a <code class="idl"><a data-link-type="idl" href="#domtokenlist">DOMTokenList</a></code> object is created and its associated <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-named-attribute"><var>associated attribute’s local name</var> attribute</a> or
-associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-named-attribute"><var>associated attribute’s local name</var> attribute</a> is <a data-link-type="dfn" href="#attribute-is-set">set</a>, run these substeps: </p>
-   <ol>
-    <li>
-     <p>Let <var>temporary tokens</var> be the new <a data-link-type="dfn" href="#concept-attribute-value">value</a>, <a data-link-type="dfn" href="#concept-ordered-set-parser">parsed</a>. </p>
-    <li>
-     <p>For each <var>token</var> in <var>temporary tokens</var>, run <a data-link-type="dfn" href="#concept-domtokenlist-validation">validation steps</a> with <var>token</var>. If the return value is true, append <var>token</var> to <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>. </p>
-   </ol>
+associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-named-attribute"><var>associated attribute’s local name</var> attribute</a> is <a data-link-type="dfn" href="#attribute-is-set">set</a>, set <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a> to the new <a data-link-type="dfn" href="#concept-attribute-value">value</a>, <a data-link-type="dfn" href="#concept-ordered-set-parser">parsed</a>. </p>
    <p>When an associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-named-attribute"><var>associated attribute’s local name</var> attribute</a> is <a data-link-type="dfn" href="#attribute-is-removed">removed</a>, set <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a> to the empty set. </p>
    <dl class="domintro">
     <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-length">length</a></code></code> 
@@ -4133,10 +4128,9 @@ associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a da
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if <var>token</var> contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. </p>
     <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-add">add(<var>tokens</var>…)</a></code> 
     <dd>
-     <p>Adds all valid arguments passed, except those already present. </p>
+     <p>Adds all arguments passed, except those already present. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if one if the arguments is the empty string. </p>
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if one of the arguments contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. </p>
-     <p>Returns false if any invalid arguments passed, true otherwise. </p>
     <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-remove">remove(<var>tokens</var>…)</a></code> 
     <dd>
      <p>Removes arguments passed, if they are present. </p>
@@ -4145,7 +4139,7 @@ associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a da
     <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-toggle">toggle(<var>token</var> [, <var>force</var>])</a></code> 
     <dd>
      <p>If <var>force</var> is not given, "toggles" <var>token</var>, removing it if it’s present and
-  adding it if it’s not present and is valid. If <var>force</var> is true, adds <var>token</var> if it is valid (same as <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-add">add()</a></code>). If <var>force</var> is false, removes <var>token</var> (same
+  adding it if it’s not present. If <var>force</var> is true, adds <var>token</var> (same as <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-add">add()</a></code>). If <var>force</var> is false, removes <var>token</var> (same
   as <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-remove">remove()</a></code>). </p>
      <p>Returns true if <var>token</var> is now present, and false otherwise. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if <var>token</var> is empty. </p>
@@ -4155,6 +4149,11 @@ associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a da
      <p>Replaces <var>token</var> with <var>newToken</var>. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if one if the arguments is the empty string. </p>
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if one of the arguments contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. </p>
+    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-supports">supports(<var>token</var>)</a></code> 
+    <dd>
+     <p>Returns true if <var>token</var> is in the associated attribute’s supported tokens. Returns
+  false otherwise. </p>
+     <p>Throws a <code>TypeError</code> exception if the associated attribute has no supported tokens defined. </p>
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="DOMTokenList" data-dfn-type="attribute" data-export="" id="dom-domtokenlist-length"><code>length</code><a class="self-link" href="#dom-domtokenlist-length"></a></dfn> attribute' getter must return the
 number of tokens in the <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>. </p>
@@ -4189,14 +4188,10 @@ invoked, must run these steps: </p>
       <li>
        <p>If <var>token</var> contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. </p>
      </ol>
-    <li>Let <var>valid</var> be true. 
     <li>
-     <p>For each <var>token</var> in <var>tokens</var>, in given order, that is not in <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>, run <a data-link-type="dfn" href="#concept-domtokenlist-validation">validation steps</a> with <var>token</var>. If the return value is false,
- set <var>valid</var> to false. Otherwise, append <var>token</var> to <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>. </p>
+     <p>For each <var>token</var> in <var>tokens</var>, in given order, that is not in <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>, append <var>token</var> to <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>. </p>
     <li>
      <p>Run the <a data-link-type="dfn" href="#concept-dtl-update">update steps</a>. </p>
-    <li>
-     <p>Return <var>valid</var>. </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="DOMTokenList" data-dfn-type="method" data-export="" data-lt="remove(tokens)|remove()" id="dom-domtokenlist-remove"><code>remove(<var>tokens</var>…)</code><a class="self-link" href="#dom-domtokenlist-remove"></a></dfn> method, when invoked, must run these steps: </p>
    <ol>
@@ -4233,9 +4228,6 @@ invoked, must run these steps: </p>
       <li>
        <p>If <var>force</var> is passed and is false, return false. </p>
       <li>
-       <p>Otherwise, run <a data-link-type="dfn" href="#concept-domtokenlist-validation">validation steps</a> with <var>token</var>. If the return value is
-   false, return false. </p>
-      <li>
        <p>Otherwise, append <var>token</var> to <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>, run the <a data-link-type="dfn" href="#concept-dtl-update">update steps</a>, and
    return true. </p>
      </ol>
@@ -4247,11 +4239,18 @@ invoked, must run these steps: </p>
     <li>
      <p>If either <var>token</var> or <var>newToken</var> contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. </p>
     <li>
-     <p>If <var>token</var> is not in <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a> or running the <a data-link-type="dfn" href="#concept-domtokenlist-validation">validation steps</a> for <var>newToken</var> return false, terminate these steps. </p>
+     <p>If <var>token</var> is not in <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a>, terminate these steps. </p>
     <li>
      <p>Replace <var>token</var> in <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a> with <var>newToken</var>. </p>
     <li>
      <p>Run the <a data-link-type="dfn" href="#concept-dtl-update">update steps</a>. </p>
+   </ol>
+   <p>The <dfn class="idl-code" data-dfn-for="DOMTokenList" data-dfn-type="method" data-export="" data-lt="supports(token)" id="dom-domtokenlist-supports"><code>supports(<var>token</var>…)</code><a class="self-link" href="#dom-domtokenlist-supports"></a></dfn> method, when invoked, must run these steps: </p>
+   <ol>
+    <li>
+     <p>Let <var>result</var> be the return value of <a data-link-type="dfn" href="#concept-domtokenlist-validation">validation steps</a> called with <var>token</var>. Rethrow any exceptions. </p>
+    <li>
+     <p>Return <var>result</var>. </p>
    </ol>
    <p>The <dfn data-dfn-for="DOMTokenList" data-dfn-type="dfn" data-export="" id="dom-domtokenlist-stringifier">stringification behavior<a class="self-link" href="#dom-domtokenlist-stringifier"></a></dfn> must return the result of running <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-dtl-serialize">serialize steps</a>. </p>
    <h3 class="heading settled" data-level="7.2" id="interface-domsettabletokenlist"><span class="secno">7.2. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#domsettabletokenlist">DOMSettableTokenList</a></code></span><a class="self-link" href="#interface-domsettabletokenlist"></a></h3>
@@ -5395,6 +5394,7 @@ namespace and local name localName</a><span>, in §4.4</span>
    <li><a href="#dom-characterdata-substringdata">substringData(offset, count)</a><span>, in §4.9</span>
    <li><a href="#dom-mutationobserverinit-subtree">subtree</a><span>, in §4.3.1</span>
    <li><a href="#concept-supported-tokens">supported tokens</a><span>, in §7.1</span>
+   <li><a href="#dom-domtokenlist-supports">supports(token)</a><span>, in §7.1</span>
    <li><a href="#dom-range-surroundcontents">surroundContents(newParent)</a><span>, in §5.2</span>
    <li>
     systemId
@@ -5434,6 +5434,7 @@ namespace and local name localName</a><span>, in §4.4</span>
      <li><a href="#dom-domtokenlist-contains-token-token">argument for DOMTokenList/contains(token)</a><span>, in §7.1</span>
      <li><a href="#dom-domtokenlist-toggle-token-force-token">argument for DOMTokenList/toggle(token, force), DOMTokenList/toggle(token)</a><span>, in §7.1</span>
      <li><a href="#dom-domtokenlist-replace-token-newtoken-token">argument for DOMTokenList/replace(token, newToken)</a><span>, in §7.1</span>
+     <li><a href="#dom-domtokenlist-supports-token-token">argument for DOMTokenList/supports(token)</a><span>, in §7.1</span>
     </ul>
    <li>
     tokens
@@ -6052,10 +6053,11 @@ interface <a href="#domtokenlist">DOMTokenList</a> {
   readonly attribute unsigned long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long " href="#dom-domtokenlist-length">length</a>;
   getter DOMString? <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-item">item</a>(unsigned long <a href="#dom-domtokenlist-item-index-index">index</a>);
   boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-contains">contains</a>(DOMString <a href="#dom-domtokenlist-contains-token-token">token</a>);
-  boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-add">add</a>(DOMString... <a href="#dom-domtokenlist-add-tokens-tokens">tokens</a>);
+  void <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-add">add</a>(DOMString... <a href="#dom-domtokenlist-add-tokens-tokens">tokens</a>);
   void <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-remove">remove</a>(DOMString... <a href="#dom-domtokenlist-remove-tokens-tokens">tokens</a>);
   boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-toggle">toggle</a>(DOMString <a href="#dom-domtokenlist-toggle-token-force-token">token</a>, optional boolean <a href="#dom-domtokenlist-toggle-token-force-force">force</a>);
   void <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-replace">replace</a>(DOMString <a href="#dom-domtokenlist-replace-token-newtoken-token">token</a>, DOMString <a href="#dom-domtokenlist-replace-token-newtoken-newtoken">newToken</a>);
+  boolean <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-supports">supports</a>(DOMString <a href="#dom-domtokenlist-supports-token-token">token</a>);
   <a data-link-type="dfn" href="#dom-domtokenlist-stringifier">stringifier</a>;
   iterable&lt;DOMString>;
 };


### PR DESCRIPTION
This follows up on the discussion we had in https://github.com/whatwg/dom/pull/114 regarding feature detection for DOMTokenLists:

* It removes references to "validation steps" from `add()`, `toggle()`, `replace()` and object creation.
* It adds `supports()` as discussed.
* When the associated attribute has no supported tokens, `TypeError` is thrown (by the "validation steps")

/cc @zcorpan @domenic @annevk 