### PR TITLE
Make addEventListener throw for service worker optimization

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1065,6 +1065,15 @@ seen from the definition above, an <a>event listener</a> is a more broad concept
 method, when invoked, must run these steps:
 
 <ol>
+ <li>
+  <p>If the <a>context object</a>'s global object is a {{ServiceWorkerGlobalScope}} object and its
+  associated <a>service worker</a>'s <a>script resource</a>'s <a>has ever been evaluated flag</a> is
+  set, <a>throw</a> a <code>TypeError</code>. [[!SW]]
+
+  <p class="note no-backref">To optimize storing the event types allowed for the service worker and
+  to avoid non-deterministic changes to the event listeners, invocation of the method is allowed
+  only during the very first evaluation of the service worker script.
+
  <li><p>If <var>callback</var> is null, terminate these steps.
 
  <li><p>Let <var>capture</var> and <var>passive</var> be the result of <a>flattening</a>
@@ -1082,6 +1091,10 @@ method, when invoked, must run these steps:
 method, when invoked, must, run these steps
 
 <ol>
+ <li><p>If the <a>context object</a>'s global object is a {{ServiceWorkerGlobalScope}} object and
+ its associated <a>service worker</a>'s <a>script resource</a>'s <a>has ever been evaluated flag</a>
+ is set, <a>throw</a> a <code>TypeError</code>. [[!SW]]
+
  <li><p>Let <var>capture</var> and <var>passive</var> be the result of <a>flattening</a>
  <var>options</var>.
 


### PR DESCRIPTION
To optimize the service worker execution behavior, this change makes
addEventListener throw when it is called after the very first
evaluation of the service worker script.

SW issue: https://github.com/slightlyoff/ServiceWorker/issues/718