### PR TITLE
Issue #156. Add legacy event type check to invoke algorithm.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1192,8 +1192,32 @@ for discussion).
    <li><p>If <var>event</var>'s <a>stop immediate propagation flag</a> is set, terminate the
    <a>invoke</a> algorithm.
 
-   <li><p>If <var>event</var>'s {{Event/type}} attribute value is not <var>listener</var>'s
-   <b>type</b>, terminate these substeps (and run them for the next <a>event listener</a>).
+   <li><p>Let <var>original event type</var> be <var>event</var>'s {{Event/type}} attribute value.
+
+   <li>
+    <p>If <var>original event type</var> is not <var>listener</var>'s <b>type</b>, run these
+    subsubsteps:
+
+    <ol>
+     <li>
+      <p>If <var>original event type</var> is an <a>ASCII case-insensitive</a> match for any of the
+      strings in the first column in the following table, set <var>event</var>'s {{Event/type}}
+      attribute value to the string in the second column on the same row as the matching string:
+
+      <table>
+       <thead>
+        <tr><th>Event Type<th>Legacy Event Type
+       <tbody>
+        <tr><td>"<code>animationend</code>"<td>"<code>webkitAnimationEnd</code>"
+        <tr><td>"<code>animationiteration</code>"<td>"<code>webkitAnimationIteration</code>"
+        <tr><td>"<code>animationstart</code>"<td>"<code>webkitAnimationStart</code>"
+        <tr><td>"<code>transitionend</code>"<td>"<code>webkitTransitionEnd</code>"
+      </table>
+
+     <li><p>If <var>event</var>'s {{Event/type}} attribute value is <var>listener</var>'s
+     <b>type</b>, continue, else terminate these substeps (and run them for the next
+     <a>event listener</a>).
+    </ol>
 
    <li><p>If <var>event</var>'s {{Event/eventPhase}} attribute value is {{Event/CAPTURING_PHASE}}
    and <var>listener</var>'s <b>capture</b> is false, terminate these substeps (and run them for the
@@ -1211,6 +1235,10 @@ for discussion).
    <a>callback this value</a>. If this throws any exception, <a>report the exception</a>.
 
    <li><p>Clear <var>event</var>'s <a>in passive listener flag</a>.
+
+   <li>If <var>event</var>'s {{Event/type}} attribute value is not equal to
+   <var>original event type</var>, set <var>event</var>'s {{Event/type}} attribute value to
+   <var>original event type</var>.
   </ol>
 </ol>
 

--- a/dom.html
+++ b/dom.html
@@ -220,9 +220,9 @@
   "DOM Event Architecture" and "Basic Event Interfaces" chapters of <cite>DOM Level 3 Events</cite> <a data-link-type="biblio" href="#biblio-uievents-20031107">[uievents-20031107]</a> (specific types of events do not
   belong in the DOM Standard), and <cite>DOM Level 2 Traversal and Range</cite> <a data-link-type="biblio" href="#biblio-dom-level-2-traversal-range">[DOM-Level-2-Traversal-Range]</a>, and: </p>
      <ul class="brief">
-      <li>Aligning them with the JavaScript ecosystem where possible. 
-      <li>Aligning them with existing implementations. 
-      <li>Simplifying them as much as possible. 
+      <li>Aligning them with the JavaScript ecosystem where possible.
+      <li>Aligning them with existing implementations.
+      <li>Simplifying them as much as possible.
      </ul>
     <li>
      <p>By moving features from the HTML Standard <a data-link-type="biblio" href="#biblio-html">[HTML]</a> that make more sense to be
@@ -326,31 +326,31 @@ corresponding characters in the range U+0061 to U+007A, inclusive.</p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-ordered-set-parser">ordered set parser<a class="self-link" href="#concept-ordered-set-parser"></a></dfn> takes a string <var>input</var> and then runs these steps:</p>
    <ol>
     <li>Let <var>position</var> be a pointer into <var>input</var>,
- initially pointing at the start of the string. 
-    <li>Let <var>tokens</var> be an ordered set of tokens, initially empty. 
-    <li><a data-link-type="dfn" href="#skip-ascii-whitespace">Skip ASCII whitespace</a>. 
+ initially pointing at the start of the string.
+    <li>Let <var>tokens</var> be an ordered set of tokens, initially empty.
+    <li><a data-link-type="dfn" href="#skip-ascii-whitespace">Skip ASCII whitespace</a>.
     <li>
-     While <var>position</var> is not past the end of <var>input</var>: 
+     While <var>position</var> is not past the end of <var>input</var>:
      <ol>
       <li><a data-link-type="dfn" href="#collect-a-code-point-sequence">Collect a code point sequence</a> of code points that are
-   not <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. 
+   not <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>.
       <li>If the collected string is not in <var>tokens</var>, append the
-   collected string to <var>tokens</var>. 
-      <li><a data-link-type="dfn" href="#skip-ascii-whitespace">Skip ASCII whitespace</a>. 
+   collected string to <var>tokens</var>.
+      <li><a data-link-type="dfn" href="#skip-ascii-whitespace">Skip ASCII whitespace</a>.
      </ol>
-    <li>Return <var>tokens</var>. 
+    <li>Return <var>tokens</var>.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="collect-a-code-point-sequence">collect a code point sequence<a class="self-link" href="#collect-a-code-point-sequence"></a></dfn> of <var>code points</var>, run these steps:</p>
    <ol>
     <li>Let <var>input</var> and <var>position</var> be the same
  variables as those of the same name in the algorithm that invoked these
- steps. 
-    <li>Let <var>result</var> be the empty string. 
+ steps.
+    <li>Let <var>result</var> be the empty string.
     <li>While <var>position</var> does not point past the end of <var>input</var> and the code point at <var>position</var> is
  one of <var>code points</var>, append that code point to the end
  of <var>result</var> and advance <var>position</var> to the
- next code point in <var>input</var>. 
-    <li>Return <var>result</var>. 
+ next code point in <var>input</var>.
+    <li>Return <var>result</var>.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="skip-ascii-whitespace">skip ASCII whitespace<a class="self-link" href="#skip-ascii-whitespace"></a></dfn> means to <a data-link-type="dfn" href="#collect-a-code-point-sequence">collect a code point sequence</a> of <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a> and discard the
 return value.</p>
@@ -358,16 +358,16 @@ return value.</p>
    <h3 class="heading settled" data-level="2.4" id="selectors"><span class="secno">2.4. </span><span class="content">Selectors</span><a class="self-link" href="#selectors"></a></h3>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="match-a-relative-selectors-string">match a relative selectors string<a class="self-link" href="#match-a-relative-selectors-string"></a></dfn> <var>relativeSelectors</var> against a <var>set</var>, run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-relative-selector">parse a relative selector</a> from <var>relativeSelectors</var> against <var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
-    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
-    <li>Return the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a> <var>s</var> using <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope elements</a> <var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-relative-selector">parse a relative selector</a> from <var>relativeSelectors</var> against <var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>.
+    <li>Return the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a> <var>s</var> using <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope elements</a> <var>set</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="scope-match-a-selectors-string">scope-match a selectors string<a class="self-link" href="#scope-match-a-selectors-string"></a></dfn> <var>selectors</var> against a <var>node</var>, run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
-    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>.
     <li>Return the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#evaluate-a-selector">evaluate a selector</a> <var>s</var> against <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> using <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scoping-root">scoping root</a> <var>node</var> and
- scoping method <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-filtered">scope-filtered</a>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>. 
+ scoping method <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-filtered">scope-filtered</a>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>.
    </ol>
    <p class="note" role="note">Support for namespaces within selectors is not planned and will not be
 added. </p>
@@ -377,26 +377,26 @@ added. </p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="xmlns-namespace">XMLNS namespace<a class="self-link" href="#xmlns-namespace"></a></dfn> is <code>http://www.w3.org/2000/xmlns/</code>.</p>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="validate">validate<a class="self-link" href="#validate"></a></dfn> a <var>qualifiedName</var>, run these steps:</p>
    <ol>
-    <li>If <var>qualifiedName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
-    <li>If <var>qualifiedName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception. 
+    <li>If <var>qualifiedName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception.
+    <li>If <var>qualifiedName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="validate-and-extract">validate and extract<a class="self-link" href="#validate-and-extract"></a></dfn> a <var>namespace</var> and <var>qualifiedName</var>,
 run these steps:</p>
    <ol>
-    <li>If <var>namespace</var> is the empty string, set it to null. 
-    <li><a data-link-type="dfn" href="#validate">Validate</a> <var>qualifiedName</var>. Rethrow any exceptions. 
-    <li>Let <var>prefix</var> be null. 
-    <li>Let <var>localName</var> be <var>qualifiedName</var>. 
+    <li>If <var>namespace</var> is the empty string, set it to null.
+    <li><a data-link-type="dfn" href="#validate">Validate</a> <var>qualifiedName</var>. Rethrow any exceptions.
+    <li>Let <var>prefix</var> be null.
+    <li>Let <var>localName</var> be <var>qualifiedName</var>.
     <li>If <var>qualifiedName</var> contains a "<code>:</code>" (U+003E), then split the
  string on it and set <var>prefix</var> to the part before and <var>localName</var> to
- the part after. 
-    <li>If <var>prefix</var> is non-null and <var>namespace</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception. 
+ the part after.
+    <li>If <var>prefix</var> is non-null and <var>namespace</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception.
     <li>If <var>prefix</var> is "<code>xml</code>" and <var>namespace</var> is
- not the <a data-link-type="dfn" href="#xml-namespace">XML namespace</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception. 
+ not the <a data-link-type="dfn" href="#xml-namespace">XML namespace</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception.
     <li>If either <var>qualifiedName</var> or <var>prefix</var> is
- "<code>xmlns</code>" and <var>namespace</var> is not the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception. 
-    <li>If <var>namespace</var> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a> and neither <var>qualifiedName</var> nor <var>prefix</var> is "<code>xmlns</code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception. 
-    <li>Return <var>namespace</var>, <var>prefix</var>, and <var>localName</var>. 
+ "<code>xmlns</code>" and <var>namespace</var> is not the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception.
+    <li>If <var>namespace</var> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a> and neither <var>qualifiedName</var> nor <var>prefix</var> is "<code>xmlns</code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception.
+    <li>Return <var>namespace</var>, <var>prefix</var>, and <var>localName</var>.
    </ol>
    <h2 class="heading settled" data-level="3" id="events"><span class="secno">3. </span><span class="content">Events</span><a class="self-link" href="#events"></a></h2>
    <h3 class="heading settled" data-level="3.1" id="introduction-to-dom-events"><span class="secno">3.1. </span><span class="content">Introduction to "DOM Events"</span><a class="self-link" href="#introduction-to-dom-events"></a></h3>
@@ -503,46 +503,46 @@ something has occurred, e.g. that an image has completed downloading. It is
 represented by the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface or an interface that
 inherits from the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface.</p>
    <dl class="domintro">
-    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-event-event">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code> 
+    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-event-event">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
     <dd>Returns a new <var>event</var> whose <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is set to <var>type</var>. The optional <code class="idl"><a class="idl-code" data-link-type="argument" href="#dom-event-event-type-eventinitdict-eventinitdict">eventInitDict</a></code> argument
  allows for setting the <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attributes via object
- members of the same name. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code></code> 
+ members of the same name.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code></code>
     <dd>Returns the type of <var>event</var>, e.g.
  "<code>click</code>", "<code>hashchange</code>", or
- "<code>submit</code>". 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code></code> 
-    <dd>Returns the object to which <var>event</var> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code></code> 
+ "<code>submit</code>".
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code></code>
+    <dd>Returns the object to which <var>event</var> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code></code>
     <dd>Returns the object whose <a data-link-type="dfn" href="#concept-event-listener">event listener</a>’s <b>callback</b> is currently being
- invoked. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-event">event</a>’s phase, which is one of <code class="idl"><a data-link-type="idl" href="#dom-event-none">NONE</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-event-bubbling_phase">BUBBLING_PHASE</a></code>. 
-    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stoppropagation">stopPropagation</a>()</code> 
-    <dd>When <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, invoking this method prevents <var>event</var> from reaching any objects other than the current object. 
-    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stopimmediatepropagation">stopImmediatePropagation</a>()</code> 
+ invoked.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-event">event</a>’s phase, which is one of <code class="idl"><a data-link-type="idl" href="#dom-event-none">NONE</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-event-bubbling_phase">BUBBLING_PHASE</a></code>.
+    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stoppropagation">stopPropagation</a>()</code>
+    <dd>When <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, invoking this method prevents <var>event</var> from reaching any objects other than the current object.
+    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-stopimmediatepropagation">stopImmediatePropagation</a>()</code>
     <dd>Invoking this method prevents <var>event</var> from reaching
  any registered <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> after the current one finishes running and, when <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, also prevents <var>event</var> from reaching any
- other objects. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code></code> 
-    <dd>Returns true or false depending on how <var>event</var> was initialized. True if <var>event</var> goes through its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, and false otherwise. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code></code> 
+ other objects.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code></code>
+    <dd>Returns true or false depending on how <var>event</var> was initialized. True if <var>event</var> goes through its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, and false otherwise.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code></code>
     <dd>Returns true or false depending on how <var>event</var> was initialized. Its return
  value does not always carry meaning, but true can indicate that part of the operation
- during which <var>event</var> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>, can be canceled by invoking the <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> method. 
-    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-preventdefault">preventDefault</a>()</code> 
+ during which <var>event</var> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>, can be canceled by invoking the <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> method.
+    <dt><code><var>event</var> . <a class="idl-code" data-link-type="method" href="#dom-event-preventdefault">preventDefault</a>()</code>
     <dd>If invoked when the <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute value is true, and while executing a
  listener for the <var>event</var> with <code class="idl"><a data-link-type="idl" href="#dom-eventlisteneroptions-passive">passive</a></code> set to false, signals to
- the operation that caused <var>event</var> to be <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> that it needs to be canceled. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-defaultprevented">defaultPrevented</a></code></code> 
+ the operation that caused <var>event</var> to be <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> that it needs to be canceled.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-defaultprevented">defaultPrevented</a></code></code>
     <dd>Returns true if <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> was invoked successfully to indicate cancellation,
- and false otherwise. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code></code> 
+ and false otherwise.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code></code>
     <dd>Returns true if <var>event</var> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent, and
- false otherwise. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-timestamp">timeStamp</a></code></code> 
+ false otherwise.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-timestamp">timeStamp</a></code></code>
     <dd>Returns the creation time of <var>event</var> as the number of milliseconds that
- passed since 00:00:00 UTC on 1 January 1970. 
+ passed since 00:00:00 UTC on 1 January 1970.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="attribute" data-export="" id="dom-event-type">type<a class="self-link" href="#dom-event-type"></a></dfn> attribute must
 return the value it was initialized to. When an <a data-link-type="dfn" href="#concept-event">event</a> is created the attribute must be
@@ -552,29 +552,29 @@ initialized to null.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="attribute" data-export="" id="dom-event-eventphase">eventPhase<a class="self-link" href="#dom-event-eventphase"></a></dfn> attribute must return the value it was initialized to, which must be one of
 the following:</p>
    <dl>
-    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-none">NONE<a class="self-link" href="#dom-event-none"></a></dfn> (numeric value 0) 
-    <dd><a data-link-type="dfn" href="#concept-event">Events</a> not currently <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> are in this phase. 
-    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-capturing_phase">CAPTURING_PHASE<a class="self-link" href="#dom-event-capturing_phase"></a></dfn> (numeric value 1) 
+    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-none">NONE<a class="self-link" href="#dom-event-none"></a></dfn> (numeric value 0)
+    <dd><a data-link-type="dfn" href="#concept-event">Events</a> not currently <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> are in this phase.
+    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-capturing_phase">CAPTURING_PHASE<a class="self-link" href="#dom-event-capturing_phase"></a></dfn> (numeric value 1)
     <dd>When an <a data-link-type="dfn" href="#concept-event">event</a> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to an object that <a data-link-type="dfn" href="#concept-tree-participate">participates</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> it will be in this phase before it
- reaches its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value. 
-    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-at_target">AT_TARGET<a class="self-link" href="#dom-event-at_target"></a></dfn> (numeric value 2) 
+ reaches its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value.
+    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-at_target">AT_TARGET<a class="self-link" href="#dom-event-at_target"></a></dfn> (numeric value 2)
     <dd>When an <a data-link-type="dfn" href="#concept-event">event</a> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> it will be in this
- phase on its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value. 
-    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-bubbling_phase">BUBBLING_PHASE<a class="self-link" href="#dom-event-bubbling_phase"></a></dfn> (numeric value 3) 
+ phase on its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value.
+    <dt><dfn class="idl-code" data-dfn-for="Event" data-dfn-type="const" data-export="" id="dom-event-bubbling_phase">BUBBLING_PHASE<a class="self-link" href="#dom-event-bubbling_phase"></a></dfn> (numeric value 3)
     <dd>When an <a data-link-type="dfn" href="#concept-event">event</a> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to an object that <a data-link-type="dfn" href="#concept-tree-participate">participates</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> it will be in this phase after it
- reaches its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value. 
+ reaches its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value.
    </dl>
-    Initially the attribute must be initialized to <code class="idl"><a data-link-type="idl" href="#dom-event-none">NONE</a></code>. 
+    Initially the attribute must be initialized to <code class="idl"><a data-link-type="idl" href="#dom-event-none">NONE</a></code>.
    <hr>
    <p>Each <a data-link-type="dfn" href="#concept-event">event</a> has the following associated
 flags that are all initially unset:</p>
    <ul>
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-propagation-flag">stop propagation flag<a class="self-link" href="#stop-propagation-flag"></a></dfn> 
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-immediate-propagation-flag">stop immediate propagation flag<a class="self-link" href="#stop-immediate-propagation-flag"></a></dfn> 
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="canceled-flag">canceled flag<a class="self-link" href="#canceled-flag"></a></dfn> 
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="initialized-flag">initialized flag<a class="self-link" href="#initialized-flag"></a></dfn> 
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="dispatch-flag">dispatch flag<a class="self-link" href="#dispatch-flag"></a></dfn> 
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="in-passive-listener-flag">in passive listener flag<a class="self-link" href="#in-passive-listener-flag"></a></dfn> 
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-propagation-flag">stop propagation flag<a class="self-link" href="#stop-propagation-flag"></a></dfn>
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-immediate-propagation-flag">stop immediate propagation flag<a class="self-link" href="#stop-immediate-propagation-flag"></a></dfn>
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="canceled-flag">canceled flag<a class="self-link" href="#canceled-flag"></a></dfn>
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="initialized-flag">initialized flag<a class="self-link" href="#initialized-flag"></a></dfn>
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="dispatch-flag">dispatch flag<a class="self-link" href="#dispatch-flag"></a></dfn>
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="in-passive-listener-flag">in passive listener flag<a class="self-link" href="#in-passive-listener-flag"></a></dfn>
    </ul>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="method" data-export="" id="dom-event-stoppropagation">stopPropagation()<a class="self-link" href="#dom-event-stoppropagation"></a></dfn> method must set the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="method" data-export="" id="dom-event-stopimmediatepropagation">stopImmediatePropagation()<a class="self-link" href="#dom-event-stopimmediatepropagation"></a></dfn> method must set both the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -597,22 +597,22 @@ initialized to the number of milliseconds that have passed since
    <hr>
    <p>To <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="concept-event-initialize">initialize<a class="self-link" href="#concept-event-initialize"></a></dfn> an <var>event</var>, with <var>type</var>, <var>bubbles</var>, and <var>cancelable</var>, run these steps:</p>
    <ol>
-    <li>Set the <a data-link-type="dfn" href="#initialized-flag">initialized flag</a>. 
-    <li>Unset the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a>, <a data-link-type="dfn" href="#stop-immediate-propagation-flag">stop immediate propagation flag</a>, and <a data-link-type="dfn" href="#canceled-flag">canceled flag</a>. 
+    <li>Set the <a data-link-type="dfn" href="#initialized-flag">initialized flag</a>.
+    <li>Unset the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a>, <a data-link-type="dfn" href="#stop-immediate-propagation-flag">stop immediate propagation flag</a>, and <a data-link-type="dfn" href="#canceled-flag">canceled flag</a>.
     <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute
- to false. 
+ to false.
     <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute to
- null. 
-    <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute to <var>type</var>. 
-    <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> attribute to <var>bubbles</var>. 
+ null.
+    <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute to <var>type</var>.
+    <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> attribute to <var>bubbles</var>.
     <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute
- to <var>cancelable</var>. 
+ to <var>cancelable</var>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="method" data-export="" id="dom-event-initevent">initEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>)<a class="self-link" href="#dom-event-initevent"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
     <li>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#dispatch-flag">dispatch flag</a> is set, terminate
- these steps. 
-    <li><a data-link-type="dfn" href="#concept-event-initialize">Initialize</a> the <a data-link-type="dfn" href="#context-object">context object</a> with <var>type</var>, <var>bubbles</var>, and <var>cancelable</var>. 
+ these steps.
+    <li><a data-link-type="dfn" href="#concept-event-initialize">Initialize</a> the <a data-link-type="dfn" href="#context-object">context object</a> with <var>type</var>, <var>bubbles</var>, and <var>cancelable</var>.
    </ol>
    <p class="note no-backref" role="note">As <a data-link-type="dfn" href="#concept-event">events</a> have constructors <code class="idl"><a data-link-type="idl" href="#dom-event-initevent">initEvent()</a></code> is superfluous. However,
 it has to be supported for legacy content. </p>
@@ -631,23 +631,23 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
 </pre>
    <p><a data-link-type="dfn" href="#concept-event">Events</a> using the <code class="idl"><a data-link-type="idl" href="#customevent">CustomEvent</a></code> interface can be used to carry custom data.</p>
    <dl class="domintro">
-    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-customevent-customevent">CustomEvent</a>(<var>type</var> [, <var>eventInitDict</var>])</code> 
+    <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-customevent-customevent">CustomEvent</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
     <dd>Works analogously to the constructor for <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> except
  that the optional <var>eventInitDict</var> argument now
  allows for setting the <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code> attribute
- too. 
-    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code></code> 
+ too.
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code></code>
     <dd>Returns any custom data <var>event</var> was created with.
- Typically used for synthetic events. 
+ Typically used for synthetic events.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="CustomEvent" data-dfn-type="attribute" data-export="" id="dom-customevent-detail">detail<a class="self-link" href="#dom-customevent-detail"></a></dfn> attribute
 must return the value it was initialized to.</p>
    <p>The <dfn class="idl-code" data-dfn-for="CustomEvent" data-dfn-type="method" data-export="" id="dom-customevent-initcustomevent">initCustomEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>, <var>detail</var>)<a class="self-link" href="#dom-customevent-initcustomevent"></a></dfn> method must, when invoked, run these steps:</p>
    <ol>
     <li>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#dispatch-flag">dispatch flag</a> is set, terminate
- these steps. 
-    <li><a data-link-type="dfn" href="#concept-event-initialize">Initialize</a> the <a data-link-type="dfn" href="#context-object">context object</a> with <var>type</var>, <var>bubbles</var>, and <var>cancelable</var>. 
-    <li>Set <a data-link-type="dfn" href="#context-object">context object</a>’s <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code> attribute to <var>detail</var>. 
+ these steps.
+    <li><a data-link-type="dfn" href="#concept-event-initialize">Initialize</a> the <a data-link-type="dfn" href="#context-object">context object</a> with <var>type</var>, <var>bubbles</var>, and <var>cancelable</var>.
+    <li>Set <a data-link-type="dfn" href="#context-object">context object</a>’s <code class="idl"><a data-link-type="idl" href="#dom-customevent-detail">detail</a></code> attribute to <var>detail</var>.
    </ol>
    <h3 class="heading settled" data-level="3.4" id="constructing-events"><span class="secno">3.4. </span><span class="content">Constructing events</span><a class="self-link" href="#constructing-events"></a></h3>
    <p>When a <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="concept-event-constructor">constructor<a class="self-link" href="#concept-event-constructor"></a></dfn> of the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface, or of an interface that inherits from the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface, is
@@ -697,11 +697,11 @@ initially unset. </p>
    <p class="note no-backref" role="note">The callback is named <code class="idl"><a data-link-type="idl" href="#callbackdef-eventlistener">EventListener</a></code> for historical reasons. As can be
 seen from the definition above, an <a data-link-type="dfn" href="#concept-event-listener">event listener</a> is a more broad concept. </p>
    <dl class="domintro">
-    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-addeventlistener">addEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code> 
+    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-addeventlistener">addEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code>
     <dd>
       Appends an <a data-link-type="dfn" href="#concept-event-listener">event listener</a> for <a data-link-type="dfn" href="#concept-event">events</a> whose <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value
   is <var>type</var>. The <var>callback</var> argument sets the <b>callback</b> that will
-  be invoked when the <a data-link-type="dfn" href="#concept-event">event</a> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>. 
+  be invoked when the <a data-link-type="dfn" href="#concept-event">event</a> is <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a>.
      <p>The <var>options</var> argument sets listener-specific options. For compatibility this can be just
   a boolean, in which case the method behaves exactly as if the value was specified as <var>options</var>’ <code>capture</code> member.</p>
      <p>When set to true, <var>options</var>’ <code>capture</code> member prevents <b>callback</b> from
@@ -710,11 +710,11 @@ seen from the definition above, an <a data-link-type="dfn" href="#concept-event-
   performance optimizations described in <a href="#observing-event-listeners">§3.7 Observing event listeners</a>.</p>
      <p>The <a data-link-type="dfn" href="#concept-event-listener">event listener</a> is appended to <var>target</var>’s list of <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> and is
   not appended if it is a duplicate, i.e., having the same <b>type</b>, <b>callback</b>, <b>capture</b> and <b>passive</b> values.</p>
-    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-removeeventlistener">removeEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code> 
-    <dd>Remove the <a data-link-type="dfn" href="#concept-event-listener">event listener</a> in <var>target</var>’s list of <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> with the same <var>type</var>, <var>callback</var>, and <var>options</var>. 
-    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-dispatchevent">dispatchEvent</a>(<var>event</var>)</code> 
+    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-removeeventlistener">removeEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code>
+    <dd>Remove the <a data-link-type="dfn" href="#concept-event-listener">event listener</a> in <var>target</var>’s list of <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> with the same <var>type</var>, <var>callback</var>, and <var>options</var>.
+    <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-dispatchevent">dispatchEvent</a>(<var>event</var>)</code>
     <dd><a data-link-type="dfn" href="#concept-event-dispatch">Dispatches</a> a synthetic event <var>event</var> to <var>target</var> and returns
- true if either <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute value is false or its <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> method was not invoked, and false otherwise. 
+ true if either <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute value is false or its <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> method was not invoked, and false otherwise.
    </dl>
    <p>To <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="concept-flatten-options">flatten<a class="self-link" href="#concept-flatten-options"></a></dfn> <var>options</var> run these steps: </p>
    <ol>
@@ -835,7 +835,36 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-eventlisteneroptions
       <li>
        <p>If <var>event</var>’s <a data-link-type="dfn" href="#stop-immediate-propagation-flag">stop immediate propagation flag</a> is set, terminate the <a data-link-type="dfn" href="#concept-event-listener-invoke">invoke</a> algorithm. </p>
       <li>
-       <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is not <var>listener</var>’s <b>type</b>, terminate these substeps (and run them for the next <a data-link-type="dfn" href="#concept-event-listener">event listener</a>). </p>
+       <p>Let <var>original event type</var> be <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value. </p>
+      <li>
+       <p>If <var>original event type</var> is not <var>listener</var>’s <b>type</b>, run these
+    subsubsteps: </p>
+       <ol>
+        <li>
+         <p>If <var>original event type</var> is an <a data-link-type="dfn" href="#ascii-case-insensitive">ASCII case-insensitive</a> match for any of the
+      strings in the first column in the following table, set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value to the string in the second column on the same row as the matching string: </p>
+         <table>
+          <thead>
+           <tr>
+            <th>Event Type
+            <th>Legacy Event Type
+          <tbody>
+           <tr>
+            <td>"<code>animationend</code>"
+            <td>"<code>webkitAnimationEnd</code>"
+           <tr>
+            <td>"<code>animationiteration</code>"
+            <td>"<code>webkitAnimationIteration</code>"
+           <tr>
+            <td>"<code>animationstart</code>"
+            <td>"<code>webkitAnimationStart</code>"
+           <tr>
+            <td>"<code>transitionend</code>"
+            <td>"<code>webkitTransitionEnd</code>"
+         </table>
+        <li>
+         <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is <var>listener</var>’s <b>type</b>, continue, else terminate these substeps (and run them for the next <a data-link-type="dfn" href="#concept-event-listener">event listener</a>). </p>
+       </ol>
       <li>
        <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute value is <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code> and <var>listener</var>’s <b>capture</b> is false, terminate these substeps (and run them for the
    next <a data-link-type="dfn" href="#concept-event-listener">event listener</a>). </p>
@@ -847,6 +876,7 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-eventlisteneroptions
        <p>Call <var>listener</var>’s <b>callback</b>’s <code class="idl"><a data-link-type="idl" href="#dom-eventlistener-handleevent">handleEvent()</a></code>, with <var>event</var> as argument and <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute value as <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-callback-this-value">callback this value</a>. If this throws any exception, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">report the exception</a>. </p>
       <li>
        <p>Clear <var>event</var>’s <a data-link-type="dfn" href="#in-passive-listener-flag">in passive listener flag</a>. </p>
+      <li>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is not equal to <var>original event type</var>, set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value to <var>original event type</var>.
      </ol>
    </ol>
    <h3 class="heading settled" data-level="3.9" id="firing-events"><span class="secno">3.9. </span><span class="content">Firing events</span><a class="self-link" href="#firing-events"></a></h3>
@@ -883,26 +913,26 @@ applications.</p>
    <p>It is represented as follows:</p>
    <ul class="domTree">
     <li>
-      <a data-link-type="dfn" href="#concept-document">Document</a> 
+      <a data-link-type="dfn" href="#concept-document">Document</a>
      <ul>
-      <li class="t10"><a data-link-type="dfn" href="#concept-doctype">Doctype</a>: <code>html</code> 
+      <li class="t10"><a data-link-type="dfn" href="#concept-doctype">Doctype</a>: <code>html</code>
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>html</code> <span class="t2"><code class="attribute name">class</code>="<code class="attribute value">e</code>"</span> 
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>html</code> <span class="t2"><code class="attribute name">class</code>="<code class="attribute value">e</code>"</span>
        <ul>
         <li class="t1">
-          <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>head</code> 
+          <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>head</code>
          <ul>
           <li class="t1">
-            <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>title</code> 
+            <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>title</code>
            <ul>
-            <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Aliens?</span> 
+            <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Aliens?</span>
            </ul>
          </ul>
-        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>⏎␣</span> 
+        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>⏎␣</span>
         <li class="t1">
-          <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>body</code> 
+          <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>body</code>
          <ul>
-          <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Why yes.⏎</span> 
+          <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>Why yes.⏎</span>
          </ul>
        </ul>
      </ul>
@@ -916,72 +946,72 @@ or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
    <p>A <a data-link-type="dfn" href="#concept-node-tree">node tree</a> is constrained as
 follows, expressed as a relationship between the type of <a data-link-type="dfn" href="#concept-node">node</a> and its allowed <a data-link-type="dfn" href="#concept-tree-child">children</a>:</p>
    <dl>
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
     <dd>
-      In <a data-link-type="dfn" href="#concept-tree-order">tree order</a>: 
+      In <a data-link-type="dfn" href="#concept-tree-order">tree order</a>:
      <ol>
-      <li>Zero or more nodes each of which is either <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>. 
-      <li>Optionally one <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> node. 
-      <li>Zero or more nodes each of which is either <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>. 
-      <li>Optionally one <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> node. 
-      <li>Zero or more nodes each of which is either <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>. 
+      <li>Zero or more nodes each of which is either <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>.
+      <li>Optionally one <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> node.
+      <li>Zero or more nodes each of which is either <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>.
+      <li>Optionally one <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> node.
+      <li>Zero or more nodes each of which is either <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>.
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
-    <dd>Zero or more nodes each of which is one of <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>, or <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dd>None. 
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dd>Zero or more nodes each of which is one of <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>, or <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>.
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dd>None.
    </dl>
    <p>The <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-length">length<a class="self-link" href="#concept-node-length"></a></dfn> of a <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> depends on <var>node</var>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-    <dd>Zero. 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dd>Zero.
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
     <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute
- value. 
-    <dt>Any other node 
-    <dd>Its number of <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
+ value.
+    <dt>Any other node
+    <dd>Its number of <a data-link-type="dfn" href="#concept-tree-child">children</a>.
    </dl>
    <p>A <a data-link-type="dfn" href="#concept-node">node</a> is considered <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-empty">empty<a class="self-link" href="#concept-node-empty"></a></dfn> if its <a data-link-type="dfn" href="#concept-node-length">length</a> is zero.</p>
    <h4 class="heading settled" data-level="4.2.1" id="mutation-algorithms"><span class="secno">4.2.1. </span><span class="content">Mutation algorithms</span><a class="self-link" href="#mutation-algorithms"></a></h4>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-ensure-pre-insertion-validity">ensure pre-insertion validity<a class="self-link" href="#concept-node-ensure-pre-insertion-validity"></a></dfn> of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:</p>
    <ol>
-    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
-    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
-    <li>If <var>child</var> is not null and its <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
+    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
+    <li>If <var>child</var> is not null and its <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception.
+    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
     <li>If either <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> and <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, or <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a> and <var>parent</var> is
- not a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+ not a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
     <li>
       If <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, and any of the statements below, switched
-  on <var>node</var>, are true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+  on <var>node</var>, are true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
      <dl class="switch">
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> 
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>
       <dd>
-        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
+        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>.
        <p>Otherwise, if <var>node</var> has one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> and either <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, or <var>child</var> is not null and
     a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>.</p>
-      <dt><a data-link-type="dfn" href="#concept-element">element</a> 
-      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, or <var>child</var> is not null and a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>. 
-      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a> 
+      <dt><a data-link-type="dfn" href="#concept-element">element</a>
+      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, or <var>child</var> is not null and a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>.
+      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a>
       <dd><var>parent</var> has a <a data-link-type="dfn" href="#concept-doctype">doctype</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>, <var>child</var> is
-   non-null and an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>child</var>, or <var>child</var> is null and <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
+   non-null and an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>child</var>, or <var>child</var> is null and <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>.
      </dl>
    </ol>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-pre-insert">pre-insert<a class="self-link" href="#concept-node-pre-insert"></a></dfn> a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:</p>
    <ol>
-    <li><a data-link-type="dfn" href="#concept-node-ensure-pre-insertion-validity">Ensure pre-insertion validity</a> of <var>node</var> into <var>parent</var> before <var>child</var>. 
-    <li>Let <var>reference child</var> be <var>child</var>. 
+    <li><a data-link-type="dfn" href="#concept-node-ensure-pre-insertion-validity">Ensure pre-insertion validity</a> of <var>node</var> into <var>parent</var> before <var>child</var>.
+    <li>Let <var>reference child</var> be <var>child</var>.
     <li>If <var>reference child</var> is <var>node</var>, set it
- to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>. 
-    <li>Return <var>node</var>. 
+ to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
+    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>.
+    <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>.
+    <li>Return <var>node</var>.
    </ol>
    <p><a data-link-type="dfn" href="#other-applicable-specifications">Specifications</a> may define <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-insert-ext">insertion steps<a class="self-link" href="#concept-node-insert-ext"></a></dfn> for all or some <a data-link-type="dfn" href="#concept-node">nodes</a>. The algorithm is passed <var>newNode</var> as
 indicated in the <a data-link-type="dfn" href="#concept-node-insert">insert</a> algorithm below.</p>
@@ -989,61 +1019,61 @@ indicated in the <a data-link-type="dfn" href="#concept-node-insert">insert</a> 
    <ol>
     <li>Let <var>count</var> be the number of <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>node</var> if
  it is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>,
- and one otherwise. 
+ and one otherwise.
     <li>
-      If <var>child</var> is non-null, run these substeps: 
+      If <var>child</var> is non-null, run these substeps:
      <ol>
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>,
-   increase its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by <var>count</var>. 
+   increase its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by <var>count</var>.
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>,
-   increase its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by <var>count</var>. 
+   increase its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by <var>count</var>.
      </ol>
     <li>Let <var>nodes</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is
  a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a
- list containing solely <var>node</var> otherwise. 
-    <li>If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a> its <a data-link-type="dfn" href="#concept-tree-child">children</a> with the <i>suppress observers flag</i> set. 
+ list containing solely <var>node</var> otherwise.
+    <li>If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a> its <a data-link-type="dfn" href="#concept-tree-child">children</a> with the <i>suppress observers flag</i> set.
     <li>
-      If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>node</var> with removedNodes <var>nodes</var>. 
+      If <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>node</var> with removedNodes <var>nodes</var>.
      <p class="note no-backref" role="note">This step intentionally does not pay attention to the <i>suppress observers flag</i>. </p>
     <li>
-      For each <var>newNode</var> in <var>nodes</var>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run these substeps: 
+      For each <var>newNode</var> in <var>nodes</var>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, run these substeps:
      <ol>
-      <li>Insert <var>newNode</var> into <var>parent</var> before <var>child</var> or at the end of <var>parent</var> if <var>child</var> is null. 
-      <li>Run the <a data-link-type="dfn" href="#concept-node-insert-ext">insertion steps</a> with <var>newNode</var>. 
+      <li>Insert <var>newNode</var> into <var>parent</var> before <var>child</var> or at the end of <var>parent</var> if <var>child</var> is null.
+      <li>Run the <a data-link-type="dfn" href="#concept-node-insert-ext">insertion steps</a> with <var>newNode</var>.
      </ol>
-    <li>If <i>suppress observers flag</i> is unset, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with addedNodes <var>nodes</var>, nextSibling <var>child</var>, and previousSibling <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> or <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>child</var> is null. 
+    <li>If <i>suppress observers flag</i> is unset, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with addedNodes <var>nodes</var>, nextSibling <var>child</var>, and previousSibling <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> or <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>child</var> is null.
    </ol>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-append">append<a class="self-link" href="#concept-node-append"></a></dfn> a <var>node</var> to a <var>parent</var>, <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> <var>node</var> into <var>parent</var> before null.</p>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-replace">replace<a class="self-link" href="#concept-node-replace"></a></dfn> a <var>child</var> with <var>node</var> within a <var>parent</var>, run these
 steps:</p>
    <ol>
-    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
-    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
-    <li>If <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+    <li>If <var>parent</var> is not a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, or <code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
+    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
+    <li>If <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception.
+    <li>If <var>node</var> is not a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
     <li>If either <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> and <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, or <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a> and <var>parent</var> is
- not a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+ not a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
     <li>
       If <var>parent</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, and any of the statements below, switched
-  on <var>node</var>, are true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>. 
+  on <var>node</var>, are true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code>.
      <dl class="switch">
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> 
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>
       <dd>
-        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
+        If <var>node</var> has more than one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> or has a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>.
        <p>Otherwise, if <var>node</var> has one <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> and either <var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var> or a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>.</p>
-      <dt><a data-link-type="dfn" href="#concept-element">element</a> 
-      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var> or a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>. 
-      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a> 
-      <dd><var>parent</var> has a <a data-link-type="dfn" href="#concept-doctype">doctype</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var>, or an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>child</var>. 
+      <dt><a data-link-type="dfn" href="#concept-element">element</a>
+      <dd><var>parent</var> has an <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var> or a <a data-link-type="dfn" href="#concept-doctype">doctype</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>child</var>.
+      <dt><a data-link-type="dfn" href="#concept-doctype">doctype</a>
+      <dd><var>parent</var> has a <a data-link-type="dfn" href="#concept-doctype">doctype</a> <a data-link-type="dfn" href="#concept-tree-child">child</a> that is not <var>child</var>, or an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>child</var>.
      </dl>
      <p class="note no-backref" role="note">The above statements differ from the <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> algorithm. </p>
-    <li>Let <var>reference child</var> be <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
+    <li>Let <var>reference child</var> be <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
     <li>If <var>reference child</var> is <var>node</var>, set it
- to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
+ to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
     <li>
      <p>Let <var>previousSibling</var> be <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>. </p>
-    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li>Let <var>removedNodes</var> be the empty list. 
+    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>.
+    <li>Let <var>removedNodes</var> be the empty list.
     <li>
      <p>If <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null, run these substeps: </p>
      <ol>
@@ -1053,52 +1083,52 @@ steps:</p>
        <p><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>child</var> from its <var>parent</var> with the <i>suppress observers flag</i> set. </p>
      </ol>
      <p class="note no-backref" role="note">The above can only be false if <var>child</var> is <var>node</var>. </p>
-    <li>Let <var>nodes</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a list containing solely <var>node</var> otherwise. 
+    <li>Let <var>nodes</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a list containing solely <var>node</var> otherwise.
     <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var> with
- the <i>suppress observers flag</i> set. 
+ the <i>suppress observers flag</i> set.
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>childList</code>" for target <var>parent</var> with addedNodes <var>nodes</var>, removedNodes <var>removedNodes</var>,
- nextSibling <var>reference child</var>, and previousSibling <var>previousSibling</var>. 
-    <li>Return <var>child</var>. 
+ nextSibling <var>reference child</var>, and previousSibling <var>previousSibling</var>.
+    <li>Return <var>child</var>.
    </ol>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-replace-all">replace all<a class="self-link" href="#concept-node-replace-all"></a></dfn> with a <var>node</var> within a <var>parent</var>, run these steps:</p>
    <ol>
-    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-adopt">adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li>Let <var>removedNodes</var> be <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
+    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-adopt">adopt</a> <var>node</var> into <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>.
+    <li>Let <var>removedNodes</var> be <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a>.
     <li>Let <var>addedNodes</var> be the empty list if <var>node</var> is
- null, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a list containing <var>node</var> otherwise. 
-    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> all <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, with the <i>suppress observers flag</i> set. 
-    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-insert">insert</a> <var>node</var> into <var>parent</var> before null with the <i>suppress observers flag</i> set. 
+ null, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and a list containing <var>node</var> otherwise.
+    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> all <var>parent</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, with the <i>suppress observers flag</i> set.
+    <li>If <var>node</var> is not null, <a data-link-type="dfn" href="#concept-node-insert">insert</a> <var>node</var> into <var>parent</var> before null with the <i>suppress observers flag</i> set.
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with addedNodes <var>addedNodes</var> and
- removedNodes <var>removedNodes</var>. 
+ removedNodes <var>removedNodes</var>.
    </ol>
    <p class="note no-backref" role="note">This algorithm does not make any checks with regards to the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> constraints. Specification authors need to use it wisely. </p>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-pre-remove">pre-remove<a class="self-link" href="#concept-node-pre-remove"></a></dfn> a <var>child</var> from a <var>parent</var>, run these steps:</p>
    <ol>
-    <li>If <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>child</var> from <var>parent</var>. 
-    <li>Return <var>child</var>. 
+    <li>If <var>child</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not <var>parent</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception.
+    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>child</var> from <var>parent</var>.
+    <li>Return <var>child</var>.
    </ol>
    <p><a data-link-type="dfn" href="#other-applicable-specifications">Specifications</a> may define <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-remove-ext">removing steps<a class="self-link" href="#concept-node-remove-ext"></a></dfn> for all or some <a data-link-type="dfn" href="#concept-node">nodes</a>. The algorithm is passed <var>removedNode</var>, <var>oldParent</var>, and <var>oldPreviousSibling</var>, as indicated in the <a data-link-type="dfn" href="#concept-node-remove">remove</a> algorithm below.</p>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-remove">remove<a class="self-link" href="#concept-node-remove"></a></dfn> a <var>node</var> from a <var>parent</var>, with an optional <i>suppress observers flag</i>, run these
 steps:</p>
    <ol>
-    <li>Let <var>index</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
+    <li>Let <var>index</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>.
     <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>node</var>, set its <a data-link-type="dfn" href="#concept-range-start">start</a> to
- (<var>parent</var>, <var>index</var>). 
+ (<var>parent</var>, <var>index</var>).
     <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>node</var>, set its <a data-link-type="dfn" href="#concept-range-end">end</a> to
- (<var>parent</var>, <var>index</var>). 
-    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>index</var>, decrease its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by one. 
-    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>index</var>, decrease its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by one. 
+ (<var>parent</var>, <var>index</var>).
+    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>index</var>, decrease its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by one.
+    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>index</var>, decrease its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by one.
     <li>
      <p>For each <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object <var>iterator</var> whose <a data-link-type="dfn" href="#concept-traversal-root">root</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>, run the <a data-link-type="dfn" href="#nodeiterator-pre-removing-steps"><code>NodeIterator</code> pre-removing steps</a> given <var>node</var> and <var>iterator</var>. </p>
-    <li>Let <var>oldPreviousSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>. 
-    <li>Let <var>oldNextSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
-    <li>Remove <var>node</var> from its <var>parent</var>. 
-    <li>Run the <a data-link-type="dfn" href="#concept-node-remove-ext">removing steps</a> with <var>node</var>, <var>parent</var>, and <var>oldPreviousSibling</var>. 
+    <li>Let <var>oldPreviousSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>.
+    <li>Let <var>oldNextSibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
+    <li>Remove <var>node</var> from its <var>parent</var>.
+    <li>Run the <a data-link-type="dfn" href="#concept-node-remove-ext">removing steps</a> with <var>node</var>, <var>parent</var>, and <var>oldPreviousSibling</var>.
     <li>For each <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> <var>ancestor</var> of <var>parent</var>, if <var>ancestor</var> has any <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>options</b>' <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> is true, then for each
- such <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var>, append a <a data-link-type="dfn" href="#transient-registered-observer">transient registered observer</a> whose <b>observer</b> and <b>options</b> are identical to those of <var>registered</var> and <b>source</b> which is <var>registered</var> to <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>. 
+ such <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var>, append a <a data-link-type="dfn" href="#transient-registered-observer">transient registered observer</a> whose <b>observer</b> and <b>options</b> are identical to those of <var>registered</var> and <b>source</b> which is <var>registered</var> to <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>.
     <li>If <i>suppress observers flag</i> is unset, <a data-link-type="dfn" href="#queue-a-mutation-record">queue a mutation record</a> of "<code>childList</code>" for <var>parent</var> with removedNodes a list solely containing <var>node</var>,
- nextSibling <var>oldNextSibling</var>, and previousSibling <var>oldPreviousSibling</var>. 
+ nextSibling <var>oldNextSibling</var>, and previousSibling <var>oldPreviousSibling</var>.
    </ol>
    <h4 class="heading settled" data-level="4.2.2" id="interface-nonelementparentnode"><span class="secno">4.2.2. </span><span class="content">Interface <code>NonElementParentNode</code></span><a class="self-link" href="#interface-nonelementparentnode"></a></h4>
    <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="#dom-nonelementparentnode-getelementbyid">getElementById()</a></code> method is not
@@ -1114,8 +1144,8 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="non
 <a data-link-type="idl-name" href="#documentfragment">DocumentFragment</a> implements <a data-link-type="idl-name" href="#nonelementparentnode">NonElementParentNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-nonelementparentnode-getelementbyid">getElementById</a>(<var>elementId</var>)</code> 
-    <dd>Returns the first <a data-link-type="dfn" href="#concept-element">element</a> within <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> whose <a data-link-type="dfn" href="#concept-id">ID</a> is <var>elementId</var>. 
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-nonelementparentnode-getelementbyid">getElementById</a>(<var>elementId</var>)</code>
+    <dd>Returns the first <a data-link-type="dfn" href="#concept-element">element</a> within <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> whose <a data-link-type="dfn" href="#concept-id">ID</a> is <var>elementId</var>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="NonElementParentNode" data-dfn-type="method" data-export="" id="dom-nonelementparentnode-getelementbyid">getElementById(<var>elementId</var>)<a class="self-link" href="#dom-nonelementparentnode-getelementbyid"></a></dfn> method must return the first <a data-link-type="dfn" href="#concept-element">element</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, within <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>, whose <a data-link-type="dfn" href="#concept-id">ID</a> is <var>elementId</var>, and null if there is no
 such <a data-link-type="dfn" href="#concept-element">element</a> otherwise.</p>
@@ -1156,32 +1186,32 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="par
 <a data-link-type="idl-name" href="#element">Element</a> implements <a data-link-type="idl-name" href="#parentnode">ParentNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>collection</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-children">children</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-child">child</a> <a data-link-type="dfn" href="#concept-element">elements</a>. 
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-firstelementchild">firstElementChild</a></code></code> 
-    <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-lastelementchild">lastElementChild</a></code></code> 
-    <dd>Returns the last <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-prepend">prepend</a>(<var>nodes</var>)</code> 
+    <dt><code><var>collection</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-children">children</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-child">child</a> <a data-link-type="dfn" href="#concept-element">elements</a>.
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-firstelementchild">firstElementChild</a></code></code>
+    <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise.
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-parentnode-lastelementchild">lastElementChild</a></code></code>
+    <dd>Returns the last <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise.
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-prepend">prepend</a>(<var>nodes</var>)</code>
     <dd>
-      Inserts <var>nodes</var> before the <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
+      Inserts <var>nodes</var> before the <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>.
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-append">append</a>(<var>nodes</var>)</code> 
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-append">append</a>(<var>nodes</var>)</code>
     <dd>
-      Inserts <var>nodes</var> after the <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
+      Inserts <var>nodes</var> after the <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> of <var>node</var>, while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>.
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-query">query</a>(<var>relativeSelectors</var>)</code> 
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-query">query</a>(<var>relativeSelectors</var>)</code>
     <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> that is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node</var> that
-  matches <var>relativeSelectors</var>. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryall">queryAll</a>(<var>relativeSelectors</var>)</code> 
+  matches <var>relativeSelectors</var>.
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryall">queryAll</a>(<var>relativeSelectors</var>)</code>
     <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>node</var> that
-  match <var>relativeSelectors</var>. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselector">querySelector</a>(<var>selectors</var>)</code> 
+  match <var>relativeSelectors</var>.
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselector">querySelector</a>(<var>selectors</var>)</code>
     <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> that is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node</var> that
-  matches <var>selectors</var>. 
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselectorall">querySelectorAll</a>(<var>selectors</var>)</code> 
+  matches <var>selectors</var>.
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-parentnode-queryselectorall">querySelectorAll</a>(<var>selectors</var>)</code>
     <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>node</var> that
-  match <var>selectors</var>. 
+  match <var>selectors</var>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-children">children<a class="self-link" href="#dom-parentnode-children"></a></dfn> attribute must return an <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> <a data-link-type="dfn" href="#concept-collection">collection</a> rooted at the <a data-link-type="dfn" href="#context-object">context object</a> matching only <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-child">children</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-firstelementchild">firstElementChild<a class="self-link" href="#dom-parentnode-firstelementchild"></a></dfn> attribute must return the first <a data-link-type="dfn" href="#concept-tree-child">child</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise.</p>
@@ -1189,13 +1219,13 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="par
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="attribute" data-export="" id="dom-parentnode-childelementcount">childElementCount<a class="self-link" href="#dom-parentnode-childelementcount"></a></dfn> attribute must return the number of <a data-link-type="dfn" href="#concept-tree-child">children</a> of the <a data-link-type="dfn" href="#context-object">context object</a> that are <a data-link-type="dfn" href="#concept-element">elements</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" data-lt="prepend(nodes...)|prepend(nodes)" id="dom-parentnode-prepend">prepend(<var>nodes</var>)<a class="self-link" href="#dom-parentnode-prepend"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a> before the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. 
+    <li>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>.
+    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a> before the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" data-lt="append(nodes...)|append(nodes)" id="dom-parentnode-append">append(<var>nodes</var>)<a class="self-link" href="#dom-parentnode-append"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>node</var> to the <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li>Let <var>node</var> be the result of <a data-link-type="dfn" href="#converting-nodes-into-a-node">converting <var>nodes</var> into a node</a>.
+    <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>node</var> to the <a data-link-type="dfn" href="#context-object">context object</a>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="ParentNode" data-dfn-type="method" data-export="" id="dom-parentnode-query"><code>query(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-parentnode-query"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a> <var>relativeSelectors</var> against
 a set consisting of <a data-link-type="dfn" href="#context-object">context object</a>, and null if the result is an empty list.</p>
@@ -1219,12 +1249,12 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="non
 <a data-link-type="idl-name" href="#characterdata">CharacterData</a> implements <a data-link-type="idl-name" href="#nondocumenttypechildnode">NonDocumentTypeChildNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling</a></code></code> 
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling</a></code></code>
     <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that
- is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
-    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-nextelementsibling">nextElementSibling</a></code></code> 
+ is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise.
+    <dt><code><var>element</var> = <var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-nondocumenttypechildnode-nextelementsibling">nextElementSibling</a></code></code>
     <dd>Returns the first <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that
- is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise. 
+ is an <a data-link-type="dfn" href="#concept-element">element</a>, and null otherwise.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="NonDocumentTypeChildNode" data-dfn-type="attribute" data-export="" id="dom-nondocumenttypechildnode-previouselementsibling">previousElementSibling<a class="self-link" href="#dom-nondocumenttypechildnode-previouselementsibling"></a></dfn> attribute must return the first <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <a data-link-type="dfn" href="#concept-tree-sibling">sibling</a> that is an <a data-link-type="dfn" href="#concept-element">element</a>,
 and null otherwise.</p>
@@ -1244,23 +1274,23 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="chi
 <a data-link-type="idl-name" href="#characterdata">CharacterData</a> implements <a data-link-type="idl-name" href="#childnode">ChildNode</a>;
 </pre>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-before">before(nodes)</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-before">before(nodes)</a></code></code>
     <dd>
       Inserts <var>nodes</var> just before <var>node</var>,
-  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
+  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>.
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-after">after(nodes)</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-after">after(nodes)</a></code></code>
     <dd>
       Inserts <var>nodes</var> just after <var>node</var>,
-  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
+  while replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>.
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-replacewith">replaceWith(nodes)</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-replacewith">replaceWith(nodes)</a></code></code>
     <dd>
       Replaces <var>node</var> with <var>nodes</var>, while
-  replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
+  replacing strings in <var>nodes</var> with equivalent <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>.
      <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">Throws</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> if the constraints of the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> are violated.</p>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-remove">remove()</a></code></code> 
-    <dd>Removes <var>node</var>. 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-childnode-remove">remove()</a></code></code>
+    <dd>Removes <var>node</var>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="ChildNode" data-dfn-type="method" data-export="" data-lt="before(nodes...)|before(nodes)" id="dom-childnode-before"><code>before(<var>nodes</var>)</code><a class="self-link" href="#dom-childnode-before"></a></dfn> method, when
 invoked, must run these steps:</p>
@@ -1324,18 +1354,18 @@ these steps:</p>
 };
 </pre>
    <div class="XXX">
-     IDL bugs: <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20020"> Array subclassing</a> and <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=23225">class, not interface</a>. 
+     IDL bugs: <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=20020"> Array subclassing</a> and <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=23225">class, not interface</a>.
     <p><code class="idl"><a data-link-type="idl" href="#elements">Elements</a></code> is a subclass of <code class="idl"><a data-link-type="idl">Array</a></code> with two additional methods. It replaces the need
 for <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> and <code class="idl"><a data-link-type="idl" href="#nodelist">NodeList</a></code>. (If <a data-link-type="dfn" href="#concept-node">nodes</a> need to be represented rather
 than <a data-link-type="dfn" href="#concept-element">elements</a> a simple <code class="idl"><a data-link-type="idl">Array</a></code> can be used.)</p>
    </div>
    <dl class="domintro">
-    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-query-relativeselectors">query(relativeSelectors)</a></code></code> 
+    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-query-relativeselectors">query(relativeSelectors)</a></code></code>
     <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> that is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>elements</var> that
-  matches <var>relativeSelectors</var>. 
-    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-queryall-relativeselectors">queryAll(relativeSelectors)</a></code></code> 
+  matches <var>relativeSelectors</var>.
+    <dt><code><var>elements</var> . <code class="idl"><a data-link-type="idl" href="#dom-elements-queryall-relativeselectors">queryAll(relativeSelectors)</a></code></code>
     <dd> Returns all <a data-link-type="dfn" href="#concept-element">element</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of <var>elements</var> that
-  match <var>relativeSelectors</var>. 
+  match <var>relativeSelectors</var>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Elements" data-dfn-type="method" data-export="" id="dom-elements-query-relativeselectors"><code>query(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-elements-query-relativeselectors"></a></dfn> method, when invoked, must return the first result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a> <var>relativeSelectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>, and null if the result is an empty list.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Elements" data-dfn-type="method" data-export="" id="dom-elements-queryall-relativeselectors"><code>queryAll(<var>relativeSelectors</var>)</code><a class="self-link" href="#dom-elements-queryall-relativeselectors"></a></dfn> method, when invoked, must return the result of running <code class="lang-javascript highlight"><span class="k">this</span><span class="p">.</span><span class="nx">constructor</span></code> with the result of running <a data-link-type="dfn" href="#match-a-relative-selectors-string">match a relative selectors string</a> <var>relativeSelectors</var> against the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
@@ -1361,11 +1391,11 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="nod
 };
 </pre>
    <dl class="domintro">
-    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-length">length</a></code> 
-    <dd> Returns the number of <a data-link-type="dfn" href="#concept-node">nodes</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>. 
-    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-item">item(index)</a></code> 
-    <dt><var>element</var> = <var>collection</var>[<var>index</var>] 
-    <dd> Returns the <a data-link-type="dfn" href="#concept-node">node</a> with index <var>index</var> from the <a data-link-type="dfn" href="#concept-collection">collection</a>. The <a data-link-type="dfn" href="#concept-node">nodes</a> are sorted in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-length">length</a></code>
+    <dd> Returns the number of <a data-link-type="dfn" href="#concept-node">nodes</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a>.
+    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-nodelist-item">item(index)</a></code>
+    <dt><var>element</var> = <var>collection</var>[<var>index</var>]
+    <dd> Returns the <a data-link-type="dfn" href="#concept-node">node</a> with index <var>index</var> from the <a data-link-type="dfn" href="#concept-collection">collection</a>. The <a data-link-type="dfn" href="#concept-node">nodes</a> are sorted in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
    </dl>
    <div class="impl">
     <p>The object’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a> are the numbers in the range zero to one less than the number of nodes <a data-link-type="dfn" href="#represented-by-the-collection">represented by the collection</a>. If there are no such elements, then
@@ -1388,16 +1418,16 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="htm
    <p class="note no-backref" role="note"><code class="idl"><a data-link-type="idl" href="#elements">Elements</a></code> is the better solution for representing a <a data-link-type="dfn" href="#concept-collection">collection</a> of <a data-link-type="dfn" href="#concept-element">elements</a>. <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> is an historical artifact we
 cannot rid the web of. </p>
    <dl class="domintro">
-    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-length">length</a></code> 
+    <dt><var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-length">length</a></code>
     <dd> Returns the number of <a data-link-type="dfn" href="#concept-element">elements</a> in
-  the <a data-link-type="dfn" href="#concept-collection">collection</a>. 
-    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-item">item(index)</a></code> 
-    <dt><var>element</var> = <var>collection</var>[<var>index</var>] 
+  the <a data-link-type="dfn" href="#concept-collection">collection</a>.
+    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-item">item(index)</a></code>
+    <dt><var>element</var> = <var>collection</var>[<var>index</var>]
     <dd> Returns the <a data-link-type="dfn" href="#concept-element">element</a> with index <var>index</var> from the <a data-link-type="dfn" href="#concept-collection">collection</a>.
-  The <a data-link-type="dfn" href="#concept-element">elements</a> are sorted in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
-    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-nameditem">namedItem(name)</a></code> 
-    <dt><var>element</var> = <var>collection</var>[<var>name</var>] 
-    <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> with <a data-link-type="dfn" href="#concept-id">ID</a> or name <var>name</var> from the collection. 
+  The <a data-link-type="dfn" href="#concept-element">elements</a> are sorted in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
+    <dt><var>element</var> = <var>collection</var> . <code class="idl"><a data-link-type="idl" href="#dom-htmlcollection-nameditem">namedItem(name)</a></code>
+    <dt><var>element</var> = <var>collection</var>[<var>name</var>]
+    <dd> Returns the first <a data-link-type="dfn" href="#concept-element">element</a> with <a data-link-type="dfn" href="#concept-id">ID</a> or name <var>name</var> from the collection.
    </dl>
    <p>The object’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a> are the numbers in the range zero to one less than
 the number of elements <a data-link-type="dfn" href="#represented-by-the-collection">represented by the collection</a>. If there are no such elements, then
@@ -1433,8 +1463,8 @@ invoked, must run these steps: </p>
      <p>Return the first <a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#concept-collection">collection</a> for which at least one of
   the following is true: </p>
      <ul>
-      <li>it has an <a data-link-type="dfn" href="#concept-id">ID</a> which is <var>key</var>; 
-      <li>it is in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> a <a data-link-type="dfn" href="#concept-named-attribute"><code>name</code> attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>key</var>; 
+      <li>it has an <a data-link-type="dfn" href="#concept-id">ID</a> which is <var>key</var>;
+      <li>it is in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> a <a data-link-type="dfn" href="#concept-named-attribute"><code>name</code> attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>key</var>;
      </ul>
      <p>or null if there is no such <a data-link-type="dfn" href="#concept-element">element</a>. </p>
    </ol>
@@ -1444,22 +1474,22 @@ associated list of <code class="idl"><a data-link-type="idl" href="#mutationobse
    <p>To <dfn data-dfn-type="dfn" data-export="" id="queue-a-mutation-observer-compound-microtask">queue a mutation observer compound microtask<a class="self-link" href="#queue-a-mutation-observer-compound-microtask"></a></dfn>, run these steps:</p>
    <ol>
     <li>If <a data-link-type="dfn" href="#mutation-observer-compound-microtask-queued-flag">mutation observer compound microtask queued flag</a> is set, terminate
- these steps. 
-    <li>Set <a data-link-type="dfn" href="#mutation-observer-compound-microtask-queued-flag">mutation observer compound microtask queued flag</a>. 
-    <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue</a> a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#compound-microtask">compound microtask</a> to <a data-link-type="dfn" href="#notify-mutation-observers">notify mutation observers</a>. 
+ these steps.
+    <li>Set <a data-link-type="dfn" href="#mutation-observer-compound-microtask-queued-flag">mutation observer compound microtask queued flag</a>.
+    <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">Queue</a> a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#compound-microtask">compound microtask</a> to <a data-link-type="dfn" href="#notify-mutation-observers">notify mutation observers</a>.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="notify-mutation-observers">notify mutation observers<a class="self-link" href="#notify-mutation-observers"></a></dfn>, run these steps:</p>
    <ol>
-    <li>Unset <a data-link-type="dfn" href="#mutation-observer-compound-microtask-queued-flag">mutation observer compound microtask queued flag</a>. 
+    <li>Unset <a data-link-type="dfn" href="#mutation-observer-compound-microtask-queued-flag">mutation observer compound microtask queued flag</a>.
     <li>Let <var>notify list</var> be a copy of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts">unit of related similar-origin browsing contexts</a>'
- list of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> objects. 
+ list of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> objects.
     <li>
-      For each <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object <var>mo</var> in <var>notify list</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#execute-a-compound-microtask-subtask">execute a compound microtask subtask</a> to run these steps: <a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
+      For each <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object <var>mo</var> in <var>notify list</var>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#execute-a-compound-microtask-subtask">execute a compound microtask subtask</a> to run these steps: <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
      <ol>
-      <li>Let <var>queue</var> be a copy of <var>mo</var>’s <a data-link-type="dfn" href="#concept-mo-queue">record queue</a>. 
-      <li>Empty <var>mo</var>’s <a data-link-type="dfn" href="#concept-mo-queue">record queue</a>. 
-      <li>Remove all <a data-link-type="dfn" href="#transient-registered-observer">transient registered observers</a> whose <b>observer</b> is <var>mo</var>. 
-      <li>If <var>queue</var> is non-empty, call <var>mo</var>’s <a data-link-type="dfn" href="#concept-mo-callback">callback</a> with <var>queue</var> as first argument, and <var>mo</var> (itself) as second argument and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-callback-this-value">callback this value</a>. If this throws an exception, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">report the exception</a>. 
+      <li>Let <var>queue</var> be a copy of <var>mo</var>’s <a data-link-type="dfn" href="#concept-mo-queue">record queue</a>.
+      <li>Empty <var>mo</var>’s <a data-link-type="dfn" href="#concept-mo-queue">record queue</a>.
+      <li>Remove all <a data-link-type="dfn" href="#transient-registered-observer">transient registered observers</a> whose <b>observer</b> is <var>mo</var>.
+      <li>If <var>queue</var> is non-empty, call <var>mo</var>’s <a data-link-type="dfn" href="#concept-mo-callback">callback</a> with <var>queue</var> as first argument, and <var>mo</var> (itself) as second argument and <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-callback-this-value">callback this value</a>. If this throws an exception, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">report the exception</a>.
      </ol>
    </ol>
    <hr>
@@ -1492,55 +1522,55 @@ dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="d
 to the <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-type="dfn" href="#concept-node">nodes</a>.</p>
    <p>Each <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object has these associated concepts:</p>
    <ul>
-    <li>A <dfn data-dfn-for="MutationObserver" data-dfn-type="dfn" data-export="" id="concept-mo-callback">callback<a class="self-link" href="#concept-mo-callback"></a></dfn> set on creation. 
-    <li>A list of <a data-link-type="dfn" href="#concept-node">nodes</a> on which it is a <a data-link-type="dfn" href="#registered-observer">registered observer</a>’s <b>observer</b> that is initially empty. 
-    <li>A list of <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code> objects called the <dfn data-dfn-for="MutationObserver" data-dfn-type="dfn" data-export="" id="concept-mo-queue">record queue<a class="self-link" href="#concept-mo-queue"></a></dfn> that is initially empty. 
+    <li>A <dfn data-dfn-for="MutationObserver" data-dfn-type="dfn" data-export="" id="concept-mo-callback">callback<a class="self-link" href="#concept-mo-callback"></a></dfn> set on creation.
+    <li>A list of <a data-link-type="dfn" href="#concept-node">nodes</a> on which it is a <a data-link-type="dfn" href="#registered-observer">registered observer</a>’s <b>observer</b> that is initially empty.
+    <li>A list of <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code> objects called the <dfn data-dfn-for="MutationObserver" data-dfn-type="dfn" data-export="" id="concept-mo-queue">record queue<a class="self-link" href="#concept-mo-queue"></a></dfn> that is initially empty.
    </ul>
    <dl class="domintro">
-    <dt><code><var>observer</var> = new <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-mutationobserver">MutationObserver(callback)</a></code></code> 
+    <dt><code><var>observer</var> = new <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-mutationobserver">MutationObserver(callback)</a></code></code>
     <dd>Constructs a <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object and sets its <a data-link-type="dfn" href="#concept-mo-callback">callback</a> to <var>callback</var>. The <var>callback</var> is invoked with a
  list of <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code> objects as first argument and the
  constructed <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object as second argument. It is
  invoked after <a data-link-type="dfn" href="#concept-node">nodes</a> registered with the <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe()</a></code> method, are
- mutated. 
-    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe(target, options)</a></code></code> 
+ mutated.
+    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe(target, options)</a></code></code>
     <dd>
       Instructs the user agent to observe a given <var>target</var> (a <a data-link-type="dfn" href="#concept-node">node</a>) and report any mutations based on
-  the criteria given by <var>options</var> (an object). 
+  the criteria given by <var>options</var> (an object).
      <p>The <var>options</var> argument allows for setting mutation
   observation options via object members. These are the object members that
   can be used:</p>
      <dl>
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code> 
-      <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> are to be observed. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> 
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code>
+      <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-tree-child">children</a> are to be observed.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>
       <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-attribute">attributes</a> are to be observed. Can be omitted if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> and/or <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is
-   specified. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> 
-      <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> are to be observed. Can be omitted if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is specified. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code> 
+   specified.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code>
+      <dd>Set to true if mutations to <var>target</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> are to be observed. Can be omitted if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is specified.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-subtree">subtree</a></code>
       <dd>Set to true if mutations to not just <var>target</var>, but
    also <var>target</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> are to be
-   observed. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> 
+   observed.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code>
       <dd>Set to true if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is true or omitted
    and <var>target</var>’s <a data-link-type="dfn" href="#concept-attribute">attribute</a> <a data-link-type="dfn" href="#concept-attribute-value">value</a> before the mutation
-   needs to be recorded. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> 
+   needs to be recorded.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code>
       <dd>Set to true if <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is set to true or omitted and <var>target</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> before the mutation
-   needs to be recorded. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> 
+   needs to be recorded.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code>
       <dd>Set to a list of <a data-link-type="dfn" href="#concept-attribute">attribute</a> <a data-link-type="dfn" href="#concept-attribute-local-name">local names</a> (without <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>) if not all <a data-link-type="dfn" href="#concept-attribute">attribute</a> mutations need to be
    observed and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is true
-   or omitted. 
+   or omitted.
      </dl>
-    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-disconnect">disconnect()</a></code></code> 
+    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-disconnect">disconnect()</a></code></code>
     <dd>Stops <var>observer</var> from observing any mutations.
  Until the <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-observe">observe()</a></code> method
- is used again, <var>observer</var>’s <a data-link-type="dfn" href="#concept-mo-callback">callback</a> will not be invoked. 
-    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-takerecords">takeRecords()</a></code></code> 
+ is used again, <var>observer</var>’s <a data-link-type="dfn" href="#concept-mo-callback">callback</a> will not be invoked.
+    <dt><code><var>observer</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationobserver-takerecords">takeRecords()</a></code></code>
     <dd>Empties the <a data-link-type="dfn" href="#concept-mo-queue">record queue</a> and
- returns what was in there. 
+ returns what was in there.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="MutationObserver" data-dfn-type="constructor" data-export="" id="dom-mutationobserver-mutationobserver">MutationObserver(<var>callback</var>)<a class="self-link" href="#dom-mutationobserver-mutationobserver"></a></dfn> constructor must create a new <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> object with <a data-link-type="dfn" href="#concept-mo-callback">callback</a> set to <var>callback</var>,
 append it to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts">unit of related similar-origin browsing contexts</a>' list
@@ -1548,23 +1578,23 @@ of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationOb
    <p>The <dfn class="idl-code" data-dfn-for="MutationObserver" data-dfn-type="method" data-export="" id="dom-mutationobserver-observe">observe(<var>target</var>, <var>options</var>)<a class="self-link" href="#dom-mutationobserver-observe"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
     <li>If either <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
- and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is omitted, set <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> to true. 
-    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is present and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is omitted, set <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> to true. 
-    <li>If none of <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code> <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+ and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is omitted, set <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> to true.
+    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is present and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is omitted, set <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> to true.
+    <li>If none of <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-childlist">childList</a></code> <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is true, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>.
     <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributeoldvalue">attributeOldValue</a></code> is true
- and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+ and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>.
     <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributefilter">attributeFilter</a></code> is present
- and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
-    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is true and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. 
+ and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-attributes">attributes</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>.
+    <li>If <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdataoldvalue">characterDataOldValue</a></code> is true and <var>options</var>’ <code class="idl"><a data-link-type="idl" href="#dom-mutationobserverinit-characterdata">characterData</a></code> is false, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>.
     <li>
       For each <a data-link-type="dfn" href="#registered-observer">registered observer</a> <var>registered</var> in <var>target</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a> whose <b>observer</b> is
-  the <a data-link-type="dfn" href="#context-object">context object</a>: 
+  the <a data-link-type="dfn" href="#context-object">context object</a>:
      <ol>
-      <li>Remove all <a data-link-type="dfn" href="#transient-registered-observer">transient registered observers</a> whose <b>source</b> is <var>registered</var>. 
-      <li>Replace <var>registered</var>’s <b>options</b> with <var>options</var>. 
+      <li>Remove all <a data-link-type="dfn" href="#transient-registered-observer">transient registered observers</a> whose <b>source</b> is <var>registered</var>.
+      <li>Replace <var>registered</var>’s <b>options</b> with <var>options</var>.
      </ol>
     <li>Otherwise, add a new <a data-link-type="dfn" href="#registered-observer">registered observer</a> to <var>target</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a> with the <a data-link-type="dfn" href="#context-object">context object</a> as the <b>observer</b> and <var>options</var> as the <b>options</b>,
- and add <var>target</var> to <a data-link-type="dfn" href="#context-object">context object</a>’s list of <a data-link-type="dfn" href="#concept-node">nodes</a> on which it is registered. 
+ and add <var>target</var> to <a data-link-type="dfn" href="#context-object">context object</a>’s list of <a data-link-type="dfn" href="#concept-node">nodes</a> on which it is registered.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="MutationObserver" data-dfn-type="method" data-export="" id="dom-mutationobserver-disconnect">disconnect()<a class="self-link" href="#dom-mutationobserver-disconnect"></a></dfn> method must, for each <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> in the <a data-link-type="dfn" href="#context-object">context object</a>’s list of <a data-link-type="dfn" href="#concept-node">nodes</a>, remove any <a data-link-type="dfn" href="#registered-observer">registered observer</a> on <var>node</var> for which the <a data-link-type="dfn" href="#context-object">context object</a> is the <b>observer</b>, and also
 empty <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-mo-queue">record queue</a>.</p>
@@ -1574,38 +1604,38 @@ empty <a data-link-type="dfn" href="#context-object">context object</a>’s <a d
 previousSibling <var>previousSibling</var>, and nextSibling <var>nextSibling</var>, run these steps:</p>
    <ol>
     <li>Let <var>interested observers</var> be an initially empty set
- of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> objects optionally paired with a string. 
-    <li>Let <var>nodes</var> be the <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestors</a> of <var>target</var>. 
+ of <code class="idl"><a data-link-type="idl" href="#mutationobserver">MutationObserver</a></code> objects optionally paired with a string.
+    <li>Let <var>nodes</var> be the <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestors</a> of <var>target</var>.
     <li>
       Then, for each <var>node</var> in <var>nodes</var>, and
-  then for each <var>registered observer</var> (with <var>registered observer</var>’s <b>options</b> as <var>options</var>) in <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>: 
+  then for each <var>registered observer</var> (with <var>registered observer</var>’s <b>options</b> as <var>options</var>) in <var>node</var>’s list of <a data-link-type="dfn" href="#registered-observer">registered observers</a>:
      <ol>
-      <li>If <var>node</var> is not <var>target</var> and <var>options</var>’ <code>subtree</code> is false, continue. 
-      <li>If <var>type</var> is "<code>attributes</code>" and <var>options</var>’ <code>attributes</code> is not true, continue. 
-      <li>If <var>type</var> is "<code>attributes</code>", <var>options</var>’ <code>attributeFilter</code> is present, and either <var>options</var>’ <code>attributeFilter</code> does not contain <var>name</var> or <var>namespace</var> is non-null, continue. 
-      <li>If <var>type</var> is "<code>characterData</code>" and <var>options</var>’ <code>characterData</code> is not true, continue. 
-      <li>If <var>type</var> is "<code>childList</code>" and <var>options</var>’ <code>childList</code> is false, continue. 
+      <li>If <var>node</var> is not <var>target</var> and <var>options</var>’ <code>subtree</code> is false, continue.
+      <li>If <var>type</var> is "<code>attributes</code>" and <var>options</var>’ <code>attributes</code> is not true, continue.
+      <li>If <var>type</var> is "<code>attributes</code>", <var>options</var>’ <code>attributeFilter</code> is present, and either <var>options</var>’ <code>attributeFilter</code> does not contain <var>name</var> or <var>namespace</var> is non-null, continue.
+      <li>If <var>type</var> is "<code>characterData</code>" and <var>options</var>’ <code>characterData</code> is not true, continue.
+      <li>If <var>type</var> is "<code>childList</code>" and <var>options</var>’ <code>childList</code> is false, continue.
       <li>If <var>registered observer</var>’s <b>observer</b> is
-   not in <var>interested observers</var>, append <var>registered observer</var>’s <b>observer</b> to <var>interested observers</var>. 
+   not in <var>interested observers</var>, append <var>registered observer</var>’s <b>observer</b> to <var>interested observers</var>.
       <li>If either <var>type</var> is "<code>attributes</code>"
    and <var>options</var>’ <code>attributeOldValue</code> is true, or <var>type</var> is "<code>characterData</code>" and <var>options</var>’ <code>characterDataOldValue</code> is true,
-   set the paired string of <var>registered observer</var>’s <b>observer</b> in <var>interested observers</var> to <var>oldValue</var>. 
+   set the paired string of <var>registered observer</var>’s <b>observer</b> in <var>interested observers</var> to <var>oldValue</var>.
      </ol>
     <li>
-      Then, for each <var>observer</var> in <var>interested observers</var>: 
+      Then, for each <var>observer</var> in <var>interested observers</var>:
      <ol>
-      <li>Let <var>record</var> be a new <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code> object with its <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code> set to <var>type</var> and <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-target">target</a></code> set to <var>target</var>. 
+      <li>Let <var>record</var> be a new <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code> object with its <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code> set to <var>type</var> and <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-target">target</a></code> set to <var>target</var>.
       <li>If <var>name</var> and <var>namespace</var> are given,
-   set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributename">attributeName</a></code> to <var>name</var>, and <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributenamespace">attributeNamespace</a></code> to <var>namespace</var>. 
-      <li>If <var>addedNodes</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-addednodes">addedNodes</a></code> to <var>addedNodes</var>. 
-      <li>If <var>removedNodes</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-removednodes">removedNodes</a></code> to <var>removedNodes</var>, 
-      <li>If <var>previousSibling</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-previoussibling">previousSibling</a></code> to <var>previousSibling</var>. 
-      <li>If <var>nextSibling</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-nextsibling">nextSibling</a></code> to <var>nextSibling</var>. 
+   set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributename">attributeName</a></code> to <var>name</var>, and <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributenamespace">attributeNamespace</a></code> to <var>namespace</var>.
+      <li>If <var>addedNodes</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-addednodes">addedNodes</a></code> to <var>addedNodes</var>.
+      <li>If <var>removedNodes</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-removednodes">removedNodes</a></code> to <var>removedNodes</var>,
+      <li>If <var>previousSibling</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-previoussibling">previousSibling</a></code> to <var>previousSibling</var>.
+      <li>If <var>nextSibling</var> is given, set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-nextsibling">nextSibling</a></code> to <var>nextSibling</var>.
       <li>If <var>observer</var> has a paired string,
-   set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-oldvalue">oldValue</a></code> to <var>observer</var>’s paired string. 
-      <li>Append <var>record</var> to <var>observer</var>’s <a data-link-type="dfn" href="#concept-mo-queue">record queue</a>. 
+   set <var>record</var>’s <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-oldvalue">oldValue</a></code> to <var>observer</var>’s paired string.
+      <li>Append <var>record</var> to <var>observer</var>’s <a data-link-type="dfn" href="#concept-mo-queue">record queue</a>.
      </ol>
-    <li><a data-link-type="dfn" href="#queue-a-mutation-observer-compound-microtask">Queue a mutation observer compound microtask</a>. 
+    <li><a data-link-type="dfn" href="#queue-a-mutation-observer-compound-microtask">Queue a mutation observer compound microtask</a>.
    </ol>
    <h4 class="heading settled" data-level="4.3.3" id="interface-mutationrecord"><span class="secno">4.3.3. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#mutationrecord">MutationRecord</a></code></span><a class="self-link" href="#interface-mutationrecord"></a></h4>
 <pre class="idl">[Exposed=Window]
@@ -1622,36 +1652,36 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mut
 };
 </pre>
    <dl class="domintro">
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code></code> 
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code></code>
     <dd>Returns "<code>attributes</code>" if it was an <a data-link-type="dfn" href="#concept-attribute">attribute</a> mutation.
  "<code>characterData</code>" if it was a mutation to a <code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. And
- "<code>childList</code>" if it was a mutation to the <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-type="dfn" href="#concept-node">nodes</a>. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-target">target</a></code></code> 
+ "<code>childList</code>" if it was a mutation to the <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-type="dfn" href="#concept-node">nodes</a>.
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-target">target</a></code></code>
     <dd>Returns the <a data-link-type="dfn" href="#concept-node">node</a> the mutation
  affected, depending on the <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code>.
  For "<code>attributes</code>", it is the <a data-link-type="dfn" href="#concept-element">element</a> whose <a data-link-type="dfn" href="#concept-attribute">attribute</a> changed. For
  "<code>characterData</code>", it is the <code class="idl"><a data-link-type="idl" href="#characterdata">CharacterData</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. For "<code>childList</code>",
- it is the <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-child">children</a> changed. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-addednodes">addedNodes</a></code></code> 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-removednodes">removedNodes</a></code></code> 
+ it is the <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-child">children</a> changed.
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-addednodes">addedNodes</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-removednodes">removedNodes</a></code></code>
     <dd>Return the <a data-link-type="dfn" href="#concept-node">nodes</a> added and removed
- respectively. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-previoussibling">previousSibling</a></code></code> 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-nextsibling">nextSibling</a></code></code> 
+ respectively.
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-previoussibling">previousSibling</a></code></code>
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-nextsibling">nextSibling</a></code></code>
     <dd>Return the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous</a> and <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> respectively
- of the added or removed <a data-link-type="dfn" href="#concept-node">nodes</a>, and null otherwise. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributename">attributeName</a></code></code> 
+ of the added or removed <a data-link-type="dfn" href="#concept-node">nodes</a>, and null otherwise.
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributename">attributeName</a></code></code>
     <dd>Returns the <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> of the
- changed <a data-link-type="dfn" href="#concept-attribute">attribute</a>, and null otherwise. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributenamespace">attributeNamespace</a></code></code> 
+ changed <a data-link-type="dfn" href="#concept-attribute">attribute</a>, and null otherwise.
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-attributenamespace">attributeNamespace</a></code></code>
     <dd>Returns the <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> of the
- changed <a data-link-type="dfn" href="#concept-attribute">attribute</a>, and null otherwise. 
-    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-oldvalue">oldValue</a></code></code> 
+ changed <a data-link-type="dfn" href="#concept-attribute">attribute</a>, and null otherwise.
+    <dt><code><var>record</var> . <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-oldvalue">oldValue</a></code></code>
     <dd>The return value depends on <code class="idl"><a data-link-type="idl" href="#dom-mutationrecord-type">type</a></code>. For
  "<code>attributes</code>", it is the <a data-link-type="dfn" href="#concept-attribute-value">value</a> of the
  changed <a data-link-type="dfn" href="#concept-attribute">attribute</a> before the change.
  For "<code>characterData</code>", it is the <a data-link-type="dfn" href="#concept-cd-data">data</a> of the changed <a data-link-type="dfn" href="#concept-node">node</a> before the change. For
- "<code>childList</code>", it is null. 
+ "<code>childList</code>", it is null.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="MutationRecord" data-dfn-type="attribute" data-export="" id="dom-mutationrecord-type">type<a class="self-link" href="#dom-mutationrecord-type"></a></dfn> and <dfn class="idl-code" data-dfn-for="MutationRecord" data-dfn-type="attribute" data-export="" id="dom-mutationrecord-target">target<a class="self-link" href="#dom-mutationrecord-target"></a></dfn> attributes must return the values they were initialized to.</p>
    <p>The <dfn class="idl-code" data-dfn-for="MutationRecord" data-dfn-type="attribute" data-export="" id="dom-mutationrecord-addednodes">addedNodes<a class="self-link" href="#dom-mutationrecord-addednodes"></a></dfn> and <dfn class="idl-code" data-dfn-for="MutationRecord" data-dfn-type="attribute" data-export="" id="dom-mutationrecord-removednodes">removedNodes<a class="self-link" href="#dom-mutationrecord-removednodes"></a></dfn> attributes must return the values they were initialized to. Unless stated
@@ -1727,116 +1757,116 @@ that is a <a data-link-type="dfn" href="#concept-document">document</a>.</p>
    <p class="note no-backref" role="note">A <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> can be changed by the <a data-link-type="dfn" href="#concept-node-adopt">adopt</a> algorithm. </p>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code></code>
     <dd>
-      Returns the type of <var>node</var>, represented by a number from the following list: 
+      Returns the type of <var>node</var>, represented by a number from the following list:
      <dl>
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-element_node">ELEMENT_NODE</a></code></code> (1) 
-      <dd><var>node</var> is an <a data-link-type="dfn" href="#concept-element">element</a>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-text_node">TEXT_NODE</a></code></code> (3) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE</a></code></code> (7) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-comment_node">COMMENT_NODE</a></code></code> (8) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_node">DOCUMENT_NODE</a></code></code> (9) 
-      <dd><var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_type_node">DOCUMENT_TYPE_NODE</a></code></code> (10) 
-      <dd><var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_fragment_node">DOCUMENT_FRAGMENT_NODE</a></code></code> (11) 
-      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-element_node">ELEMENT_NODE</a></code></code> (1)
+      <dd><var>node</var> is an <a data-link-type="dfn" href="#concept-element">element</a>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-text_node">TEXT_NODE</a></code></code> (3)
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE</a></code></code> (7)
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-comment_node">COMMENT_NODE</a></code></code> (8)
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_node">DOCUMENT_NODE</a></code></code> (9)
+      <dd><var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_type_node">DOCUMENT_TYPE_NODE</a></code></code> (10)
+      <dd><var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_fragment_node">DOCUMENT_FRAGMENT_NODE</a></code></code> (11)
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
      </dl>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodename">nodeName</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodename">nodeName</a></code></code>
     <dd>
       Returns a string appropriate for the type of <var>node</var>, as
-  follows: 
+  follows:
      <dl>
-      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
-      <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value. 
-      <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-      <dd>"<code>#text</code>". 
-      <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-      <dd>Its <a data-link-type="dfn" href="#concept-pi-target">target</a>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-      <dd>"<code>#comment</code>". 
-      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
-      <dd>"<code>#document</code>". 
-      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-      <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-      <dd>"<code>#document-fragment</code>". 
+      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+      <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value.
+      <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+      <dd>"<code>#text</code>".
+      <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+      <dd>Its <a data-link-type="dfn" href="#concept-pi-target">target</a>.
+      <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+      <dd>"<code>#comment</code>".
+      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+      <dd>"<code>#document</code>".
+      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+      <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>.
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+      <dd>"<code>#document-fragment</code>".
      </dl>
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nodetype">nodeType<a class="self-link" href="#dom-node-nodetype"></a></dfn> attribute’s getter, when invoked, must return
 the first matching statement, switching on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
-    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-element_node">ELEMENT_NODE<a class="self-link" href="#dom-node-element_node"></a></dfn> (1) 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-text_node">TEXT_NODE<a class="self-link" href="#dom-node-text_node"></a></dfn> (3); 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE<a class="self-link" href="#dom-node-processing_instruction_node"></a></dfn> (7); 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-comment_node">COMMENT_NODE<a class="self-link" href="#dom-node-comment_node"></a></dfn> (8); 
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
-    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_node">DOCUMENT_NODE<a class="self-link" href="#dom-node-document_node"></a></dfn> (9); 
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_type_node">DOCUMENT_TYPE_NODE<a class="self-link" href="#dom-node-document_type_node"></a></dfn> (10); 
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_fragment_node">DOCUMENT_FRAGMENT_NODE<a class="self-link" href="#dom-node-document_fragment_node"></a></dfn> (11). 
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-element_node">ELEMENT_NODE<a class="self-link" href="#dom-node-element_node"></a></dfn> (1)
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-text_node">TEXT_NODE<a class="self-link" href="#dom-node-text_node"></a></dfn> (3);
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE<a class="self-link" href="#dom-node-processing_instruction_node"></a></dfn> (7);
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-comment_node">COMMENT_NODE<a class="self-link" href="#dom-node-comment_node"></a></dfn> (8);
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_node">DOCUMENT_NODE<a class="self-link" href="#dom-node-document_node"></a></dfn> (9);
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_type_node">DOCUMENT_TYPE_NODE<a class="self-link" href="#dom-node-document_type_node"></a></dfn> (10);
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_fragment_node">DOCUMENT_FRAGMENT_NODE<a class="self-link" href="#dom-node-document_fragment_node"></a></dfn> (11).
    </dl>
    <p></p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nodename">nodeName<a class="self-link" href="#dom-node-nodename"></a></dfn> attribute’s getter, when invoked, must return
 the first matching statement, switching on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
-    <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value. 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dd>"<code>#text</code>". 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-    <dd>Its <a data-link-type="dfn" href="#concept-pi-target">target</a>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dd>"<code>#comment</code>". 
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
-    <dd>"<code>#document</code>". 
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-    <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-    <dd>"<code>#document-fragment</code>". 
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+    <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value.
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dd>"<code>#text</code>".
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dd>Its <a data-link-type="dfn" href="#concept-pi-target">target</a>.
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dd>"<code>#comment</code>".
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
+    <dd>"<code>#document</code>".
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>.
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dd>"<code>#document-fragment</code>".
    </dl>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-baseuri">baseURI</a></code></code> 
-    <dd>Returns <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>’s <a data-link-type="dfn" href="#concept-document-base-url">base URL</a>. 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-baseuri">baseURI</a></code></code>
+    <dd>Returns <var>node</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>’s <a data-link-type="dfn" href="#concept-document-base-url">base URL</a>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-baseuri"><code>baseURI</code><a class="self-link" href="#dom-node-baseuri"></a></dfn> attribute’s getter must return <a data-link-type="dfn" href="#concept-node-document">node document</a>’s <a data-link-type="dfn" href="#concept-document-base-url">base URL</a>, <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a>.</p>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-ownerdocument">ownerDocument</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-ownerdocument">ownerDocument</a></code></code>
     <dd> Returns the <a data-link-type="dfn" href="#concept-node-document">node document</a>.
-  Returns null for <a data-link-type="dfn" href="#concept-document">documents</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentnode">parentNode</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentelement">parentElement</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#parent-element">parent element</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-haschildnodes">hasChildNodes()</a></code></code> 
-    <dd>Returns whether <var>node</var> has <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-childnodes">childNodes</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-firstchild">firstChild</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-lastchild">lastChild</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-last-child">last child</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-previoussibling">previousSibling</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nextsibling">nextSibling</a></code></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
+  Returns null for <a data-link-type="dfn" href="#concept-document">documents</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentnode">parentNode</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-parentelement">parentElement</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#parent-element">parent element</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-haschildnodes">hasChildNodes()</a></code></code>
+    <dd>Returns whether <var>node</var> has <a data-link-type="dfn" href="#concept-tree-child">children</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-childnodes">childNodes</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-child">children</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-firstchild">firstChild</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-lastchild">lastChild</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-last-child">last child</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-previoussibling">previousSibling</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nextsibling">nextSibling</a></code></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
    </dl>
    <div class="impl">
     <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-ownerdocument">ownerDocument<a class="self-link" href="#dom-node-ownerdocument"></a></dfn> attribute must run these steps:</p>
     <ol>
-     <li>If the <a data-link-type="dfn" href="#context-object">context object</a> is a <a data-link-type="dfn" href="#concept-document">document</a>, return null. 
-     <li>Return the <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
+     <li>If the <a data-link-type="dfn" href="#context-object">context object</a> is a <a data-link-type="dfn" href="#concept-document">document</a>, return null.
+     <li>Return the <a data-link-type="dfn" href="#concept-node-document">node document</a>.
     </ol>
     <div class="note" role="note"> The <a data-link-type="dfn" href="#concept-node-document">node document</a> of a <a data-link-type="dfn" href="#concept-document">document</a> is that <a data-link-type="dfn" href="#concept-document">document</a> itself.
 All <a data-link-type="dfn" href="#concept-node">nodes</a> have a <a data-link-type="dfn" href="#concept-document">document</a> at all times. </div>
@@ -1853,95 +1883,95 @@ All <a data-link-type="dfn" href="#concept-node">nodes</a> have a <a data-link-t
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nodevalue">nodeValue<a class="self-link" href="#dom-node-nodevalue"></a></dfn> attribute
 must return the following, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-    <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
-    <dt>Any other node 
-    <dd>Null. 
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>.
+    <dt>Any other node
+    <dd>Null.
    </dl>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-node-nodevalue">nodeValue</a></code> attribute must,
 on setting, if the new value is null, act as if it was the empty string
 instead, and then do as described below, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
     <dd><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <a data-link-type="dfn" href="#context-object">context object</a>, offset 0, count <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value, and
- data new value. 
-    <dt>Any other node 
-    <dd>Do nothing. 
+ data new value.
+    <dt>Any other node
+    <dd>Do nothing.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-textcontent">textContent<a class="self-link" href="#dom-node-textcontent"></a></dfn> attribute must return the following, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
     <dd>The concatenation of <a data-link-type="dfn" href="#concept-cd-data">data</a> of all
- the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
-    <dt>Any other node 
-    <dd>Null. 
+ the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+    <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>.
+    <dt>Any other node
+    <dd>Null.
    </dl>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-node-textcontent">textContent</a></code> attribute must,
 on setting, if the new value is null, act as if it was the empty string
 instead, and then do as described below, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
     <dd>
      <ol>
-      <li>Let <var>node</var> be null. 
+      <li>Let <var>node</var> be null.
       <li>If new value is not the empty string, set <var>node</var> to
-   a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is new value. 
-      <li><a data-link-type="dfn" href="#concept-node-replace-all">Replace all</a> with <var>node</var> within the <a data-link-type="dfn" href="#context-object">context object</a>. 
+   a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is new value.
+      <li><a data-link-type="dfn" href="#concept-node-replace-all">Replace all</a> with <var>node</var> within the <a data-link-type="dfn" href="#context-object">context object</a>.
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
     <dd><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <a data-link-type="dfn" href="#context-object">context object</a>, offset 0, count <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value, and
- data new value. 
-    <dt>Any other node 
-    <dd>Do nothing. 
+ data new value.
+    <dt>Any other node
+    <dd>Do nothing.
    </dl>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-normalize">normalize()</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-normalize">normalize()</a></code></code>
     <dd>Removes <a data-link-type="dfn" href="#concept-node-empty">empty</a> <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> and concatenates
- the <a data-link-type="dfn" href="#concept-cd-data">data</a> of remaining <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> into the first of their <a data-link-type="dfn" href="#concept-node">nodes</a>. 
+ the <a data-link-type="dfn" href="#concept-cd-data">data</a> of remaining <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> into the first of their <a data-link-type="dfn" href="#concept-node">nodes</a>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-normalize">normalize()<a class="self-link" href="#dom-node-normalize"></a></dfn> method
 must run these steps:</p>
    <p>For each <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <ol>
-    <li>Let <var>node</var> be the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a>. 
-    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value. 
+    <li>Let <var>node</var> be the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a>.
+    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value.
     <li>If <var>length</var> is zero, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> and
- continue with the next <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, if any. 
-    <li>Let <var>data</var> be the concatenation of the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>node</var>’s <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> (excluding itself), in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+ continue with the next <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, if any.
+    <li>Let <var>data</var> be the concatenation of the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>node</var>’s <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> (excluding itself), in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
     <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>node</var>, offset <var>length</var>,
- count 0, and data <var>data</var>. 
-    <li>Let <var>current node</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
+ count 0, and data <var>data</var>.
+    <li>Let <var>current node</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
     <li>
-     While <var>current node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node: 
+     While <var>current node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node:
      <ol>
-      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>current node</var>, add <var>length</var> to its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> and set its <a data-link-type="dfn" href="#concept-range-start-node">start node</a> to <var>node</var>. 
-      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>current node</var>, add <var>length</var> to its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> and set its <a data-link-type="dfn" href="#concept-range-end-node">end node</a> to <var>node</var>. 
-      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>, set its <a data-link-type="dfn" href="#concept-range-start-node">start node</a> to <var>node</var> and its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> to <var>length</var>. 
-      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>, set its <a data-link-type="dfn" href="#concept-range-end-node">end node</a> to <var>node</var> and its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> to <var>length</var>. 
-      <li>Add <var>current node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value to <var>length</var>. 
-      <li>Set <var>current node</var> to its <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
+      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>current node</var>, add <var>length</var> to its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> and set its <a data-link-type="dfn" href="#concept-range-start-node">start node</a> to <var>node</var>.
+      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>current node</var>, add <var>length</var> to its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> and set its <a data-link-type="dfn" href="#concept-range-end-node">end node</a> to <var>node</var>.
+      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>, set its <a data-link-type="dfn" href="#concept-range-start-node">start node</a> to <var>node</var> and its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> to <var>length</var>.
+      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is <var>current node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>, set its <a data-link-type="dfn" href="#concept-range-end-node">end node</a> to <var>node</var> and its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> to <var>length</var>.
+      <li>Add <var>current node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value to <var>length</var>.
+      <li>Set <var>current node</var> to its <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
      </ol>
-    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>node</var>’s <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> (excluding itself), in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <li><a data-link-type="dfn" href="#concept-node-remove">Remove</a> <var>node</var>’s <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> (excluding itself), in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
    </ol>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-node-clonenode">cloneNode([<var>deep</var> = false])</a></code> 
-    <dd>Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>. 
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-isequalnode">isEqualNode(otherNode)</a></code></code> 
-    <dd>Returns whether <var>node</var> and <var>otherNode</var> have the same properties. 
+    <dt><code><var>node</var> . <a class="idl-code" data-link-type="method" href="#dom-node-clonenode">cloneNode([<var>deep</var> = false])</a></code>
+    <dd>Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>.
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-isequalnode">isEqualNode(otherNode)</a></code></code>
+    <dd>Returns whether <var>node</var> and <var>otherNode</var> have the same properties.
    </dl>
    <div class="impl">
     <p><a data-link-type="dfn" href="#other-applicable-specifications">Specifications</a> may define <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-clone-ext">cloning steps<a class="self-link" href="#concept-node-clone-ext"></a></dfn> for all or some <a data-link-type="dfn" href="#concept-node">nodes</a>. The algorithm is passed <var>copy</var>, <var>node</var>, <var>document</var>, and an optional <i>clone children flag</i>, as
@@ -1956,14 +1986,14 @@ run these steps:</p>
      <li>
       <p>Let <var>copy</var> be a <a data-link-type="dfn" href="#concept-node">node</a> that implements the same interfaces as <var>node</var>, and fulfills these additional requirements, switching on <var>node</var>: </p>
       <dl class="switch">
-       <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
+       <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
        <dd>
         <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-document-encoding">encoding</a>, <a data-link-type="dfn" href="#concept-document-content-type">content type</a>, <a data-link-type="dfn" href="#concept-document-url">URL</a>, <a data-link-type="dfn" href="#concept-document-type">type</a>,
     and <a data-link-type="dfn" href="#concept-document-mode">mode</a>, to those of <var>node</var>. </p>
-       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
+       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
        <dd>
         <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-doctype-name">name</a>, <a data-link-type="dfn" href="#concept-doctype-publicid">public ID</a>, and <a data-link-type="dfn" href="#concept-doctype-systemid">system ID</a>, to those of <var>node</var>. </p>
-       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
+       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
        <dd>
         <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>, and <a data-link-type="dfn" href="#concept-element-local-name">local name</a>, to those of <var>node</var>. </p>
         <p>For each <var>attribute</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, in order, run these substeps: </p>
@@ -1976,96 +2006,96 @@ run these steps:</p>
          <li>
           <p><a data-link-type="dfn" href="#concept-element-attributes-append">Append</a> <var>copyAttribute</var> to <var>copy</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. </p>
         </ol>
-       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-       <dd>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>, to that of <var>node</var>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
+       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+       <dd>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>, to that of <var>node</var>.
+       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
        <dd>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-pi-target">target</a> and <a data-link-type="dfn" href="#concept-cd-data">data</a> to
-   those of <var>node</var>. 
-       <dt>Any other node 
-       <dd>— 
+   those of <var>node</var>.
+       <dt>Any other node
+       <dd>—
       </dl>
      <li>
       <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> and <var>document</var> to <var>copy</var>, if <var>copy</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, and set <var>copy</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var> otherwise. </p>
-     <li>Run any <a data-link-type="dfn" href="#concept-node-clone-ext">cloning steps</a> defined for <var>node</var> in <a data-link-type="dfn" href="#other-applicable-specifications">other applicable specifications</a> and pass <var>copy</var>, <var>node</var>, <var>document</var> and the <i>clone children flag</i> if set, as parameters. 
-     <li>If the <i>clone children flag</i> is set, <a data-link-type="dfn" href="#concept-node-clone">clone</a> all the <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>node</var> and append them to <var>copy</var>, with <var>document</var> as specified and the <i>clone children flag</i> being set. 
-     <li>Return <var>copy</var>. 
+     <li>Run any <a data-link-type="dfn" href="#concept-node-clone-ext">cloning steps</a> defined for <var>node</var> in <a data-link-type="dfn" href="#other-applicable-specifications">other applicable specifications</a> and pass <var>copy</var>, <var>node</var>, <var>document</var> and the <i>clone children flag</i> if set, as parameters.
+     <li>If the <i>clone children flag</i> is set, <a data-link-type="dfn" href="#concept-node-clone">clone</a> all the <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>node</var> and append them to <var>copy</var>, with <var>document</var> as specified and the <i>clone children flag</i> being set.
+     <li>Return <var>copy</var>.
     </ol>
     <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" data-lt="cloneNode(deep)|cloneNode()" id="dom-node-clonenode"><code>cloneNode(<var>deep</var>)</code><a class="self-link" href="#dom-node-clonenode"></a></dfn> method, when
 invoked, must return a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, with
 the <i>clone children flag</i> set if <var>deep</var> is true.</p>
     <p>A <a data-link-type="dfn" href="#concept-node">node</a> <var>A</var> <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-equals">equals<a class="self-link" href="#concept-node-equals"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a> <var>B</var> if all of the following conditions are true:</p>
     <ul>
-     <li><var>A</var> and <var>B</var>’s <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code> attribute value is identical. 
+     <li><var>A</var> and <var>B</var>’s <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code> attribute value is identical.
      <li>
-       The following are also equal, depending on <var>A</var>: 
+       The following are also equal, depending on <var>A</var>:
       <dl class="switch">
-       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-       <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>, <a data-link-type="dfn" href="#concept-doctype-publicid">public ID</a>, and <a data-link-type="dfn" href="#concept-doctype-systemid">system ID</a>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
+       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+       <dd>Its <a data-link-type="dfn" href="#concept-doctype-name">name</a>, <a data-link-type="dfn" href="#concept-doctype-publicid">public ID</a>, and <a data-link-type="dfn" href="#concept-doctype-systemid">system ID</a>.
+       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
        <dd> Its <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a>, and its
-    number of <a data-link-type="dfn" href="#concept-attribute">attributes</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
-       <dd>Its <a data-link-type="dfn" href="#concept-pi-target">target</a> and <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
-       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
-       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-       <dd>Its <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
-       <dt>Any other node 
-       <dd>— 
+    number of <a data-link-type="dfn" href="#concept-attribute">attributes</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>.
+       <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>
+       <dd>Its <a data-link-type="dfn" href="#concept-pi-target">target</a> and <a data-link-type="dfn" href="#concept-cd-data">data</a>.
+       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
+       <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>
+       <dd>Its <a data-link-type="dfn" href="#concept-cd-data">data</a>.
+       <dt>Any other node
+       <dd>—
       </dl>
-     <li>If <var>A</var> is an <a data-link-type="dfn" href="#concept-element">element</a>, each <a data-link-type="dfn" href="#concept-attribute">attribute</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> has an <a data-link-type="dfn" href="#concept-attribute">attribute</a> with the same <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, and <a data-link-type="dfn" href="#concept-attribute-value">value</a> in <var>B</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
-     <li><var>A</var> and <var>B</var> have the same number of <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
-     <li>Each <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>A</var> <a data-link-type="dfn" href="#concept-node-equals">equals</a> the <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>B</var> at the identical <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
+     <li>If <var>A</var> is an <a data-link-type="dfn" href="#concept-element">element</a>, each <a data-link-type="dfn" href="#concept-attribute">attribute</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> has an <a data-link-type="dfn" href="#concept-attribute">attribute</a> with the same <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, and <a data-link-type="dfn" href="#concept-attribute-value">value</a> in <var>B</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>.
+     <li><var>A</var> and <var>B</var> have the same number of <a data-link-type="dfn" href="#concept-tree-child">children</a>.
+     <li>Each <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>A</var> <a data-link-type="dfn" href="#concept-node-equals">equals</a> the <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>B</var> at the identical <a data-link-type="dfn" href="#concept-tree-index">index</a>.
     </ul>
     <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-isequalnode">isEqualNode(<var>otherNode</var>)<a class="self-link" href="#dom-node-isequalnode"></a></dfn> method must return true if <var>node</var> is not null and <a data-link-type="dfn" href="#context-object">context object</a> <a data-link-type="dfn" href="#concept-node-equals">equals</a> <var>otherNode</var>, and false otherwise.</p>
    </div>
    <hr>
    <dl class="domintro">
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-comparedocumentposition">compareDocumentPosition(other)</a></code></code> 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-comparedocumentposition">compareDocumentPosition(other)</a></code></code>
     <dd>
-      Returns a bitmask indicating the position of <var>other</var> relative to <var>node</var>. These are the bits that can be set: 
+      Returns a bitmask indicating the position of <var>other</var> relative to <var>node</var>. These are the bits that can be set:
      <dl>
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></code></code> (1) 
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></code></code> (1)
       <dd>Set when <var>node</var> and <var>other</var> are not in the
-   same <a data-link-type="dfn" href="#concept-tree">tree</a>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code></code> (2) 
-      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>node</var>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code></code> (4) 
-      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node</var>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code></code> (8) 
-      <dd>Set when <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>node</var>. 
-      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code></code> (16, 10 in hexadecimal) 
-      <dd>Set when <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node</var>. 
+   same <a data-link-type="dfn" href="#concept-tree">tree</a>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code></code> (2)
+      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>node</var>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code></code> (4)
+      <dd>Set when <var>other</var> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node</var>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code></code> (8)
+      <dd>Set when <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>node</var>.
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code></code> (16, 10 in hexadecimal)
+      <dd>Set when <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node</var>.
      </dl>
-    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-contains">contains(other)</a></code></code> 
-    <dd>Returns true if <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>node</var>, and false otherwise. 
+    <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-contains">contains(other)</a></code></code>
+    <dd>Returns true if <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of <var>node</var>, and false otherwise.
    </dl>
    <p>These are the constants <code class="idl"><a data-link-type="idl" href="#dom-node-comparedocumentposition">compareDocumentPosition()</a></code> returns as mask:</p>
    <ul class="brief">
-    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED<a class="self-link" href="#dom-node-document_position_disconnected"></a></dfn> (1); 
-    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING<a class="self-link" href="#dom-node-document_position_preceding"></a></dfn> (2); 
-    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING<a class="self-link" href="#dom-node-document_position_following"></a></dfn> (4); 
-    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS<a class="self-link" href="#dom-node-document_position_contains"></a></dfn> (8); 
-    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY<a class="self-link" href="#dom-node-document_position_contained_by"></a></dfn> (16, 10 in hexadecimal); 
-    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC<a class="self-link" href="#dom-node-document_position_implementation_specific"></a></dfn> (32, 20 in hexadecimal). 
+    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED<a class="self-link" href="#dom-node-document_position_disconnected"></a></dfn> (1);
+    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING<a class="self-link" href="#dom-node-document_position_preceding"></a></dfn> (2);
+    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING<a class="self-link" href="#dom-node-document_position_following"></a></dfn> (4);
+    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS<a class="self-link" href="#dom-node-document_position_contains"></a></dfn> (8);
+    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY<a class="self-link" href="#dom-node-document_position_contained_by"></a></dfn> (16, 10 in hexadecimal);
+    <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC<a class="self-link" href="#dom-node-document_position_implementation_specific"></a></dfn> (32, 20 in hexadecimal).
    </ul>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-comparedocumentposition">compareDocumentPosition(<var>other</var>)<a class="self-link" href="#dom-node-comparedocumentposition"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>reference</var> be the <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li>Let <var>reference</var> be the <a data-link-type="dfn" href="#context-object">context object</a>.
     <li>If <var>other</var> and <var>reference</var> are the
- same object, return zero. 
+ same object, return zero.
     <li>
       If <var>other</var> and <var>reference</var> are not
   in the same <a data-link-type="dfn" href="#concept-tree">tree</a>, return the result of
   adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</a></code>,
   and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>,
-  with the constraint that this is to be consistent, together. 
+  with the constraint that this is to be consistent, together.
      <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In JavaScript
   implementations <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span></code> can be used. </p>
-    <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
-    <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
-    <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
-    <li>Return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
+    <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>.
+    <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>.
+    <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>.
+    <li>Return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-contains">contains(<var>other</var>)<a class="self-link" href="#dom-node-contains"></a></dfn> method must return true if <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of
 the <a data-link-type="dfn" href="#context-object">context object</a>, and false otherwise (including when <var>other</var> is null).</p>
@@ -2073,79 +2103,79 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="locate a namespace prefix|locating a namespace prefix" id="locate-a-namespace-prefix">locate a namespace prefix<a class="self-link" href="#locate-a-namespace-prefix"></a></dfn> for an <var>element</var> using <var>namespace</var> run these steps:</p>
    <ol>
     <li>If <var>element</var>’s <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is not
- null, return its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>. 
+ null, return its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>.
     <li>If <var>element</var> <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is
  "<code>xmlns</code>" and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>namespace</var>, then return <var>element</var>’s first
- such <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>. 
+ such <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>.
     <li>If <var>element</var>’s <a data-link-type="dfn" href="#parent-element">parent element</a> is not null,
  return the result of running <a data-link-type="dfn" href="#locate-a-namespace-prefix">locate a namespace prefix</a> on that <a data-link-type="dfn" href="#concept-element">element</a> using <var>namespace</var>.
- Otherwise, return null. 
+ Otherwise, return null.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="locate-a-namespace">locate a namespace<a class="self-link" href="#locate-a-namespace"></a></dfn> for a <var>node</var> using <var>prefix</var> depends on <var>node</var>:</p>
    <dl class="switch">
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
     <dd>
      <ol>
       <li>If its <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is
-   not null and its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is <var>prefix</var>, return <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>. 
+   not null and its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is <var>prefix</var>, return <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>.
       <li>
-        If it <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>" and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>prefix</var>, or if <var>prefix</var> is null and it <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is null and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is "<code>xmlns</code>": 
+        If it <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>" and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>prefix</var>, or if <var>prefix</var> is null and it <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is null and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is "<code>xmlns</code>":
        <ol>
         <li>Let <var>value</var> be its <a data-link-type="dfn" href="#concept-attribute-value">value</a> if it is not the empty
-     string, and null otherwise. 
-        <li>Return <var>value</var>. 
+     string, and null otherwise.
+        <li>Return <var>value</var>.
        </ol>
-      <li>If its <a data-link-type="dfn" href="#parent-element">parent element</a> is null, return null. 
+      <li>If its <a data-link-type="dfn" href="#parent-element">parent element</a> is null, return null.
       <li>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> on
-   its <a data-link-type="dfn" href="#parent-element">parent element</a> using <var>prefix</var>. 
+   its <a data-link-type="dfn" href="#parent-element">parent element</a> using <var>prefix</var>.
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
     <dd>
      <ol>
-      <li>If its <a data-link-type="dfn" href="#document-element">document element</a> is null, return null. 
+      <li>If its <a data-link-type="dfn" href="#document-element">document element</a> is null, return null.
       <li>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> on
-   its <a data-link-type="dfn" href="#document-element">document element</a> using <var>prefix</var>. 
+   its <a data-link-type="dfn" href="#document-element">document element</a> using <var>prefix</var>.
      </ol>
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-    <dd>Return null. 
-    <dt>Any other node 
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+    <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+    <dd>Return null.
+    <dt>Any other node
     <dd>
      <ol>
-      <li>If its <a data-link-type="dfn" href="#parent-element">parent element</a> is null, return null. 
+      <li>If its <a data-link-type="dfn" href="#parent-element">parent element</a> is null, return null.
       <li>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> on
-   its <a data-link-type="dfn" href="#parent-element">parent element</a> using <var>prefix</var>. 
+   its <a data-link-type="dfn" href="#parent-element">parent element</a> using <var>prefix</var>.
      </ol>
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-lookupprefix">lookupPrefix(<var>namespace</var>)<a class="self-link" href="#dom-node-lookupprefix"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>If <var>namespace</var> is null or the empty string, return null. 
+    <li>If <var>namespace</var> is null or the empty string, return null.
     <li>
-      Otherwise it depends on the <a data-link-type="dfn" href="#context-object">context object</a>: 
+      Otherwise it depends on the <a data-link-type="dfn" href="#context-object">context object</a>:
      <dl class="switch">
-      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
-      <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for the node using <var>namespace</var>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
+      <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
+      <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for the node using <var>namespace</var>.
+      <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
       <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#document-element">document element</a>, if that is not null, and null
-   otherwise. 
-      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-      <dd>Return null. 
-      <dt>Any other node 
-      <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#parent-element">parent element</a>, or if that is null, null. 
+   otherwise.
+      <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
+      <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>
+      <dd>Return null.
+      <dt>Any other node
+      <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#parent-element">parent element</a>, or if that is null, null.
      </dl>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-lookupnamespaceuri">lookupNamespaceURI(<var>prefix</var>)<a class="self-link" href="#dom-node-lookupnamespaceuri"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>If <var>prefix</var> is the empty string, set it to null. 
-    <li>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> for the <a data-link-type="dfn" href="#context-object">context object</a> using <var>prefix</var>. 
+    <li>If <var>prefix</var> is the empty string, set it to null.
+    <li>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> for the <a data-link-type="dfn" href="#context-object">context object</a> using <var>prefix</var>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-isdefaultnamespace">isDefaultNamespace(<var>namespace</var>)<a class="self-link" href="#dom-node-isdefaultnamespace"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>If <var>namespace</var> is the empty string, set it to null. 
+    <li>If <var>namespace</var> is the empty string, set it to null.
     <li>Let <var>defaultNamespace</var> be the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> for the <a data-link-type="dfn" href="#context-object">context object</a> using
- null. 
-    <li>Return true if <var>defaultNamespace</var> is the same as <var>namespace</var>, and false otherwise. 
+ null.
+    <li>Return true if <var>defaultNamespace</var> is the same as <var>namespace</var>, and false otherwise.
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-insertbefore">insertBefore(<var>node</var>, <var>child</var>)<a class="self-link" href="#dom-node-insertbefore"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-node-pre-insert">pre-inserting</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a> before <var>child</var>.</p>
@@ -2174,22 +2204,22 @@ the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
 returned by an earlier call. </p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getelementsbytagnamens">list of elements with namespace <var>namespace</var> and local name <var>localName</var><a class="self-link" href="#concept-getelementsbytagnamens"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a> <var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
    <ol>
-    <li>If <var>namespace</var> is the empty string, set it to null. 
-    <li>If both <var>namespace</var> and <var>localName</var> are "<code>*</code>" (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>. 
+    <li>If <var>namespace</var> is the empty string, set it to null.
+    <li>If both <var>namespace</var> and <var>localName</var> are "<code>*</code>" (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>.
     <li>Otherwise, if <var>namespace</var> is "<code>*</code>"
- (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
+ (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.
     <li>Otherwise, if <var>localName</var> is "<code>*</code>"
- (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var>. 
-    <li>Otherwise, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>. 
+ (U+002A), return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var>.
+    <li>Otherwise, return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>, whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.
    </ol>
    <p>When invoked with the same arguments, the same <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> object may be returned as returned by an earlier call.</p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-getelementsbyclassname">list of elements with class names <var>classNames</var><a class="self-link" href="#concept-getelementsbyclassname"></a></dfn> for a <a data-link-type="dfn" href="#concept-node">node</a> <var>root</var> is the <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> returned by the following algorithm:</p>
    <ol>
-    <li> Let <var>classes</var> be the result of running the <a data-link-type="dfn" href="#concept-ordered-set-parser">ordered set parser</a> on <var>classNames</var>. 
-    <li> If <var>classes</var> is the empty set, return an empty <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code>. 
+    <li> Let <var>classes</var> be the result of running the <a data-link-type="dfn" href="#concept-ordered-set-parser">ordered set parser</a> on <var>classNames</var>.
+    <li> If <var>classes</var> is the empty set, return an empty <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code>.
     <li>
       Return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> rooted at <var>root</var>,
-  whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> that have all their <a data-link-type="dfn" href="#concept-class">classes</a> in <var>classes</var>. 
+  whose filter matches <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> that have all their <a data-link-type="dfn" href="#concept-class">classes</a> in <var>classes</var>.
      <p>The comparisons for the <a data-link-type="dfn" href="#concept-class">classes</a> must be done in an <a data-link-type="dfn" href="#ascii-case-insensitive">ASCII case-insensitive</a> manner if <var>root</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>’s <a data-link-type="dfn" href="#concept-document-mode">mode</a> is
   "<code>quirks</code>", and in a <a data-link-type="dfn" href="#case-sensitive">case-sensitive</a> manner otherwise.</p>
    </ol>
@@ -2259,22 +2289,22 @@ and its <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/bro
    </div>
    <hr>
    <dl class="domintro">
-    <dt><code><var>document</var> = new <code class="idl"><a data-link-type="idl" href="#dom-document-document">Document()</a></code></code> 
-    <dd>Returns a new <a data-link-type="dfn" href="#concept-document">document</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code></code> 
-    <dd>Returns <var>document</var>’s <code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code> object. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-url">URL</a></code></code> 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documenturi">documentURI</a></code></code> 
-    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-url">URL</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-origin">origin</a></code></code> 
-    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-compatmode">compatMode</a></code></code> 
+    <dt><code><var>document</var> = new <code class="idl"><a data-link-type="idl" href="#dom-document-document">Document()</a></code></code>
+    <dd>Returns a new <a data-link-type="dfn" href="#concept-document">document</a>.
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code></code>
+    <dd>Returns <var>document</var>’s <code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code> object.
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-url">URL</a></code></code>
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documenturi">documentURI</a></code></code>
+    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-url">URL</a>.
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-origin">origin</a></code></code>
+    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a>.
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-compatmode">compatMode</a></code></code>
     <dd> Returns the string "<code>BackCompat</code>" if <var>document</var>’s <a data-link-type="dfn" href="#concept-document-mode">mode</a> is "<code>quirks</code>", and "<code>CSS1Compat</code>"
-  otherwise. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-characterset">characterSet</a></code></code> 
-    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-encoding">encoding</a>. 
-    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-contenttype">contentType</a></code></code> 
-    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-content-type">content type</a>. 
+  otherwise.
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-characterset">characterSet</a></code></code>
+    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-encoding">encoding</a>.
+    <dt><code><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-contenttype">contentType</a></code></code>
+    <dd>Returns <var>document</var>’s <a data-link-type="dfn" href="#concept-document-content-type">content type</a>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="constructor" data-export="" id="dom-document-document"><code>Document()</code><a class="self-link" href="#dom-document-document"></a></dfn> constructor
 must return a new <a data-link-type="dfn" href="#concept-document">document</a> whose <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the
@@ -2290,30 +2320,30 @@ return "<code>BackCompat</code>" if <a data-link-type="dfn" href="#context-objec
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-contenttype"><code>contentType</code><a class="self-link" href="#dom-document-contenttype"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-document-content-type">content type</a>.</p>
    <hr>
    <dl class="domintro">
-    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-doctype">doctype</a></code> 
+    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-doctype">doctype</a></code>
     <dd>Returns the <a data-link-type="dfn" href="#concept-doctype">doctype</a> or null if
- there is none. 
-    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documentelement">documentElement</a></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#document-element">document element</a>. 
-    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagname">getElementsByTagName(qualifiedName)</a></code> 
+ there is none.
+    <dt><var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-documentelement">documentElement</a></code>
+    <dd>Returns the <a data-link-type="dfn" href="#document-element">document element</a>.
+    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagname">getElementsByTagName(qualifiedName)</a></code>
     <dd>
      <p>If <var>qualifiedName</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>. </p>
      <p>Otherwise, returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-qualified-name">qualified name</a> is <var>qualifiedName</var>. (Matches case-insensitively against <a data-link-type="dfn" href="#concept-element">elements</a> in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> within an <a data-link-type="dfn" href="#html-document">HTML document</a>.) </p>
-    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagnamens">getElementsByTagNameNS(namespace, localName)</a></code> 
+    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbytagnamens">getElementsByTagNameNS(namespace, localName)</a></code>
     <dd>
       If <var>namespace</var> and <var>localName</var> are
-  "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>. 
+  "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a>.
      <p>If only <var>namespace</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.</p>
      <p>If only <var>localName</var> is "<code>*</code>" returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var>.</p>
      <p>Otherwise, returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of all <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> <a data-link-type="dfn" href="#concept-element">elements</a> whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>localName</var>.</p>
-    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbyclassname">getElementsByClassName(classNames)</a></code> 
-    <dt><var>collection</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-getelementsbyclassname">getElementsByClassName(classNames)</a></code> 
+    <dt><var>collection</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-getelementsbyclassname">getElementsByClassName(classNames)</a></code>
+    <dt><var>collection</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-getelementsbyclassname">getElementsByClassName(classNames)</a></code>
     <dd> Returns a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> of the <a data-link-type="dfn" href="#concept-element">elements</a> in the object on which
   the method was invoked (a <a data-link-type="dfn" href="#concept-document">document</a> or
   an <a data-link-type="dfn" href="#concept-element">element</a>) that have all the classes
   given by <var>classNames</var>.
   The <var>classNames</var> argument is interpreted as a
-  space-separated list of classes. 
+  space-separated list of classes.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-doctype"><code>doctype</code><a class="self-link" href="#dom-document-doctype"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-tree-child">child</a> of the <a data-link-type="dfn" href="#concept-document">document</a> that is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, and null otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-documentelement"><code>documentElement</code><a class="self-link" href="#dom-document-documentelement"></a></dfn> attribute’s getter must return
@@ -2326,7 +2356,7 @@ that are in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a
 the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbyclassname"><code>getElementsByClassName(<var>classNames</var>)</code><a class="self-link" href="#dom-document-getelementsbyclassname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbyclassname">list of elements with class names <var>classNames</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <div class="example" id="example-04d99d7d">
-    <a class="self-link" href="#example-04d99d7d"></a> Given the following XHTML fragment: 
+    <a class="self-link" href="#example-04d99d7d"></a> Given the following XHTML fragment:
 <pre>&lt;div id="example">
   &lt;p id="p1" class="aaa bbb"/>
   &lt;p id="p2" class="aaa ccc"/>
@@ -2339,36 +2369,36 @@ the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    </div>
    <hr>
    <dl class="domintro">
-    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelement">createElement(localName)</a></code> 
+    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelement">createElement(localName)</a></code>
     <dd>
-      Returns an <a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> with <var>localName</var> as <a data-link-type="dfn" href="#concept-element-local-name">local name</a>. (In an <a data-link-type="dfn" href="#html-document">HTML document</a> <var>localName</var> is lowercased.) 
+      Returns an <a data-link-type="dfn" href="#concept-element">element</a> in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> with <var>localName</var> as <a data-link-type="dfn" href="#concept-element-local-name">local name</a>. (In an <a data-link-type="dfn" href="#html-document">HTML document</a> <var>localName</var> is lowercased.)
      <p>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown.</p>
-    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS(namespace, qualifiedName)</a></code> 
+    <dt><var>element</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS(namespace, qualifiedName)</a></code>
     <dd>
       Returns an <a data-link-type="dfn" href="#concept-element">element</a> with <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> <var>namespace</var>. Its <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> will
   be everything before "<code>:</code>" (U+003E) in <var>qualifiedName</var> or null. Its <a data-link-type="dfn" href="#concept-element-local-name">local name</a> will be
-  everything after "<code>:</code>" (U+003E) in <var>qualifiedName</var> or <var>qualifiedName</var>. 
+  everything after "<code>:</code>" (U+003E) in <var>qualifiedName</var> or <var>qualifiedName</var>.
      <p>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown.</p>
      <p>If one of the following conditions is true a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception
   will be thrown:</p>
      <ul>
-      <li><var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production. 
-      <li><a data-link-type="dfn" href="#concept-element-namespace-prefix">Namespace prefix</a> is not null and <var>namespace</var> is the empty string. 
-      <li><a data-link-type="dfn" href="#concept-element-namespace-prefix">Namespace prefix</a> is "<code>xml</code>" and <var>namespace</var> is not the <a data-link-type="dfn" href="#xml-namespace">XML namespace</a>. 
-      <li><var>qualifiedName</var> or <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>" and <var>namespace</var> is not the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>. 
+      <li><var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production.
+      <li><a data-link-type="dfn" href="#concept-element-namespace-prefix">Namespace prefix</a> is not null and <var>namespace</var> is the empty string.
+      <li><a data-link-type="dfn" href="#concept-element-namespace-prefix">Namespace prefix</a> is "<code>xml</code>" and <var>namespace</var> is not the <a data-link-type="dfn" href="#xml-namespace">XML namespace</a>.
+      <li><var>qualifiedName</var> or <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>" and <var>namespace</var> is not the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a>.
       <li><var>namespace</var> is the <a data-link-type="dfn" href="#xmlns-namespace">XMLNS namespace</a> and
-   neither <var>qualifiedName</var> nor <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>". 
+   neither <var>qualifiedName</var> nor <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> is "<code>xmlns</code>".
      </ul>
-    <dt><var>documentFragment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createdocumentfragment">createDocumentFragment()</a></code> 
-    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
-    <dt><var>text</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createtextnode">createTextNode(data)</a></code> 
-    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>. 
-    <dt><var>comment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createcomment">createComment(data)</a></code> 
-    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>. 
-    <dt><var>processingInstruction</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createprocessinginstruction">createProcessingInstruction(target, data)</a></code> 
+    <dt><var>documentFragment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createdocumentfragment">createDocumentFragment()</a></code>
+    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
+    <dt><var>text</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createtextnode">createTextNode(data)</a></code>
+    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>.
+    <dt><var>comment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createcomment">createComment(data)</a></code>
+    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>.
+    <dt><var>processingInstruction</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createprocessinginstruction">createProcessingInstruction(target, data)</a></code>
     <dd> Returns a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-pi-target">target</a> is <var>target</var> and <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>.
   If <var>target</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown.
-  If <var>data</var> contains "<code>?></code>" an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown. 
+  If <var>data</var> contains "<code>?></code>" an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception will be thrown.
    </dl>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="concept-element-interface">element interface<a class="self-link" href="#concept-element-interface"></a></dfn> for any <var>name</var> and <var>namespace</var> is <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, unless
 stated otherwise.</p>
@@ -2376,20 +2406,20 @@ stated otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createelement"><code>createElement(<var>localName</var>)</code><a class="self-link" href="#dom-document-createelement"></a></dfn> method, when
 invoked, must run the these steps:</p>
    <ol>
-    <li>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
+    <li>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception.
     <li>If the <a data-link-type="dfn" href="#context-object">context object</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>,
- let <var>localName</var> be <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. 
-    <li>Let <var>interface</var> be the <a data-link-type="dfn" href="#concept-element-interface">element interface</a> for <var>localName</var> and the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>. 
+ let <var>localName</var> be <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>.
+    <li>Let <var>interface</var> be the <a data-link-type="dfn" href="#concept-element-interface">element interface</a> for <var>localName</var> and the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>.
     <li>Return a new <a data-link-type="dfn" href="#concept-element">element</a> that implements <var>interface</var>,
- with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set to <var>localName</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>. 
+ with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set to <var>localName</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createelementns"><code>createElementNS(<var>namespace</var>, <var>qualifiedName</var>)</code><a class="self-link" href="#dom-document-createelementns"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
     <li>Let <var>namespace</var>, <var>prefix</var>, and <var>localName</var> be the result of passing <var>namespace</var> and <var>qualifiedName</var> to <a data-link-type="dfn" href="#validate-and-extract">validate and extract</a>. Rethrow any
- exceptions. 
-    <li>Let <var>interface</var> be the <a data-link-type="dfn" href="#concept-element-interface">element interface</a> for <var>localName</var> and <var>namespace</var>. 
+ exceptions.
+    <li>Let <var>interface</var> be the <a data-link-type="dfn" href="#concept-element-interface">element interface</a> for <var>localName</var> and <var>namespace</var>.
     <li>Return a new <a data-link-type="dfn" href="#concept-element">element</a> that implements <var>interface</var>,
- with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to <var>namespace</var>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> set to <var>prefix</var>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set to <var>localName</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>. 
+ with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to <var>namespace</var>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> set to <var>prefix</var>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set to <var>localName</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createdocumentfragment"><code>createDocumentFragment()</code><a class="self-link" href="#dom-document-createdocumentfragment"></a></dfn> method, when invoked,
 must return a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
@@ -2404,30 +2434,30 @@ characters that match the <code><a class="css" data-link-type="type" href="https
 or that it contains two adjacent hyphens or ends with a hyphen. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createprocessinginstruction"><code>createProcessingInstruction(<var>target</var>, <var>data</var>)</code><a class="self-link" href="#dom-document-createprocessinginstruction"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>If <var>target</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
+    <li>If <var>target</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception.
     <li>If <var>data</var> contains the string
- "<code>?></code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
-    <li>Return a new <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with <a data-link-type="dfn" href="#concept-pi-target">target</a> set to <var>target</var>, <a data-link-type="dfn" href="#concept-cd-data">data</a> set to <var>data</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>. 
+ "<code>?></code>", <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception.
+    <li>Return a new <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with <a data-link-type="dfn" href="#concept-pi-target">target</a> set to <var>target</var>, <a data-link-type="dfn" href="#concept-cd-data">data</a> set to <var>data</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.
    </ol>
    <p class="note no-backref" role="note">No check is performed that <var>target</var> contains
 "<code>xml</code>" or "<code>:</code>", or that <var>data</var> contains characters that match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Char">Char</a></code> production. </p>
    <hr>
    <dl class="domintro">
-    <dt><var>clone</var> = <var>document</var> . <a class="idl-code" data-link-type="method" href="#dom-document-importnode">importNode(<var>node</var> [, <var>deep</var> = false])</a> 
+    <dt><var>clone</var> = <var>document</var> . <a class="idl-code" data-link-type="method" href="#dom-document-importnode">importNode(<var>node</var> [, <var>deep</var> = false])</a>
     <dd>
     <dd>
-      Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>. 
+      Returns a copy of <var>node</var>. If <var>deep</var> is true, the copy also includes the <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a>.
      <p>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a> or a <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception.</p>
-    <dt><var>node</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-adoptnode">adoptNode(node)</a></code> 
+    <dt><var>node</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-adoptnode">adoptNode(node)</a></code>
     <dd>
-      Moves <var>node</var> from another <a data-link-type="dfn" href="#concept-document">document</a> and returns it. 
+      Moves <var>node</var> from another <a data-link-type="dfn" href="#concept-document">document</a> and returns it.
      <p>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> or, if <var>node</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception.</p>
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" data-lt="importNode(node, deep)|importNode(node)" id="dom-document-importnode"><code>importNode(<var>node</var>, <var>deep</var>)</code><a class="self-link" href="#dom-document-importnode"></a></dfn> method,
 when invoked, must run these steps:</p>
    <ol>
-    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a> or <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception. 
-    <li>Return a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>node</var>, with <a data-link-type="dfn" href="#context-object">context object</a> and the <i>clone children flag</i> set if <var>deep</var> is true. 
+    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a> or <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception.
+    <li>Return a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>node</var>, with <a data-link-type="dfn" href="#context-object">context object</a> and the <i>clone children flag</i> set if <var>deep</var> is true.
    </ol>
    <p><a data-link-type="dfn" href="#other-applicable-specifications">Specifications</a> may define <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-adopt-ext">adopting steps<a class="self-link" href="#concept-node-adopt-ext"></a></dfn> for all or some <a data-link-type="dfn" href="#concept-node">nodes</a>. The algorithm is passed <var>node</var> and <var>oldDocument</var>, as indicated in the <a data-link-type="dfn" href="#concept-node-adopt">adopt</a> algorithm.</p>
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-adopt">adopt<a class="self-link" href="#concept-node-adopt"></a></dfn> a <var>node</var> into
@@ -2449,18 +2479,18 @@ a <var>document</var>, run these steps:</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-adoptnode"><code>adoptNode(<var>node</var>)</code><a class="self-link" href="#dom-document-adoptnode"></a></dfn> method, when invoked,
 must run these steps:</p>
    <ol>
-    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception. 
-    <li>If <var>node</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>Return <var>node</var>. 
+    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-document">document</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception.
+    <li>If <var>node</var> is a <a data-link-type="dfn" href="https://w3c.github.io/webcomponents/spec/shadow/#dfn-shadow-root">shadow root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception.
+    <li><a data-link-type="dfn" href="#concept-node-adopt">Adopt</a> <var>node</var> into the <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li>Return <var>node</var>.
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createattribute"><code>createAttribute(<var>localName</var>)</code><a class="self-link" href="#dom-document-createattribute"></a></dfn> method, when
 invoked, must run these steps:</p>
    <ol>
-    <li>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production in XML, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception. 
-    <li>If the <a data-link-type="dfn" href="#context-object">context object</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, let <var>localName</var> be <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. 
-    <li>Return a new <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>. 
+    <li>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production in XML, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception.
+    <li>If the <a data-link-type="dfn" href="#context-object">context object</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, let <var>localName</var> be <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>.
+    <li>Return a new <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createattributens"><code>createAttributeNS(<var>namespace</var>, <var>qualifiedName</var>)</code><a class="self-link" href="#dom-document-createattributens"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
@@ -2475,17 +2505,17 @@ invoked, must run these steps:</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createevent"><code>createEvent(<var>interface</var>)</code><a class="self-link" href="#dom-document-createevent"></a></dfn> method, when
 invoked, must run these steps:</p>
    <ol>
-    <li>Let <var>constructor</var> be null. 
+    <li>Let <var>constructor</var> be null.
     <li>
       If <var>interface</var> is an <a data-link-type="dfn" href="#ascii-case-insensitive">ASCII case-insensitive</a> match for any of the strings in the
   first column in the following table, set <var>constructor</var> to the
-  interface in the second column on the same row as the matching string: 
+  interface in the second column on the same row as the matching string:
      <table>
       <thead>
        <tr>
         <th>String
         <th>Interface
-        <td>Notes 
+        <td>Notes
       <tbody>
        <tr>
         <td>"<code>customevent</code>"
@@ -2493,43 +2523,43 @@ invoked, must run these steps:</p>
         <td rowspan="4">
        <tr>
         <td>"<code>event</code>
-        <td rowspan="3"><code class="idl"><a data-link-type="idl" href="#event">Event</a></code> 
+        <td rowspan="3"><code class="idl"><a data-link-type="idl" href="#event">Event</a></code>
        <tr>
-        <td>"<code>events</code>" 
+        <td>"<code>events</code>"
        <tr>
-        <td>"<code>htmlevents</code>" 
+        <td>"<code>htmlevents</code>"
        <tr>
         <td>"<code>keyboardevent</code>"
         <td rowspan="2"><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/uievents/#interface-keyboardevent">KeyboardEvent</a></code>
-        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
+        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a>
        <tr>
-        <td>"<code>keyevents</code>" 
+        <td>"<code>keyevents</code>"
        <tr>
         <td>"<code>messageevent</code>"
         <td><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">MessageEvent</a></code>
-        <td><a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
+        <td><a data-link-type="biblio" href="#biblio-html">[HTML]</a>
        <tr>
         <td>"<code>mouseevent</code>"
         <td rowspan="2"><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/uievents/#interface-mouseevent">MouseEvent</a></code>
-        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
+        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a>
        <tr>
-        <td>"<code>mouseevents</code>" 
+        <td>"<code>mouseevents</code>"
        <tr>
         <td>"<code>touchevent</code>"
         <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/touch-events/#touchevent-interface">TouchEvent</a></code>
-        <td><a data-link-type="biblio" href="#biblio-touch-events">[TOUCH-EVENTS]</a> 
+        <td><a data-link-type="biblio" href="#biblio-touch-events">[TOUCH-EVENTS]</a>
        <tr>
         <td>"<code>uievent</code>"
         <td rowspan="2"><code class="idl"><a data-link-type="idl" href="https://w3c.github.io/uievents/#interface-uievent">UIEvent</a></code>
-        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
+        <td rowspan="2"><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a>
        <tr>
-        <td>"<code>uievents</code>" 
+        <td>"<code>uievents</code>"
      </table>
-    <li>If <var>constructor</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. 
+    <li>If <var>constructor</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>.
     <li>Let <var>event</var> be the result of <a data-link-type="dfn" href="#concept-event-constructor">invoking</a> the initial
- value of <var>constructor</var> with the empty string as argument. 
-    <li>Unset <var>event</var>’s <a data-link-type="dfn" href="#initialized-flag">initialized flag</a>. 
-    <li>Return <var>event</var>. 
+ value of <var>constructor</var> with the empty string as argument.
+    <li>Unset <var>event</var>’s <a data-link-type="dfn" href="#initialized-flag">initialized flag</a>.
+    <li>Return <var>event</var>.
    </ol>
    <p class="note" role="note"><a data-link-type="dfn" href="#concept-event">Event</a> constructors ought to be used instead. </p>
    <hr>
@@ -2539,20 +2569,20 @@ new <a data-link-type="dfn" href="#concept-range">range</a> with (<a data-link-t
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" data-lt="createNodeIterator(root, whatToShow, filter)|createNodeIterator(root, whatToShow)|createNodeIterator(root)" id="dom-document-createnodeiterator"><code>createNodeIterator(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code><a class="self-link" href="#dom-document-createnodeiterator"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>Create a <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object. 
-    <li>Set <a data-link-type="dfn" href="#concept-traversal-root">root</a> to <var>root</var> and initialize the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute to <var>root</var>. 
-    <li>Initialize the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute to true. 
-    <li>Set <a data-link-type="dfn" href="#concept-traversal-whattoshow">whatToShow</a> to <var>whatToShow</var>. 
-    <li>Set <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> to <var>filter</var>. 
-    <li>Return the newly created <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object. 
+    <li>Create a <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object.
+    <li>Set <a data-link-type="dfn" href="#concept-traversal-root">root</a> to <var>root</var> and initialize the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute to <var>root</var>.
+    <li>Initialize the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute to true.
+    <li>Set <a data-link-type="dfn" href="#concept-traversal-whattoshow">whatToShow</a> to <var>whatToShow</var>.
+    <li>Set <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> to <var>filter</var>.
+    <li>Return the newly created <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> object.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" data-lt="createTreeWalker(root, whatToShow, filter)|createTreeWalker(root, whatToShow)|createTreeWalker(root)" id="dom-document-createtreewalker"><code>createTreeWalker(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code><a class="self-link" href="#dom-document-createtreewalker"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>Create a <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> object. 
-    <li>Set <a data-link-type="dfn" href="#concept-traversal-root">root</a> to <var>root</var> and initialize the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>root</var>. 
-    <li>Set <a data-link-type="dfn" href="#concept-traversal-whattoshow">whatToShow</a> to <var>whatToShow</var>. 
-    <li>Set <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> to <var>filter</var>. 
-    <li>Return the newly created <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> object. 
+    <li>Create a <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> object.
+    <li>Set <a data-link-type="dfn" href="#concept-traversal-root">root</a> to <var>root</var> and initialize the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>root</var>.
+    <li>Set <a data-link-type="dfn" href="#concept-traversal-whattoshow">whatToShow</a> to <var>whatToShow</var>.
+    <li>Set <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> to <var>filter</var>.
+    <li>Return the newly created <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> object.
    </ol>
    <h4 class="heading settled" data-level="4.5.1" id="interface-domimplementation"><span class="secno">4.5.1. </span><span class="content"> Interface <code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code></span><a class="self-link" href="#interface-domimplementation"></a></h4>
    <p>User agents must create a <code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code> object whenever
@@ -2568,18 +2598,18 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="dom
 };
 </pre>
    <dl class="domintro">
-    <dt><code><var>doctype</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-domimplementation-createdocumenttype">createDocumentType(qualifiedName, publicId, systemId)</a></code></code> 
+    <dt><code><var>doctype</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-domimplementation-createdocumenttype">createDocumentType(qualifiedName, publicId, systemId)</a></code></code>
     <dd> Returns a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, with the given <var>qualifiedName</var>, <var>publicId</var>, and <var>systemId</var>. If <var>qualifiedName</var> does not
   match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production, an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception is thrown, and if it does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml-names/#NT-QName">QName</a></code> production, a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a></code> exception
-  is thrown. 
-    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a class="idl-code" data-link-type="method" href="#dom-domimplementation-createdocument">createDocument(<var>namespace</var>, <var>qualifiedName</var> [, <var>doctype</var> = null])</a></code> 
+  is thrown.
+    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a class="idl-code" data-link-type="method" href="#dom-domimplementation-createdocument">createDocument(<var>namespace</var>, <var>qualifiedName</var> [, <var>doctype</var> = null])</a></code>
     <dd>
       Returns an <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code>, with a <a data-link-type="dfn" href="#document-element">document element</a> whose <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is <var>qualifiedName</var> and whose <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> is <var>namespace</var> (unless <var>qualifiedName</var> is the
-  empty string), and with <var>doctype</var>, if it is given, as its <a data-link-type="dfn" href="#concept-doctype">doctype</a>. 
+  empty string), and with <var>doctype</var>, if it is given, as its <a data-link-type="dfn" href="#concept-doctype">doctype</a>.
      <p>This method throws the same exceptions as the <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS()</a></code> method, when
   invoked with the same arguments.</p>
-    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a data-link-type="functionish" href="#dom-domimplementation-createhtmldocument">createHTMLDocument([<var>title</var>])</a></code> 
-    <dd> Returns a <a data-link-type="dfn" href="#concept-document">document</a>, with a basic <a data-link-type="dfn" href="#concept-tree">tree</a> already constructed including a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element, unless the <var>title</var> argument is omitted. 
+    <dt><code><var>doc</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-implementation">implementation</a></code> . <a data-link-type="functionish" href="#dom-domimplementation-createhtmldocument">createHTMLDocument([<var>title</var>])</a></code>
+    <dd> Returns a <a data-link-type="dfn" href="#concept-document">document</a>, with a basic <a data-link-type="dfn" href="#concept-tree">tree</a> already constructed including a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element, unless the <var>title</var> argument is omitted.
    </dl>
    <div class="impl">
     <p>The <dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-createdocumenttype"><code>createDocumentType(<var>qualifiedName</var>, <var>publicId</var>, <var>systemId</var>)</code><a class="self-link" href="#dom-domimplementation-createdocumenttype"></a></dfn> method, when invoked, must run these steps:</p>
@@ -2595,33 +2625,33 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="dom
     <p>The <dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" data-lt="createDocument(namespace, qualifiedName, doctype)|createDocument(namespace, qualifiedName)" id="dom-domimplementation-createdocument">createDocument(<var>namespace</var>, <var>qualifiedName</var>, <var>doctype</var>)<a class="self-link" href="#dom-domimplementation-createdocument"></a></dfn> method must run these steps:</p>
     <ol>
      <li>
-       Let <var>document</var> be a new <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code>. 
+       Let <var>document</var> be a new <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code>.
       <p class="note no-backref" role="note">This method creates an <code class="idl"><a data-link-type="idl" href="#xmldocument">XMLDocument</a></code> rather than a normal <a data-link-type="dfn" href="#concept-document">document</a>. They are identical except for the addition of the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#dom-xmldocument-load">load()</a></code> method deployed content relies upon. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> </p>
-     <li>Let <var>element</var> be null. 
+     <li>Let <var>element</var> be null.
      <li>If <var>qualifiedName</var> is not the empty string, set <var>element</var> to the result of invoking the <code class="idl"><a data-link-type="idl" href="#dom-document-createelementns">createElementNS()</a></code> method
- with the arguments <var>namespace</var> and <var>qualifiedName</var> on <var>document</var>. Rethrow any exceptions. 
-     <li>If <var>doctype</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>doctype</var> to <var>document</var>. 
-     <li>If <var>element</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>element</var> to <var>document</var>. 
-     <li><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
-     <li>Return <var>document</var>. 
+ with the arguments <var>namespace</var> and <var>qualifiedName</var> on <var>document</var>. Rethrow any exceptions.
+     <li>If <var>doctype</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>doctype</var> to <var>document</var>.
+     <li>If <var>element</var> is not null, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>element</var> to <var>document</var>.
+     <li><var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
+     <li>Return <var>document</var>.
     </ol>
     <p>The <dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" data-lt="createHTMLDocument(title)|createHTMLDocument()" id="dom-domimplementation-createhtmldocument"><code>createHTMLDocument(<var>title</var>)</code><a class="self-link" href="#dom-domimplementation-createhtmldocument"></a></dfn> method, when invoked, must run these steps:</p>
     <ol>
-     <li>Let <var>doc</var> be a new <a data-link-type="dfn" href="#concept-document">document</a> that is an <a data-link-type="dfn" href="#html-document">HTML document</a>. 
-     <li>Set <var>doc</var>’s <a data-link-type="dfn" href="#concept-document-content-type">content type</a> to "<code>text/html</code>". 
-     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <a data-link-type="dfn" href="#concept-doctype">doctype</a>, with "<code>html</code>" as its <a data-link-type="dfn" href="#concept-doctype-name">name</a> and with its <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>doc</var>, to <var>doc</var>. 
-     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code> element in the <span>HTML namespace</span>, to <var>doc</var>. 
-     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> element in the <span>HTML namespace</span>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code> element created earlier. 
+     <li>Let <var>doc</var> be a new <a data-link-type="dfn" href="#concept-document">document</a> that is an <a data-link-type="dfn" href="#html-document">HTML document</a>.
+     <li>Set <var>doc</var>’s <a data-link-type="dfn" href="#concept-document-content-type">content type</a> to "<code>text/html</code>".
+     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <a data-link-type="dfn" href="#concept-doctype">doctype</a>, with "<code>html</code>" as its <a data-link-type="dfn" href="#concept-doctype-name">name</a> and with its <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>doc</var>, to <var>doc</var>.
+     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code> element in the <span>HTML namespace</span>, to <var>doc</var>.
+     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> element in the <span>HTML namespace</span>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code> element created earlier.
      <li>
-       If the <var>title</var> argument is not omitted: 
+       If the <var>title</var> argument is not omitted:
       <ol>
-       <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> element created earlier. 
+       <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> element created earlier.
        <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with its <a data-link-type="dfn" href="#concept-cd-data">data</a> set to <var>title</var> (which could be the empty string), to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code> element created
-   earlier. 
+   earlier.
       </ol>
-     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-body-element">body</a></code> element in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code> element created earlier. 
-     <li><var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a> 
-     <li>Return <var>doc</var>. 
+     <li><a data-link-type="dfn" href="#concept-node-append">Append</a> a new <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-body-element">body</a></code> element in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, to the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code> element created earlier.
+     <li><var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin">origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>, and <var>doc</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> is an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-alias">alias</a> to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#effective-script-origin">effective script origin</a> of the <a data-link-type="dfn" href="#context-object">context object</a>’s associated <a data-link-type="dfn" href="#concept-document">document</a>. <a data-link-type="biblio" href="#biblio-html">[HTML]</a>
+     <li>Return <var>doc</var>.
     </ol>
     <p>The <dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-hasfeature"><code>hasFeature()</code><a class="self-link" href="#dom-domimplementation-hasfeature"></a></dfn> method, when
 invoked, must return true.</p>
@@ -2642,8 +2672,8 @@ associated <a data-link-type="dfn" href="#concept-element">element</a> named <df
    <p>An object <var>A</var> is a <dfn data-dfn-type="dfn" data-export="" id="concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor<a class="self-link" href="#concept-tree-host-including-inclusive-ancestor"></a></dfn> of an object <var>B</var>, if either <var>A</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>B</var>, or if <var>B</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> has an associated <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> and <var>A</var> is a <a data-link-type="dfn" href="#concept-tree-host-including-inclusive-ancestor">host-including inclusive ancestor</a> of <var>B</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a>.</p>
    <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> concept is useful for HTML’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">template</a></code> element and the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webcomponents/spec/shadow/#the-shadowroot-interface">ShadowRoot</a></code> object and impacts the <a data-link-type="dfn" href="#concept-node-pre-insert">pre-insert</a> and <a data-link-type="dfn" href="#concept-node-replace">replace</a> algorithms. </p>
    <dl class="domintro">
-    <dt><code><var>tree</var> = new <code class="idl"><a data-link-type="idl" href="#dom-documentfragment-documentfragment">DocumentFragment()</a></code></code> 
-    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
+    <dt><code><var>tree</var> = new <code class="idl"><a data-link-type="idl" href="#dom-documentfragment-documentfragment">DocumentFragment()</a></code></code>
+    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="DocumentFragment" data-dfn-type="constructor" data-export="" id="dom-documentfragment-documentfragment">DocumentFragment()<a class="self-link" href="#dom-documentfragment-documentfragment"></a></dfn> constructor
 must return a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
@@ -2717,9 +2747,9 @@ further processing of the <a data-link-type="dfn" href="#concept-attribute">attr
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="change an attribute" id="concept-element-attributes-change">change<a class="self-link" href="#concept-element-attributes-change"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attribute</var> from an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var> to <var>value</var>, run these steps:</p>
    <ol>
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>attributes</code>"
- for <var>element</var> with name <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, namespace <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, and oldValue <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
-    <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a> to <var>value</var>. 
-    <li>An <a data-link-type="dfn" href="#attribute-is-set">attribute is set</a> and an <a data-link-type="dfn" href="#attribute-is-changed">attribute is changed</a>. 
+ for <var>element</var> with name <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, namespace <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, and oldValue <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>.
+    <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a> to <var>value</var>.
+    <li>An <a data-link-type="dfn" href="#attribute-is-set">attribute is set</a> and an <a data-link-type="dfn" href="#attribute-is-changed">attribute is changed</a>.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="append an attribute" id="concept-element-attributes-append">append<a class="self-link" href="#concept-element-attributes-append"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attribute</var> to
 an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>,
@@ -2727,19 +2757,19 @@ run these steps:</p>
    <ol>
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>attributes</code>"
  for <var>element</var> with name <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, namespace <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, and oldValue
- null. 
-    <li>Append the <var>attribute</var> to the <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
-    <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to <var>element</var>. 
-    <li>An <a data-link-type="dfn" href="#attribute-is-set">attribute is set</a> and an <a data-link-type="dfn" href="#attribute-is-added">attribute is added</a>. 
+ null.
+    <li>Append the <var>attribute</var> to the <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>.
+    <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to <var>element</var>.
+    <li>An <a data-link-type="dfn" href="#attribute-is-set">attribute is set</a> and an <a data-link-type="dfn" href="#attribute-is-added">attribute is added</a>.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="remove an attribute" id="concept-element-attributes-remove">remove<a class="self-link" href="#concept-element-attributes-remove"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attribute</var> from an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>,
 run these steps:</p>
    <ol>
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>attributes</code>"
- for <var>element</var> with name <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, namespace <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, and oldValue <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
-    <li>Remove <var>attribute</var> from the <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
-    <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to null. 
-    <li>An <a data-link-type="dfn" href="#attribute-is-removed">attribute is removed</a>. 
+ for <var>element</var> with name <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, namespace <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, and oldValue <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>.
+    <li>Remove <var>attribute</var> from the <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>.
+    <li>Set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to null.
+    <li>An <a data-link-type="dfn" href="#attribute-is-removed">attribute is removed</a>.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="replace an attribute" id="concept-element-attributes-replace">replace<a class="self-link" href="#concept-element-attributes-replace"></a></dfn> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>oldAttr</var> by an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>newAttr</var> in an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
    <ol>
@@ -2767,8 +2797,8 @@ run these steps:</p>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-get-by-namespace">get an attribute by namespace and local name<a class="self-link" href="#concept-element-attributes-get-by-namespace"></a></dfn> given a <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>,
 run these steps:</p>
    <ol>
-    <li>If <var>namespace</var> is the empty string, set it to null. 
-    <li>Return the <a data-link-type="dfn" href="#concept-attribute">attribute</a> in <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, if any, and null otherwise. 
+    <li>If <var>namespace</var> is the empty string, set it to null.
+    <li>Return the <a data-link-type="dfn" href="#concept-attribute">attribute</a> in <var>element</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, if any, and null otherwise.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-set">set an attribute<a class="self-link" href="#concept-element-attributes-set"></a></dfn> given an <var>attr</var> and <var>element</var>, run these steps:</p>
    <ol>
@@ -2789,12 +2819,12 @@ run these steps:</p>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-set-value">set an attribute value<a class="self-link" href="#concept-element-attributes-set-value"></a></dfn> for
 an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var> using a <var>localName</var> and <var>value</var>, and an optional <var>prefix</var>, and <var>namespace</var>, run these steps:</p>
    <ol>
-    <li>If <var>prefix</var> is not given, set it to null. 
-    <li>If <var>namespace</var> is not given, set it to null. 
-    <li>Let <var>attribute</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and <var>element</var>. 
+    <li>If <var>prefix</var> is not given, set it to null.
+    <li>If <var>namespace</var> is not given, set it to null.
+    <li>Let <var>attribute</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and <var>element</var>.
     <li>If <var>attribute</var> is null, create an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is <var>prefix</var>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>,
- and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, and then <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to <var>element</var> and terminate these steps. 
-    <li><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a> <var>attribute</var> from <var>element</var> to <var>value</var>. 
+ and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, and then <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to <var>element</var> and terminate these steps.
+    <li><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a> <var>attribute</var> from <var>element</var> to <var>value</var>.
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-remove-by-name">remove an attribute by name<a class="self-link" href="#concept-element-attributes-remove-by-name"></a></dfn> given a <var>qualifiedName</var> and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
    <ol>
@@ -2807,9 +2837,9 @@ an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-remove-by-namespace">remove an attribute by namespace and local name<a class="self-link" href="#concept-element-attributes-remove-by-namespace"></a></dfn> given a <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
    <ol>
-    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and <var>element</var>. 
-    <li>If <var>attr</var> is non-null, <a data-link-type="dfn" href="#concept-element-attributes-remove">remove</a> it from <var>element</var>. 
-    <li>Return <var>attr</var>. 
+    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and <var>element</var>.
+    <li>If <var>attr</var> is non-null, <a data-link-type="dfn" href="#concept-element-attributes-remove">remove</a> it from <var>element</var>.
+    <li>Return <var>attr</var>.
    </ol>
    <hr>
    <p>An <a data-link-type="dfn" href="#concept-element">element</a> can have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" data-lt="ID" id="concept-id">unique identifier (ID)<a class="self-link" href="#concept-id"></a></dfn></p>
@@ -2830,14 +2860,14 @@ such <a data-link-type="dfn" href="#concept-element">element</a>. </p>
    <p>When an <a data-link-type="dfn" href="#concept-element">element</a> or one of its <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> is the <a data-link-type="dfn" href="#document-element">document element</a>, it is <dfn data-dfn-type="dfn" data-export="" id="in-a-document">in a document<a class="self-link" href="#in-a-document"></a></dfn>.</p>
    <hr>
    <dl class="domintro">
-    <dt><var>namespace</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-namespaceuri">namespaceURI</a></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>. 
-    <dt><var>prefix</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-prefix">prefix</a></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>. 
-    <dt><var>localName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-localname">localName</a></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-element-local-name">local name</a>. 
-    <dt><var>qualifiedName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> 
-    <dd>Returns the <a data-link-type="dfn" href="#concept-element-qualified-name">qualified name</a>. (The return value is uppercased in an <a data-link-type="dfn" href="#html-document">HTML document</a>.) 
+    <dt><var>namespace</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-namespaceuri">namespaceURI</a></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>.
+    <dt><var>prefix</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-prefix">prefix</a></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>.
+    <dt><var>localName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-localname">localName</a></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-element-local-name">local name</a>.
+    <dt><var>qualifiedName</var> = <var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code>
+    <dd>Returns the <a data-link-type="dfn" href="#concept-element-qualified-name">qualified name</a>. (The return value is uppercased in an <a data-link-type="dfn" href="#html-document">HTML document</a>.)
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export="" id="dom-element-namespaceuri"><code>namespaceURI</code><a class="self-link" href="#dom-element-namespaceuri"></a></dfn> attribute’s getter must return
 the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>. </p>
@@ -2851,15 +2881,15 @@ steps: </p>
     <li>
      <p>If the <a data-link-type="dfn" href="#context-object">context object</a> is in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a> and its <a data-link-type="dfn" href="#concept-node-document">node document</a> is
  an <a data-link-type="dfn" href="#html-document">HTML document</a>, let <var>qualifiedName</var> be <span>converted to ASCII uppercase</span>. </p>
-    <li>Return <var>qualifiedName</var>. 
+    <li>Return <var>qualifiedName</var>.
    </ol>
    <hr>
    <p>Some IDL attributes are defined to <dfn data-dfn-for="Attr" data-dfn-type="dfn" data-export="" id="concept-reflect">reflect<a class="self-link" href="#concept-reflect"></a></dfn> a content <a data-link-type="dfn" href="#concept-attribute">attribute</a> of a given <var>name</var>. This
 means that on getting, these steps must be run:</p>
    <ol>
-    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given null, <var>name</var>, and the <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>If <var>attr</var> is null, return the empty string. 
-    <li>Return <var>attr</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
+    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given null, <var>name</var>, and the <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li>If <var>attr</var> is null, return the empty string.
+    <li>Return <var>attr</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>.
    </ol>
    <p>On setting, <a data-link-type="dfn" href="#concept-element-attributes-set-value">set an attribute value</a> for the <a data-link-type="dfn" href="#context-object">context object</a> using <var>name</var> and the given value.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export="" id="dom-element-id"><code>id</code><a class="self-link" href="#dom-element-id"></a></dfn> attribute’s getter must <a data-link-type="dfn" href="#concept-reflect">reflect</a> the
@@ -2888,9 +2918,9 @@ invoked, must run these steps:</p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-getattributens">getAttributeNS(<var>namespace</var>, <var>localName</var>)<a class="self-link" href="#dom-element-getattributens"></a></dfn> method must run the following steps:</p>
    <ol>
-    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and the <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>If <var>attr</var> is null, return null. 
-    <li>Return <var>attr</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
+    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and the <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li>If <var>attr</var> is null, return null.
+    <li>Return <var>attr</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setattribute"><code>setAttribute(<var>qualifiedName</var>, <var>value</var>)</code><a class="self-link" href="#dom-element-setattribute"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
@@ -2931,8 +2961,8 @@ when invoked, must run these steps: </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-hasattributens"><code>hasAttributeNS(<var>namespace</var>, <var>localName</var>)</code><a class="self-link" href="#dom-element-hasattributens"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>If <var>namespace</var> is the empty string, set it to null. 
-    <li>Return true if the <a data-link-type="dfn" href="#context-object">context object</a> <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, and false otherwise. 
+    <li>If <var>namespace</var> is the empty string, set it to null.
+    <li>Return true if the <a data-link-type="dfn" href="#context-object">context object</a> <a data-link-type="dfn" href="#concept-element-attribute-has">has</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var> and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, and false otherwise.
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-getattributenode"><code>getAttributeNode(<var>qualifiedName</var>)</code><a class="self-link" href="#dom-element-getattributenode"></a></dfn> method, when invoked, must return the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-name">getting an attribute</a> given <var>qualifiedName</var> and the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
@@ -2941,33 +2971,33 @@ when invoked, must run these steps: </p>
 invoked, must return the result of <a data-link-type="dfn" href="#concept-element-attributes-set">setting an attribute</a> given <var>attr</var> and the <a data-link-type="dfn" href="#context-object">context object</a>. Rethrow any exceptions.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-removeattributenode"><code>removeAttributeNode(<var>attr</var>)</code><a class="self-link" href="#dom-element-removeattributenode"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>If <var>attr</var> is not in <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-element-attributes-remove">Remove</a> <var>attr</var> from <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>Return <var>attr</var>. 
+    <li>If <var>attr</var> is not in <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception.
+    <li><a data-link-type="dfn" href="#concept-element-attributes-remove">Remove</a> <var>attr</var> from <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li>Return <var>attr</var>.
    </ol>
    <hr>
    <dl class="domintro">
-    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-closest">closest(selectors)</a></code></code> 
-    <dd>Returns the first (starting at <var>element</var>) <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> that matches <var>selectors</var>, and null otherwise. 
-    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-matches">matches(selectors)</a></code></code> 
-    <dd>Returns true if matching <var>selectors</var> against <var>element</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> yields <var>element</var>, and false otherwise. 
+    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-closest">closest(selectors)</a></code></code>
+    <dd>Returns the first (starting at <var>element</var>) <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> that matches <var>selectors</var>, and null otherwise.
+    <dt><code><var>element</var> . <code class="idl"><a data-link-type="idl" href="#dom-element-matches">matches(selectors)</a></code></code>
+    <dd>Returns true if matching <var>selectors</var> against <var>element</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> yields <var>element</var>, and false otherwise.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-closest"><code>closest(<var>selectors</var>)</code><a class="self-link" href="#dom-element-closest"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
-    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
-    <li>Let <var>elements</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestors</a> that are <a data-link-type="dfn" href="#concept-element">elements</a>, in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>.
+    <li>Let <var>elements</var> be <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestors</a> that are <a data-link-type="dfn" href="#concept-element">elements</a>, in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
     <li>For each <var>element</var> in <var>elements</var>, if <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">match a selector against an element</a>, using <var>s</var>, <var>element</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope element</a> <a data-link-type="dfn" href="#context-object">context object</a>,
- returns success, return <var>element</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
-    <li>Return null. 
+ returns success, return <var>element</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>Return null.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-matches"><code>matches(<var>selectors</var>)</code><a class="self-link" href="#dom-element-matches"></a></dfn> and <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-webkitmatchesselector"><code>webkitMatchesSelector(<var>selectors</var>)</code><a class="self-link" href="#dom-element-webkitmatchesselector"></a></dfn> methods, when
 invoked, must run these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
-    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>. 
+    <li>Let <var>s</var> be the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#parse-a-selector">parse a selector</a> from <var>selectors</var>. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
+    <li>If <var>s</var> is failure, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code>.
     <li>Return true if the result of <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">match a selector against an element</a>, using <var>s</var>, <var>element</var>, and <a data-link-type="dfn" href="https://drafts.csswg.org/selectors-4/#scope-element">:scope element</a> <a data-link-type="dfn" href="#context-object">context object</a>,
- returns success, and false otherwise. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a> 
+ returns success, and false otherwise. <a data-link-type="biblio" href="#biblio-selectors4">[SELECTORS4]</a>
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-getelementsbytagname"><code>getElementsByTagName(<var>qualifiedName</var>)</code><a class="self-link" href="#dom-element-getelementsbytagname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagname">list of elements with qualified name <var>qualifiedName</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>. </p>
@@ -2997,8 +3027,8 @@ must return the number of <a data-link-type="dfn" href="#concept-attribute">attr
    <p>The <dfn class="idl-code" data-dfn-for="NamedNodeMap" data-dfn-type="method" data-export="" id="dom-namednodemap-item">item(<var>index</var>)<a class="self-link" href="#dom-namednodemap-item"></a></dfn> method,
 when invoked, must run these steps:</p>
    <ol>
-    <li>If <var>index</var> is equal to or greater than the number of <a data-link-type="dfn" href="#concept-attribute">attributes</a> in the <a data-link-type="dfn" href="#concept-namednodemap-attribute">attribute list</a>, return null. 
-    <li>Otherwise, return the <var>index</var>th <a data-link-type="dfn" href="#concept-attribute">attribute</a> in the <a data-link-type="dfn" href="#concept-namednodemap-attribute">attribute list</a>. 
+    <li>If <var>index</var> is equal to or greater than the number of <a data-link-type="dfn" href="#concept-attribute">attributes</a> in the <a data-link-type="dfn" href="#concept-namednodemap-attribute">attribute list</a>, return null.
+    <li>Otherwise, return the <var>index</var>th <a data-link-type="dfn" href="#concept-attribute">attribute</a> in the <a data-link-type="dfn" href="#concept-namednodemap-attribute">attribute list</a>.
    </ol>
    <p>A <code class="idl"><a data-link-type="idl" href="#namednodemap">NamedNodeMap</a></code> object’s <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-supported-property-names">supported property names</a>, all <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-unenumerable">unenumerable</a>, are the
 return value of running these steps: </p>
@@ -3031,9 +3061,9 @@ return value of running these steps: </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="NamedNodeMap" data-dfn-type="method" data-export="" id="dom-namednodemap-removenameditemns">removeNamedItemNS(<var>namespace</var>, <var>localName</var>)<a class="self-link" href="#dom-namednodemap-removenameditemns"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
-    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-remove-by-namespace">removing an attribute</a> given <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-namednodemap-element">element</a>. 
-    <li>If <var>attr</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception. 
-    <li>Return <var>attr</var>. 
+    <li>Let <var>attr</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-remove-by-namespace">removing an attribute</a> given <var>namespace</var>, <var>localName</var>, and <a data-link-type="dfn" href="#concept-namednodemap-element">element</a>.
+    <li>If <var>attr</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code> exception.
+    <li>Return <var>attr</var>.
    </ol>
    <h4 class="heading settled" data-level="4.8.2" id="interface-attr"><span class="secno">4.8.2. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code></span><a class="self-link" href="#interface-attr"></a></h4>
 <pre class="idl">[Exposed=Window]
@@ -3070,8 +3100,8 @@ null.</p>
    <p>The <code class="idl"><a data-link-type="idl" href="#dom-attr-value">value</a></code> attribute’s setter, <code class="idl"><a data-link-type="idl" href="#dom-attr-nodevalue">nodeValue</a></code> attribute’s setter, and <code class="idl"><a data-link-type="idl" href="#dom-attr-textcontent">textContent</a></code> attribute’s setter, must run these steps: </p>
    <ol>
     <li>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is null, set <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a> to the
- given value. 
-    <li>Otherwise, <a data-link-type="dfn" href="#concept-element-attributes-change">change</a> the <a data-link-type="dfn" href="#context-object">context object</a> from <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to the given value. 
+ given value.
+    <li>Otherwise, <a data-link-type="dfn" href="#concept-element-attributes-change">change</a> the <a data-link-type="dfn" href="#context-object">context object</a> from <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to the given value.
    </ol>
    <p class="note no-backref" role="note">Unlike <a data-link-type="dfn" href="#concept-node">node</a>’s <code class="idl"><a data-link-type="idl" href="#dom-node-textcontent">textContent</a></code>, no special null
 handling is required. </p>
@@ -3099,30 +3129,30 @@ not exist as <a data-link-type="dfn" href="#concept-node">node</a>. It is used b
 called <dfn data-dfn-for="CharacterData, Text, Comment, ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-cd-data">data<a class="self-link" href="#concept-cd-data"></a></dfn>.</p>
    <p>To <dfn data-dfn-for="CharacterData, Text, Comment, ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-cd-replace">replace data<a class="self-link" href="#concept-cd-replace"></a></dfn> of node <var>node</var> with offset <var>offset</var>, count <var>count</var>, and data <var>data</var>, run these steps:</p>
    <ol>
-    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value. 
-    <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
+    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value.
+    <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception.
     <li>If <var>offset</var> plus <var>count</var> is greater
- than <var>length</var> let <var>count</var> be <var>length</var> minus <var>offset</var>. 
+ than <var>length</var> let <var>count</var> be <var>length</var> minus <var>offset</var>.
     <li><a data-link-type="dfn" href="#queue-a-mutation-record">Queue a mutation record</a> of "<code>characterData</code>"
- for <var>node</var> with oldValue <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
-    <li>Insert <var>data</var> into <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> after <var>offset</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>. 
+ for <var>node</var> with oldValue <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>.
+    <li>Insert <var>data</var> into <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> after <var>offset</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>.
     <li>Let <var>delete offset</var> be <var>offset</var> plus
- the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>. 
-    <li>Starting from <var>delete offset</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>, remove <var>count</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
-    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> to <var>offset</var>. 
-    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> to <var>offset</var>. 
-    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>, then decrease it by <var>count</var>. 
-    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>, then decrease it by <var>count</var>. 
+ the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>.
+    <li>Starting from <var>delete offset</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a>, remove <var>count</var> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>.
+    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> to <var>offset</var>.
+    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var> but less than or equal to <var>offset</var> plus <var>count</var>, set its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> to <var>offset</var>.
+    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>, then decrease it by <var>count</var>.
+    <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by the number of <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> in <var>data</var>, then decrease it by <var>count</var>.
    </ol>
    <p></p>
    <p>To <dfn data-dfn-for="CharacterData, Text, Comment, ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-cd-substring">substring data<a class="self-link" href="#concept-cd-substring"></a></dfn> with node <var>node</var>, offset <var>offset</var>, and count <var>count</var>, run these steps:</p>
    <ol>
-    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value. 
-    <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
+    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value.
+    <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception.
     <li>If <var>offset</var> plus <var>count</var> is
  greater than <var>length</var>, return a string whose value is the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from the <var>offset</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> to the end of <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>, and then
- terminate these steps. 
-    <li>Return a string whose value is the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from the <var>offset</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> to the <var>offset</var>+<var>count</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> in <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
+ terminate these steps.
+    <li>Return a string whose value is the <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code units</a> from the <var>offset</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> to the <var>offset</var>+<var>count</var><sup>th</sup> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-code-unit">code unit</a> in <var>node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="CharacterData" data-dfn-type="attribute" data-export="" id="dom-characterdata-data">data<a class="self-link" href="#dom-characterdata-data"></a></dfn> attribute
 must return <a data-link-type="dfn" href="#concept-cd-data">data</a>, and on setting, must <a data-link-type="dfn" href="#concept-cd-replace">replace data</a> with node <a data-link-type="dfn" href="#context-object">context object</a> offset 0, count <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value, and data
@@ -3143,43 +3173,43 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="tex
   readonly attribute DOMString <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString " href="#dom-text-wholetext">wholeText</a>;
 };</pre>
    <dl class="domintro">
-    <dt><code><var>text</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-text-text">Text([<var>data</var> = ""])</a></code> 
-    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>. 
-    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-splittext">splitText(offset)</a></code></code> 
-    <dd>Splits <a data-link-type="dfn" href="#concept-cd-data">data</a> at the given <var>offset</var> and returns the remainder as <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
-    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-wholetext">wholeText</a></code></code> 
-    <dd>Returns the combined <a data-link-type="dfn" href="#concept-cd-data">data</a> of all direct <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a>. 
+    <dt><code><var>text</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-text-text">Text([<var>data</var> = ""])</a></code>
+    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>.
+    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-splittext">splitText(offset)</a></code></code>
+    <dd>Splits <a data-link-type="dfn" href="#concept-cd-data">data</a> at the given <var>offset</var> and returns the remainder as <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
+    <dt><code><var>text</var> . <code class="idl"><a data-link-type="idl" href="#dom-text-wholetext">wholeText</a></code></code>
+    <dd>Returns the combined <a data-link-type="dfn" href="#concept-cd-data">data</a> of all direct <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Text" data-dfn-type="constructor" data-export="" id="dom-text-text">Text(<var>data</var>)<a class="self-link" href="#dom-text-text"></a></dfn> constructor
 must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="split a Text node" id="concept-text-split">split<a class="self-link" href="#concept-text-split"></a></dfn> a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> with offset <var>offset</var>, run these steps:</p>
    <ol>
-    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value. 
-    <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
-    <li>Let <var>count</var> be <var>length</var> minus <var>offset</var>. 
-    <li>Let <var>new data</var> be the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>node</var>, offset <var>offset</var>, and count <var>count</var>. 
-    <li>Let <var>new node</var> be a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with the same <a data-link-type="dfn" href="#concept-node-document">node document</a> as <var>node</var>. Set <var>new node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> to <var>new data</var>. 
-    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+    <li>Let <var>length</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-characterdata-length">length</a></code> attribute value.
+    <li>If <var>offset</var> is greater than <var>length</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception.
+    <li>Let <var>count</var> be <var>length</var> minus <var>offset</var>.
+    <li>Let <var>new data</var> be the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>node</var>, offset <var>offset</var>, and count <var>count</var>.
+    <li>Let <var>new node</var> be a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, with the same <a data-link-type="dfn" href="#concept-node-document">node document</a> as <var>node</var>. Set <var>new node</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> to <var>new data</var>.
+    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
     <li>
-      If <var>parent</var> is not null, run these substeps: 
+      If <var>parent</var> is not null, run these substeps:
      <ol>
-      <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>new node</var> into <var>parent</var> before <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
-      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-start-node">start node</a> to <var>new node</var> and decrease its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by <var>offset</var>. 
-      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-end-node">end node</a> to <var>new node</var> and decrease its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by <var>offset</var>. 
+      <li><a data-link-type="dfn" href="#concept-node-insert">Insert</a> <var>new node</var> into <var>parent</var> before <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
+      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-start-node">start node</a> to <var>new node</var> and decrease its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by <var>offset</var>.
+      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-end-node">end node</a> to <var>new node</var> and decrease its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by <var>offset</var>.
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is equal to
-   the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>node</var> + 1, increase its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by one. 
+   the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>node</var> + 1, increase its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> by one.
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>parent</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is equal to
-   the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>node</var> + 1, increase its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by one. 
+   the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>node</var> + 1, increase its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> by one.
      </ol>
-    <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>node</var>, offset <var>offset</var>, count <var>count</var>, and data the empty string. 
+    <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>node</var>, offset <var>offset</var>, count <var>count</var>, and data the empty string.
     <li>
-      If <var>parent</var> is null, run these substeps: 
+      If <var>parent</var> is null, run these substeps:
      <ol>
       <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> is greater
-   than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> to <var>offset</var>. 
-      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> to <var>offset</var>. 
+   than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> to <var>offset</var>.
+      <li>For each <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is <var>node</var> and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> is greater than <var>offset</var>, set its <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a> to <var>offset</var>.
      </ol>
-    <li>Return <var>new node</var>. 
+    <li>Return <var>new node</var>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Text" data-dfn-type="method" data-export="" id="dom-text-splittext">splitText(<var>offset</var>)<a class="self-link" href="#dom-text-splittext"></a></dfn> method must <a data-link-type="dfn" href="#concept-text-split">split</a> the <a data-link-type="dfn" href="#context-object">context object</a> with offset <var>offset</var>.</p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="contiguous-text-nodes">contiguous <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> nodes<a class="self-link" href="#contiguous-text-nodes"></a></dfn> of a node are the node
@@ -3200,8 +3230,8 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="com
 };
 </pre>
    <dl class="domintro">
-    <dt><code><var>comment</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-comment-comment">Comment([<var>data</var> = ""])</a></code> 
-    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>. 
+    <dt><code><var>comment</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-comment-comment">Comment([<var>data</var> = ""])</a></code>
+    <dd>Returns a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Comment" data-dfn-type="constructor" data-export="" id="dom-comment-comment">Comment(<var>data</var>)<a class="self-link" href="#dom-comment-comment"></a></dfn> constructor must return a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> is the global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>.</p>
    <h2 class="heading settled" data-level="5" id="ranges"><span class="secno">5. </span><span class="content">Ranges</span><a class="self-link" href="#ranges"></a></h2>
@@ -3214,16 +3244,16 @@ a <a data-link-type="dfn" href="#concept-node-tree">node tree</a> between two <a
 for selecting and copying content.</p>
    <ul class="domTree">
     <li class="t1">
-     <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code> 
+     <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code>
      <ul>
-      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-ending BOM; decode as big-endian!"</span><span class="nt">></span></code> 
-      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span> 
+      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-ending BOM; decode as big-endian!"</span><span class="nt">></span></code>
+      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span>
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span></code> 
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span></code>
        <ul>
-        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span> 
+        <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span>
        </ul>
-      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>!</span> 
+      <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>!</span>
      </ul>
    </ul>
    <p>In the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> above, a <a data-link-type="dfn" href="#concept-range">range</a> can be used to represent the sequence
@@ -3300,19 +3330,19 @@ the second is either <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="
 as returned by the following algorithm:</p>
    <ol>
     <li>If <var>node A</var> is the same as <var>node B</var>,
- return <a data-link-type="dfn" href="#concept-range-bp-equal">equal</a> if <var>offset A</var> is the same as <var>offset B</var>, <a data-link-type="dfn" href="#concept-range-bp-before">before</a> if <var>offset A</var> is less than <var>offset B</var>, and <a data-link-type="dfn" href="#concept-range-bp-after">after</a> if <var>offset A</var> is greater than <var>offset B</var>. 
+ return <a data-link-type="dfn" href="#concept-range-bp-equal">equal</a> if <var>offset A</var> is the same as <var>offset B</var>, <a data-link-type="dfn" href="#concept-range-bp-before">before</a> if <var>offset A</var> is less than <var>offset B</var>, and <a data-link-type="dfn" href="#concept-range-bp-after">after</a> if <var>offset A</var> is greater than <var>offset B</var>.
     <li>If <var>node A</var> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node B</var>, compute the <a data-link-type="dfn" href="#concept-range-bp-position">position</a> of
  (<var>node B</var>, <var>offset B</var>) relative to
- (<var>node A</var>, <var>offset A</var>). If it is <a data-link-type="dfn" href="#concept-range-bp-before">before</a>, return <a data-link-type="dfn" href="#concept-range-bp-after">after</a>. If it is <a data-link-type="dfn" href="#concept-range-bp-after">after</a>, return <a data-link-type="dfn" href="#concept-range-bp-before">before</a>. 
+ (<var>node A</var>, <var>offset A</var>). If it is <a data-link-type="dfn" href="#concept-range-bp-before">before</a>, return <a data-link-type="dfn" href="#concept-range-bp-after">after</a>. If it is <a data-link-type="dfn" href="#concept-range-bp-after">after</a>, return <a data-link-type="dfn" href="#concept-range-bp-before">before</a>.
     <li>
-      If <var>node A</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>node B</var>: 
+      If <var>node A</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>node B</var>:
      <ol>
-      <li>Let <var>child</var> equal <var>node B</var>. 
+      <li>Let <var>child</var> equal <var>node B</var>.
       <li>While <var>child</var> is not a <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>node A</var>,
-   set <var>child</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-      <li>If the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>child</var> is less than <var>offset A</var>, return <a data-link-type="dfn" href="#concept-range-bp-after">after</a>. 
+   set <var>child</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+      <li>If the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>child</var> is less than <var>offset A</var>, return <a data-link-type="dfn" href="#concept-range-bp-after">after</a>.
      </ol>
-    <li>Return <a data-link-type="dfn" href="#concept-range-bp-before">before</a>. 
+    <li>Return <a data-link-type="dfn" href="#concept-range-bp-before">before</a>.
    </ol>
    <p>Each <a data-link-type="dfn" href="#concept-range">range</a> has two associated <a data-link-type="dfn" href="#concept-range-bp">boundary points</a> — a <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-start">start<a class="self-link" href="#concept-range-start"></a></dfn> and <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-end">end<a class="self-link" href="#concept-range-end"></a></dfn>.</p>
    <p>For convenience, <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-start-node">start node<a class="self-link" href="#concept-range-start-node"></a></dfn> is <a data-link-type="dfn" href="#concept-range-start">start</a>’s <a data-link-type="dfn" href="#concept-node">node</a>, <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-start-offset">start offset<a class="self-link" href="#concept-range-start-offset"></a></dfn> is <a data-link-type="dfn" href="#concept-range-start">start</a>’s <a data-link-type="dfn" href="#concept-range-bp-offset">offset</a>, <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-end-node">end node<a class="self-link" href="#concept-range-end-node"></a></dfn> is <a data-link-type="dfn" href="#concept-range-end">end</a>’s <a data-link-type="dfn" href="#concept-node">node</a>,  and <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-end-offset">end offset<a class="self-link" href="#concept-range-end-offset"></a></dfn> is <a data-link-type="dfn" href="#concept-range-end">end</a>’s <a data-link-type="dfn" href="#concept-range-bp-offset">offset</a>.</p>
@@ -3321,55 +3351,55 @@ as returned by the following algorithm:</p>
    <p>A <a data-link-type="dfn" href="#concept-node">node</a> is <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="partially-contained">partially contained<a class="self-link" href="#partially-contained"></a></dfn> in a <a data-link-type="dfn" href="#concept-range">range</a> if it is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of the <a data-link-type="dfn" href="#concept-range">range</a>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> but not
 its <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, or vice versa.</p>
    <div class="note" role="note">
-     Some facts to better understand these definitions: 
+     Some facts to better understand these definitions:
     <ul>
      <li>The content that one would think of as being within the <a data-link-type="dfn" href="#concept-range">range</a> consists of all <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">nodes</a>, plus
-  possibly some of the contents of the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> if those are <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>. 
+  possibly some of the contents of the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> if those are <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a>.
      <li>The <a data-link-type="dfn" href="#concept-node">nodes</a> that are contained in a <a data-link-type="dfn" href="#concept-range">range</a> will generally not be contiguous,
   because the <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of a <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> will not
-  always be <a data-link-type="dfn" href="#contained">contained</a>. 
-     <li>However, the <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of a <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> are <a data-link-type="dfn" href="#contained">contained</a>, and if two <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> are <a data-link-type="dfn" href="#contained">contained</a>, so are any <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> that lie between them. 
-     <li>The <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> of a <a data-link-type="dfn" href="#concept-range">range</a> are never <a data-link-type="dfn" href="#contained">contained</a> within it. 
+  always be <a data-link-type="dfn" href="#contained">contained</a>.
+     <li>However, the <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of a <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> are <a data-link-type="dfn" href="#contained">contained</a>, and if two <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> are <a data-link-type="dfn" href="#contained">contained</a>, so are any <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a> that lie between them.
+     <li>The <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> of a <a data-link-type="dfn" href="#concept-range">range</a> are never <a data-link-type="dfn" href="#contained">contained</a> within it.
      <li>The first <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> (if there are any) will always be
   after the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, and the
   last <a data-link-type="dfn" href="#contained">contained</a> <a data-link-type="dfn" href="#concept-node">node</a> will
-  always be equal to or before the <a data-link-type="dfn" href="#concept-range-end-node">end node</a>’s last <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a>. 
-     <li>There exists a partially contained <a data-link-type="dfn" href="#concept-node">node</a> if and only if the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> are different. 
-     <li>The <code class="idl"><a data-link-type="idl" href="#dom-range-commonancestorcontainer">commonAncestorContainer</a></code> attribute value is neither <a data-link-type="dfn" href="#contained">contained</a> nor <a data-link-type="dfn" href="#partially-contained">partially contained</a>. 
+  always be equal to or before the <a data-link-type="dfn" href="#concept-range-end-node">end node</a>’s last <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a>.
+     <li>There exists a partially contained <a data-link-type="dfn" href="#concept-node">node</a> if and only if the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a> are different.
+     <li>The <code class="idl"><a data-link-type="idl" href="#dom-range-commonancestorcontainer">commonAncestorContainer</a></code> attribute value is neither <a data-link-type="dfn" href="#contained">contained</a> nor <a data-link-type="dfn" href="#partially-contained">partially contained</a>.
      <li>If the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of the <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, the common <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> will
   be the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>. Exactly one
   of its <a data-link-type="dfn" href="#concept-tree-child">children</a> will be <a data-link-type="dfn" href="#partially-contained">partially contained</a>, and a <a data-link-type="dfn" href="#concept-tree-child">child</a> will be <a data-link-type="dfn" href="#contained">contained</a> if and only if it <a data-link-type="dfn" href="#concept-tree-preceding">precedes</a> the <a data-link-type="dfn" href="#partially-contained">partially contained</a> <a data-link-type="dfn" href="#concept-tree-child">child</a>. If the <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, the opposite
-  holds. 
+  holds.
      <li>If the <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is
   not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of
   the <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, nor vice versa,
   the common <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> will
   be distinct from both of them. Exactly two of its <a data-link-type="dfn" href="#concept-tree-child">children</a> will be <a data-link-type="dfn" href="#partially-contained">partially contained</a>, and a <a data-link-type="dfn" href="#concept-tree-child">child</a> will be contained if and only
-  if it lies between those two. 
+  if it lies between those two.
     </ul>
    </div>
    <hr>
    <dl class="domintro">
-    <dt><code><var>range</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-range-range">Range()</a></code> 
-    <dd>Returns a new <a data-link-type="dfn" href="#concept-range">range</a>. 
+    <dt><code><var>range</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-range-range">Range()</a></code>
+    <dd>Returns a new <a data-link-type="dfn" href="#concept-range">range</a>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="constructor" data-export="" id="dom-range-range"><code>Range()</code><a class="self-link" href="#dom-range-range"></a></dfn> constructor must return a new <a data-link-type="dfn" href="#concept-range">range</a> with
 (global object’s associated <a data-link-type="dfn" href="#concept-document">document</a>, 0) as its <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a>.</p>
    <hr>
    <dl class="domintro">
-    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startcontainer">startContainer</a></code> 
-    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>. 
-    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startoffset">startOffset</a></code> 
-    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>. 
-    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endcontainer">endContainer</a></code> 
-    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end-node">end node</a>. 
-    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endoffset">endOffset</a></code> 
-    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
-    <dt><var>collapsed</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-collapsed">collapsed</a></code> 
-    <dd>Returns true if <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> are the same, and false otherwise. 
-    <dt><var>container</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-commonancestorcontainer">commonAncestorContainer</a></code> 
+    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startcontainer">startContainer</a></code>
+    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>.
+    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-startoffset">startOffset</a></code>
+    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>.
+    <dt><var>node</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endcontainer">endContainer</a></code>
+    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end-node">end node</a>.
+    <dt><var>offset</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-endoffset">endOffset</a></code>
+    <dd>Returns <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>.
+    <dt><var>collapsed</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-collapsed">collapsed</a></code>
+    <dd>Returns true if <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> are the same, and false otherwise.
+    <dt><var>container</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-commonancestorcontainer">commonAncestorContainer</a></code>
     <dd>Returns the <a data-link-type="dfn" href="#concept-node">node</a>, furthest away from
- the <a data-link-type="dfn" href="#concept-document">document</a>, that is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of both <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a>. 
+ the <a data-link-type="dfn" href="#concept-document">document</a>, that is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of both <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> and <a data-link-type="dfn" href="#concept-range-end-node">end node</a>.
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="attribute" data-export="" id="dom-range-startcontainer">startContainer<a class="self-link" href="#dom-range-startcontainer"></a></dfn> attribute must return the <a data-link-type="dfn" href="#concept-range-start-node">start node</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="attribute" data-export="" id="dom-range-startoffset">startOffset<a class="self-link" href="#dom-range-startoffset"></a></dfn> attribute must return the <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>.</p>
@@ -3380,31 +3410,31 @@ must return true if <a data-link-type="dfn" href="#concept-range-start">start</a
 as <a data-link-type="dfn" href="#concept-range-end">end</a>, and false otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="attribute" data-export="" id="dom-range-commonancestorcontainer">commonAncestorContainer<a class="self-link" href="#dom-range-commonancestorcontainer"></a></dfn> attribute must run these steps:</p>
    <ol>
-    <li>Let <var>container</var> be <a data-link-type="dfn" href="#concept-range-start-node">start node</a>. 
-    <li>While <var>container</var> is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, let <var>container</var> be <var>container</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>Return <var>container</var>. 
+    <li>Let <var>container</var> be <a data-link-type="dfn" href="#concept-range-start-node">start node</a>.
+    <li>While <var>container</var> is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, let <var>container</var> be <var>container</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>Return <var>container</var>.
    </ol>
    <hr>
    <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" data-lt="set the start|set the end" id="concept-range-bp-set">set the start or end<a class="self-link" href="#concept-range-bp-set"></a></dfn> of a <var>range</var> to a <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, <var>offset</var>), run these steps:</p>
    <ol>
-    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
-    <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
-    <li>Let <var>bp</var> be the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, <var>offset</var>). 
+    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
+    <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception.
+    <li>Let <var>bp</var> be the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, <var>offset</var>).
     <li>
      <dl class="switch">
-      <dt>If these steps were invoked as "set the start" 
+      <dt>If these steps were invoked as "set the start"
       <dd>
        <ol>
         <li>If <var>bp</var> is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> the <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a>, or
-     if <var>range</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a> is not equal to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>, set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to <var>bp</var>. 
-        <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> to <var>bp</var>. 
+     if <var>range</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a> is not equal to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>, set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to <var>bp</var>.
+        <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> to <var>bp</var>.
        </ol>
-      <dt>If these steps were invoked as "set the end" 
+      <dt>If these steps were invoked as "set the end"
       <dd>
        <ol>
         <li>If <var>bp</var> is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> the <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a>,
-     or if <var>range</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a> is not equal to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>, set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> to <var>bp</var>. 
-        <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to <var>bp</var>. 
+     or if <var>range</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a> is not equal to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>, set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> to <var>bp</var>.
+        <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to <var>bp</var>.
        </ol>
      </dl>
    </ol>
@@ -3412,328 +3442,328 @@ as <a data-link-type="dfn" href="#concept-range-end">end</a>, and false otherwis
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-setend">setEnd(<var>node</var>, <var>offset</var>)<a class="self-link" href="#dom-range-setend"></a></dfn> method must <a data-link-type="dfn" href="#concept-range-bp-set">set the end</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, <var>offset</var>).</p>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-setstartbefore">setStartBefore(<var>node</var>)<a class="self-link" href="#dom-range-setstartbefore"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the start</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>). 
+    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
+    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the start</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>).
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-setstartafter">setStartAfter(<var>node</var>)<a class="self-link" href="#dom-range-setstartafter"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the start</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a> plus one). 
+    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
+    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the start</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a> plus one).
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-setendbefore">setEndBefore(<var>node</var>)<a class="self-link" href="#dom-range-setendbefore"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the end</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>). 
+    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
+    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the end</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>).
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-setendafter">setEndAfter(<var>node</var>)<a class="self-link" href="#dom-range-setendafter"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
-    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the end</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a> plus one). 
+    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
+    <li><a data-link-type="dfn" href="#concept-range-bp-set">Set the end</a> of the <a data-link-type="dfn" href="#context-object">context object</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a> plus one).
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" data-lt="collapse(toStart)|collapse()" id="dom-range-collapse"><code>collapse(<var>toStart</var>)</code><a class="self-link" href="#dom-range-collapse"></a></dfn> method, when
 invoked, must if <var>toStart</var> is true, set <a data-link-type="dfn" href="#concept-range-end">end</a> to <a data-link-type="dfn" href="#concept-range-start">start</a>, and set <a data-link-type="dfn" href="#concept-range-start">start</a> to <a data-link-type="dfn" href="#concept-range-end">end</a> otherwise.</p>
    <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-select">select<a class="self-link" href="#concept-range-select"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> within a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
-    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code>. 
-    <li>Let <var>index</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
-    <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>index</var>). 
-    <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>index</var> plus one). 
+    <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>If <var>parent</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code>.
+    <li>Let <var>index</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>.
+    <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>index</var>).
+    <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>parent</var>, <var>index</var> plus one).
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-selectnode">selectNode(<var>node</var>)<a class="self-link" href="#dom-range-selectnode"></a></dfn> method must <a data-link-type="dfn" href="#concept-range-select">select</a> <var>node</var> within <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-selectnodecontents">selectNodeContents(<var>node</var>)<a class="self-link" href="#dom-range-selectnodecontents"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code>. 
-    <li>Let <var>length</var> be the <a data-link-type="dfn" href="#concept-node-length">length</a> of <var>node</var>. 
-    <li>Set <a data-link-type="dfn" href="#concept-range-start">start</a> to the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, 0). 
-    <li>Set <a data-link-type="dfn" href="#concept-range-end">end</a> to the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, <var>length</var>). 
+    <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code>.
+    <li>Let <var>length</var> be the <a data-link-type="dfn" href="#concept-node-length">length</a> of <var>node</var>.
+    <li>Set <a data-link-type="dfn" href="#concept-range-start">start</a> to the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, 0).
+    <li>Set <a data-link-type="dfn" href="#concept-range-end">end</a> to the <a data-link-type="dfn" href="#concept-range-bp">boundary point</a> (<var>node</var>, <var>length</var>).
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-compareboundarypoints">compareBoundaryPoints(<var>how</var>, <var>sourceRange</var>)<a class="self-link" href="#dom-range-compareboundarypoints"></a></dfn> method must run these steps:</p>
    <ol>
     <li>
-      If <var>how</var> is not one of 
+      If <var>how</var> is not one of
      <ul>
-      <li><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_start">START_TO_START</a></code>, 
-      <li><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_end">START_TO_END</a></code>, 
-      <li><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_end">END_TO_END</a></code>, and 
-      <li><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_start">END_TO_START</a></code>, 
+      <li><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_start">START_TO_START</a></code>,
+      <li><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_end">START_TO_END</a></code>,
+      <li><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_end">END_TO_END</a></code>, and
+      <li><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_start">END_TO_START</a></code>,
      </ul>
-      <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception. 
+      <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> exception.
      <p></p>
-    <li>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a> is not the same as <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a></code> exception. 
+    <li>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a> is not the same as <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a></code> exception.
     <li>
-      If <var>how</var> is: 
+      If <var>how</var> is:
      <dl class="switch">
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_start">START_TO_START</a></code>: 
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_start">START_TO_START</a></code>:
       <dd> Let <var>this point</var> be the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-start">start</a>.
-    Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_end">START_TO_END</a></code>: 
+    Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a>.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-start_to_end">START_TO_END</a></code>:
       <dd> Let <var>this point</var> be the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-end">end</a>.
-    Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_end">END_TO_END</a></code>: 
+    Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a>.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_end">END_TO_END</a></code>:
       <dd> Let <var>this point</var> be the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-end">end</a>.
-     Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a>. 
-      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_start">END_TO_START</a></code>: 
+     Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a>.
+      <dt><code class="idl"><a data-link-type="idl" href="#dom-range-end_to_start">END_TO_START</a></code>:
       <dd> Let <var>this point</var> be the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-start">start</a>.
-     Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a>. 
+     Let <var>other point</var> be <var>sourceRange</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a>.
      </dl>
     <li>
-      If the <a data-link-type="dfn" href="#concept-range-bp-position">position</a> of <var>this point</var> relative to <var>other point</var> is 
+      If the <a data-link-type="dfn" href="#concept-range-bp-position">position</a> of <var>this point</var> relative to <var>other point</var> is
      <dl class="switch">
-      <dt><a data-link-type="dfn" href="#concept-range-bp-before">before</a> 
-      <dd>Return −1. 
-      <dt><a data-link-type="dfn" href="#concept-range-bp-equal">equal</a> 
-      <dd>Return 0. 
-      <dt><a data-link-type="dfn" href="#concept-range-bp-after">after</a> 
-      <dd>Return 1. 
+      <dt><a data-link-type="dfn" href="#concept-range-bp-before">before</a>
+      <dd>Return −1.
+      <dt><a data-link-type="dfn" href="#concept-range-bp-equal">equal</a>
+      <dd>Return 0.
+      <dt><a data-link-type="dfn" href="#concept-range-bp-after">after</a>
+      <dd>Return 1.
      </dl>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-deletecontents"><code>deleteContents()</code><a class="self-link" href="#dom-range-deletecontents"></a></dfn> method, when invoked, must
 run these steps:</p>
    <ol>
-    <li>If <a data-link-type="dfn" href="#concept-range-start">start</a> is <a data-link-type="dfn" href="#concept-range-end">end</a>, terminate these steps. 
+    <li>If <a data-link-type="dfn" href="#concept-range-start">start</a> is <a data-link-type="dfn" href="#concept-range-end">end</a>, terminate these steps.
     <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>,
- and <var>original end offset</var> be the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively. 
+ and <var>original end offset</var> be the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively.
     <li>If <var>original start node</var> and <var>original end node</var> are the same, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-cd-replace">replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string, and then
- terminate these steps. 
+ terminate these steps.
     <li>Let <var>nodes to remove</var> be a list of all the <a data-link-type="dfn" href="#concept-node">nodes</a> that are <a data-link-type="dfn" href="#contained">contained</a> in
- the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, omitting any <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is also <a data-link-type="dfn" href="#contained">contained</a> in the <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>If <var>original start node</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>new node</var> to <var>original start node</var> and <var>new offset</var> to <var>original start offset</var>. 
+ the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, omitting any <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is also <a data-link-type="dfn" href="#contained">contained</a> in the <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li>If <var>original start node</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>new node</var> to <var>original start node</var> and <var>new offset</var> to <var>original start offset</var>.
     <li>
-      Otherwise: 
+      Otherwise:
      <ol>
-      <li>Let <var>reference node</var> equal <var>original start node</var>. 
-      <li>While <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null and is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>reference node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+      <li>Let <var>reference node</var> equal <var>original start node</var>.
+      <li>While <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null and is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>reference node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
       <li>
         Set <var>new node</var> to the <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of <var>reference node</var>, and <var>new offset</var> to one
-    plus the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>reference node</var>. 
+    plus the <a data-link-type="dfn" href="#concept-tree-index">index</a> of <var>reference node</var>.
        <p class="note no-backref" role="note">If <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> were null, it would be the <a data-link-type="dfn" href="#concept-range-root">root</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, so would be an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, and we could not reach this point. </p>
      </ol>
-    <li>If <var>original start node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-cd-replace">replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>, data the empty string. 
+    <li>If <var>original start node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-cd-replace">replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>, data the empty string.
     <li>For each <var>node</var> in <var>nodes to remove</var>,
  in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from
- its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>If <var>original end node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-cd-replace">replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var> and data the empty string. 
+ its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>If <var>original end node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="#concept-cd-replace">replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var> and data the empty string.
     <li>Set <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> to
- (<var>new node</var>, <var>new offset</var>). 
+ (<var>new node</var>, <var>new offset</var>).
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-local-lt="extract" data-lt="extract a range" id="concept-range-extract">extract<a class="self-link" href="#concept-range-extract"></a></dfn> a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
-    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> is its <a data-link-type="dfn" href="#concept-range-end">end</a>, return <var>fragment</var>. 
-    <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively. 
+    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>.
+    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> is its <a data-link-type="dfn" href="#concept-range-end">end</a>, return <var>fragment</var>.
+    <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively.
     <li>
-      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>:
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
-      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
-      <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string. 
-      <li>Return <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>.
+      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
+      <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original end offset</var> minus <var>original start offset</var>, and data the empty string.
+      <li>Return <var>fragment</var>.
      </ol>
-    <li>Let <var>common ancestor</var> be <var>original start node</var>. 
+    <li>Let <var>common ancestor</var> be <var>original start node</var>.
     <li>While <var>common ancestor</var> is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>common ancestor</var> to
- its own <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>Let <var>first partially contained child</var> be null. 
-    <li>If <var>original start node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>first partially contained child</var> to the first <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>. 
-    <li>Let <var>last partially contained child</var> be null. 
+ its own <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>Let <var>first partially contained child</var> be null.
+    <li>If <var>original start node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>first partially contained child</var> to the first <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>.
+    <li>Let <var>last partially contained child</var> be null.
     <li>
-      If <var>original end node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original start node</var>, set <var>last partially contained child</var> to the last <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>. 
+      If <var>original end node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original start node</var>, set <var>last partially contained child</var> to the last <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>.
      <p class="note no-backref" role="note">These variable assignments do actually always make sense.
   For instance, if <var>original start node</var> is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, <var>original start node</var> is itself <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>, and so are all its <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> up until a <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var>. <var>common ancestor</var> cannot be <var>original start node</var>, because
   it has to be an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>. The other case is similar. Also, notice that the two <a data-link-type="dfn" href="#concept-tree-child">children</a> will never be equal if both are defined. </p>
-    <li>Let <var>contained children</var> be a list of all <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>common ancestor</var> that are <a data-link-type="dfn" href="#contained">contained</a> in <var>range</var>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <li>Let <var>contained children</var> be a list of all <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>common ancestor</var> that are <a data-link-type="dfn" href="#contained">contained</a> in <var>range</var>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
     <li>
-      If any member of <var>contained children</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception. 
+      If any member of <var>contained children</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception.
      <p class="note no-backref" role="note">We do not have to worry about the first or last partially
   contained node, because a <a data-link-type="dfn" href="#concept-doctype">doctype</a> can never be
   partially contained. It cannot be a boundary point of a range, and it
   cannot be the ancestor of anything. </p>
-    <li>If <var>original start node</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>new node</var> to <var>original start node</var> and <var>new offset</var> to <var>original start offset</var>. 
+    <li>If <var>original start node</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>new node</var> to <var>original start node</var> and <var>new offset</var> to <var>original start offset</var>.
     <li>
-      Otherwise: 
+      Otherwise:
      <ol>
-      <li>Let <var>reference node</var> equal <var>original start node</var>. 
-      <li>While <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null and is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>reference node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+      <li>Let <var>reference node</var> equal <var>original start node</var>.
+      <li>While <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not null and is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>reference node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
       <li>
-        Set <var>new node</var> to the <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of <var>reference node</var>, and <var>new offset</var> to one plus <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
+        Set <var>new node</var> to the <a data-link-type="dfn" href="#concept-tree-parent">parent</a> of <var>reference node</var>, and <var>new offset</var> to one plus <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>.
        <p class="note no-backref" role="note">If <var>reference node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, it would be the <a data-link-type="dfn" href="#concept-range-root">root</a> of <var>range</var>, so would be an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, and we could not reach this point. </p>
      </ol>
     <li>
-      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>:
      <p class="note no-backref" role="note">In this case, <var>first partially contained child</var> is <var>original start node</var>. </p>
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
-      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
-      <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>, and data the empty string. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>.
+      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
+      <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>original start node</var>, offset <var>original start offset</var>, count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>, and data the empty string.
      </ol>
     <li>
       Otherwise, if <var>first partially contained child</var> is not
-  null: 
+  null:
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>first partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>first partially contained child</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
    whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
-   (<var>first partially contained child</var>, <var>first partially contained child</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
+   (<var>first partially contained child</var>, <var>first partially contained child</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>).
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <var>subrange</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
      </ol>
-    <li>For each <var>contained child</var> in <var>contained children</var>, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>contained child</var> to <var>fragment</var>. 
+    <li>For each <var>contained child</var> in <var>contained children</var>, <a data-link-type="dfn" href="#concept-node-append">append</a> <var>contained child</var> to <var>fragment</var>.
     <li>
-      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>:
      <p class="note no-backref" role="note">In this case, <var>last partially contained child</var> is <var>original end node</var>. </p>
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original end node</var>. 
-      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
-      <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var>, and data the empty string. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original end node</var>.
+      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
+      <li><a data-link-type="dfn" href="#concept-cd-replace">Replace data</a> with node <var>original end node</var>, offset 0, count <var>original end offset</var>, and data the empty string.
      </ol>
     <li>
       Otherwise, if <var>last partially contained child</var> is not
-  null: 
+  null:
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>last partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>last partially contained child</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>last partially contained child</var>, 0) and whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
-   (<var>original end node</var>, <var>original end offset</var>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
+   (<var>original end node</var>, <var>original end offset</var>).
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <var>subrange</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
      </ol>
     <li>Set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> to
- (<var>new node</var>, <var>new offset</var>). 
-    <li>Return <var>fragment</var>. 
+ (<var>new node</var>, <var>new offset</var>).
+    <li>Return <var>fragment</var>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-extractcontents">extractContents()<a class="self-link" href="#dom-range-extractcontents"></a></dfn> method
 must return the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="clone a range" id="concept-range-clone">clone<a class="self-link" href="#concept-range-clone"></a></dfn> a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
-    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
-    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> is its <a data-link-type="dfn" href="#concept-range-end">end</a>, return <var>fragment</var>. 
-    <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively. 
+    <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>.
+    <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> is its <a data-link-type="dfn" href="#concept-range-end">end</a>, return <var>fragment</var>.
+    <li>Let <var>original start node</var>, <var>original start offset</var>, <var>original end node</var>, and <var>original end offset</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>, <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>, respectively.
     <li>
-      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>original start node</var> is <var>original end node</var>, and they are a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>:
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
-      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
-      <li>Return <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>.
+      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original end offset</var> minus <var>original start offset</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
+      <li>Return <var>fragment</var>.
      </ol>
-    <li>Let <var>common ancestor</var> be <var>original start node</var>. 
-    <li>While <var>common ancestor</var> is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>common ancestor</var> to its own <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-    <li>Let <var>first partially contained child</var> be null. 
-    <li>If <var>original start node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>first partially contained child</var> to the first <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>. 
-    <li>Let <var>last partially contained child</var> be null. 
+    <li>Let <var>common ancestor</var> be <var>original start node</var>.
+    <li>While <var>common ancestor</var> is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>common ancestor</var> to its own <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+    <li>Let <var>first partially contained child</var> be null.
+    <li>If <var>original start node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, set <var>first partially contained child</var> to the first <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>.
+    <li>Let <var>last partially contained child</var> be null.
     <li>
-      If <var>original end node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original start node</var>, set <var>last partially contained child</var> to the last <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>. 
+      If <var>original end node</var> is <em>not</em> an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original start node</var>, set <var>last partially contained child</var> to the last <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var> that is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>.
      <p class="note no-backref" role="note">These variable assignments do actually always make sense.
   For instance, if <var>original start node</var> is not an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>, <var>original start node</var> is itself <a data-link-type="dfn" href="#partially-contained">partially contained</a> in <var>range</var>, and so are all its <a data-link-type="dfn" href="#concept-tree-ancestor">ancestors</a> up until a <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>common ancestor</var>. <var>common ancestor</var> cannot be <var>original start node</var>, because
   it has to be an <a data-link-type="dfn" href="#concept-tree-inclusive-ancestor">inclusive ancestor</a> of <var>original end node</var>. The other case is similar. Also, notice that the two <a data-link-type="dfn" href="#concept-tree-child">children</a> will never be equal if both are defined. </p>
-    <li>Let <var>contained children</var> be a list of all <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>common ancestor</var> that are <a data-link-type="dfn" href="#contained">contained</a> in <var>range</var>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <li>Let <var>contained children</var> be a list of all <a data-link-type="dfn" href="#concept-tree-child">children</a> of <var>common ancestor</var> that are <a data-link-type="dfn" href="#contained">contained</a> in <var>range</var>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.
     <li>
-      If any member of <var>contained children</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception. 
+      If any member of <var>contained children</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception.
      <p class="note no-backref" role="note">We do not have to worry about the first or last partially
   contained node, because a <a data-link-type="dfn" href="#concept-doctype">doctype</a> can never be
   partially contained. It cannot be a boundary point of a range, and it
   cannot be the ancestor of anything. </p>
     <li>
-      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>first partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>:
      <p class="note no-backref" role="note">In this case, <var>first partially contained child</var> is <var>original start node</var>. </p>
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>. 
-      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original start node</var>.
+      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original start node</var>, offset <var>original start offset</var>, and count <var>original start node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> minus <var>original start offset</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
      </ol>
     <li>
       Otherwise, if <var>first partially contained child</var> is not
-  null: 
+  null:
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>first partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>first partially contained child</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
    whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
-   (<var>first partially contained child</var>, <var>first partially contained child</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
+   (<var>first partially contained child</var>, <var>first partially contained child</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>).
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
      </ol>
     <li>
-      For each <var>contained child</var> in <var>contained children</var>: 
+      For each <var>contained child</var> in <var>contained children</var>:
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>contained child</var> with the <i>clone children flag</i> set. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>contained child</var> with the <i>clone children flag</i> set.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
      </ol>
     <li>
-      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>: 
+      If <var>last partially contained child</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>:
      <p class="note no-backref" role="note">In this case, <var>last partially contained child</var> is <var>original end node</var>. </p>
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original end node</var>. 
-      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>original end node</var>.
+      <li>Set the <a data-link-type="dfn" href="#concept-cd-data">data</a> of <var>clone</var> to the result of <a data-link-type="dfn" href="#concept-cd-substring">substringing data</a> with node <var>original end node</var>, offset 0, and count <var>original end offset</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
      </ol>
     <li>
       Otherwise, if <var>last partially contained child</var> is not
-  null: 
+  null:
      <ol>
-      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>last partially contained child</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>. 
+      <li>Let <var>clone</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>last partially contained child</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>clone</var> to <var>fragment</var>.
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>last partially contained child</var>, 0) and whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
-   (<var>original end node</var>, <var>original end offset</var>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>. 
-      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
+   (<var>original end node</var>, <var>original end offset</var>).
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>.
+      <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>.
      </ol>
-    <li>Return <var>fragment</var>. 
+    <li>Return <var>fragment</var>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-clonecontents">cloneContents()<a class="self-link" href="#dom-range-clonecontents"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-insert">insert<a class="self-link" href="#concept-range-insert"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> into a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
     <li>
-     If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, or is <var>node</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception. 
+     If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, or is <var>node</var>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a></code> exception.
      <p></p>
-    <li>Let <var>referenceNode</var> be null. 
+    <li>Let <var>referenceNode</var> be null.
     <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>,
- set <var>referenceNode</var> to that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
+ set <var>referenceNode</var> to that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>.
     <li>Otherwise, set <var>referenceNode</var> to the <a data-link-type="dfn" href="#concept-tree-child">child</a> of <a data-link-type="dfn" href="#concept-range-start-node">start node</a> whose <a data-link-type="dfn" href="#concept-tree-index">index</a> is <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>, and null if
- there is no such <a data-link-type="dfn" href="#concept-tree-child">child</a>. 
+ there is no such <a data-link-type="dfn" href="#concept-tree-child">child</a>.
     <li>
-     Let <var>parent</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> if <var>referenceNode</var> is null, and <var>referenceNode</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> otherwise. 
+     Let <var>parent</var> be <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> if <var>referenceNode</var> is null, and <var>referenceNode</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> otherwise.
      <p></p>
-    <li><a data-link-type="dfn" href="#concept-node-ensure-pre-insertion-validity">Ensure pre-insertion validity</a> of <var>node</var> into <var>parent</var> before <var>referenceNode</var>. 
+    <li><a data-link-type="dfn" href="#concept-node-ensure-pre-insertion-validity">Ensure pre-insertion validity</a> of <var>node</var> into <var>parent</var> before <var>referenceNode</var>.
     <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, set <var>referenceNode</var> to the result of <a data-link-type="dfn" href="#concept-text-split">splitting</a> it with
- offset <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>. 
-    <li>If <var>node</var> is <var>referenceNode</var>, set <var>referenceNode</var> to its <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
+ offset <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a>.
+    <li>If <var>node</var> is <var>referenceNode</var>, set <var>referenceNode</var> to its <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>.
     <li>
      If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is not
- null, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+ null, <a data-link-type="dfn" href="#concept-node-remove">remove</a> <var>node</var> from its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
      <p></p>
     <li>Let <var>newOffset</var> be <var>parent</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> if <var>referenceNode</var> is null,
- and <var>referenceNode</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a> otherwise. 
-    <li>Increase <var>newOffset</var> by <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and one otherwise. 
-    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into <var>parent</var> before <var>referenceNode</var>. 
+ and <var>referenceNode</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a> otherwise.
+    <li>Increase <var>newOffset</var> by <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a> if <var>node</var> is a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, and one otherwise.
+    <li><a data-link-type="dfn" href="#concept-node-pre-insert">Pre-insert</a> <var>node</var> into <var>parent</var> before <var>referenceNode</var>.
     <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> are the same, set <var>range</var>’s <a data-link-type="dfn" href="#concept-range-end">end</a> to
- (<var>parent</var>, <var>newOffset</var>). 
+ (<var>parent</var>, <var>newOffset</var>).
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-insertnode">insertNode(<var>node</var>)<a class="self-link" href="#dom-range-insertnode"></a></dfn> method must <a data-link-type="dfn" href="#concept-range-insert">insert</a> <var>node</var> into <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-surroundcontents">surroundContents(<var>newParent</var>)<a class="self-link" href="#dom-range-surroundcontents"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>If a non-<code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in the <a data-link-type="dfn" href="#context-object">context object</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception. 
+    <li>If a non-<code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#partially-contained">partially contained</a> in the <a data-link-type="dfn" href="#context-object">context object</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a></code> exception.
     <li>
-     If <var>newParent</var> is a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, or <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
+     If <var>newParent</var> is a <code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, or <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
      <p></p>
-    <li>Let <var>fragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>If <var>newParent</var> has <a data-link-type="dfn" href="#concept-tree-child">children</a>, <a data-link-type="dfn" href="#concept-node-replace-all">replace all</a> with null within <var>newParent</var>. 
-    <li><a data-link-type="dfn" href="#concept-range-insert">Insert</a> <var>newParent</var> into <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>fragment</var> to <var>newParent</var>. 
-    <li><a data-link-type="dfn" href="#concept-range-select">Select</a> <var>newParent</var> within <a data-link-type="dfn" href="#context-object">context object</a>. 
+    <li>Let <var>fragment</var> be the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li>If <var>newParent</var> has <a data-link-type="dfn" href="#concept-tree-child">children</a>, <a data-link-type="dfn" href="#concept-node-replace-all">replace all</a> with null within <var>newParent</var>.
+    <li><a data-link-type="dfn" href="#concept-range-insert">Insert</a> <var>newParent</var> into <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>fragment</var> to <var>newParent</var>.
+    <li><a data-link-type="dfn" href="#concept-range-select">Select</a> <var>newParent</var> within <a data-link-type="dfn" href="#context-object">context object</a>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-clonerange">cloneRange()<a class="self-link" href="#dom-range-clonerange"></a></dfn> method must return a new <a data-link-type="dfn" href="#concept-range">range</a> with the
 same <a data-link-type="dfn" href="#concept-range-start">start</a> and <a data-link-type="dfn" href="#concept-range-end">end</a> as the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
@@ -3742,55 +3772,55 @@ do nothing. <span class="note" role="note">Its functionality (disabling a <code 
 for compatibility.</span></p>
    <hr>
    <dl class="domintro">
-    <dt><var>position</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-comparepoint">comparePoint(node, offset)</a></code> 
+    <dt><var>position</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-comparepoint">comparePoint(node, offset)</a></code>
     <dd>Returns −1 if the point is before the range, 0 if the point is
- in the range, and 1 if the point is after the range. 
-    <dt><var>intersects</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-intersectsnode">intersectsNode(node)</a></code> 
-    <dd>Returns whether <var>range</var> intersects <var>node</var>. 
+ in the range, and 1 if the point is after the range.
+    <dt><var>intersects</var> = <var>range</var> . <code class="idl"><a data-link-type="idl" href="#dom-range-intersectsnode">intersectsNode(node)</a></code>
+    <dd>Returns whether <var>range</var> intersects <var>node</var>.
    </dl>
    <div class="impl">
     <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-ispointinrange">isPointInRange(<var>node</var>, <var>offset</var>)<a class="self-link" href="#dom-range-ispointinrange"></a></dfn> must run these steps:</p>
     <ol>
      <li>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is
- different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, return false. 
-     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
-     <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
-     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-start">start</a> or <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-end">end</a>, return false. 
-     <li>Return true. 
+ different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, return false.
+     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
+     <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception.
+     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-start">start</a> or <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-end">end</a>, return false.
+     <li>Return true.
     </ol>
     <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-comparepoint">comparePoint(<var>node</var>, <var>offset</var>)<a class="self-link" href="#dom-range-comparepoint"></a></dfn> method must run these steps:</p>
     <ol>
      <li>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is
- different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a></code> exception. 
-     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception. 
-     <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception. 
-     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-start">start</a>, return −1. 
-     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-end">end</a>, return 1. 
-     <li>Return 0. 
+ different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a></code> exception.
+     <li>If <var>node</var> is a <a data-link-type="dfn" href="#concept-doctype">doctype</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a></code> exception.
+     <li>If <var>offset</var> is greater than <var>node</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a></code> exception.
+     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-start">start</a>, return −1.
+     <li>If (<var>node</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-end">end</a>, return 1.
+     <li>Return 0.
     </ol>
     <hr>
     <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-intersectsnode">intersectsNode(<var>node</var>)<a class="self-link" href="#dom-range-intersectsnode"></a></dfn> method must run these steps:</p>
     <ol>
-     <li>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, return false. 
-     <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-     <li>If <var>parent</var> is null, return true. 
-     <li>Let <var>offset</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
-     <li>If (<var>parent</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-end">end</a> and (<var>parent</var>, <var>offset</var> + 1) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-start">start</a>, return true. 
-     <li>Return false. 
+     <li>If <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is different from the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-range-root">root</a>, return false.
+     <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+     <li>If <var>parent</var> is null, return true.
+     <li>Let <var>offset</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-index">index</a>.
+     <li>If (<var>parent</var>, <var>offset</var>) is <a data-link-type="dfn" href="#concept-range-bp-before">before</a> <a data-link-type="dfn" href="#concept-range-end">end</a> and (<var>parent</var>, <var>offset</var> + 1) is <a data-link-type="dfn" href="#concept-range-bp-after">after</a> <a data-link-type="dfn" href="#concept-range-start">start</a>, return true.
+     <li>Return false.
     </ol>
    </div>
    <hr>
    <p>The <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="dom-range-stringifier">stringification behavior<a class="self-link" href="#dom-range-stringifier"></a></dfn> must run
 these steps:</p>
    <ol>
-    <li>Let <var>s</var> be the empty string. 
+    <li>Let <var>s</var> be the empty string.
     <li>If <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is <a data-link-type="dfn" href="#concept-range-end-node">end node</a>, and it is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, return the
- substring of that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> beginning at <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> and ending at <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
-    <li>If <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> from the <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> until the end. 
+ substring of that <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> beginning at <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> and ending at <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>.
+    <li>If <a data-link-type="dfn" href="#concept-range-start-node">start node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> from the <a data-link-type="dfn" href="#concept-range-start-offset">start offset</a> until the end.
     <li>Append to <var>s</var> the concatenation, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>, of the <a data-link-type="dfn" href="#concept-cd-data">data</a> of all <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> that are <a data-link-type="dfn" href="#contained">contained</a> in
- the <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>If <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> from its start until the <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>. 
-    <li>Return <var>s</var>. 
+ the <a data-link-type="dfn" href="#context-object">context object</a>.
+    <li>If <a data-link-type="dfn" href="#concept-range-end-node">end node</a> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>, append to <var>s</var> the substring of that <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a> from its start until the <a data-link-type="dfn" href="#concept-range-end-offset">end offset</a>.
+    <li>Return <var>s</var>.
    </ol>
    <hr>
    <p class="note no-backref" role="note">The <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/DOM-Parsing/#widl-Range-createContextualFragment-DocumentFragment-DOMString-fragment">createContextualFragment()</a></code>, <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects">getClientRects()</a></code>,
@@ -3803,15 +3833,15 @@ has an associated <dfn data-dfn-for="traversal" data-dfn-type="dfn" data-export=
    <p>To <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-filter">filter<a class="self-link" href="#concept-node-filter"></a></dfn> <var>node</var> run
 these steps:</p>
    <ol>
-    <li>Let <var>n</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code> attribute value minus 1. 
+    <li>Let <var>n</var> be <var>node</var>’s <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code> attribute value minus 1.
     <li>If the <var>n</var><sup>th</sup> bit (where 0 is the least
  significant bit) of <a data-link-type="dfn" href="#concept-traversal-whattoshow">whatToShow</a> is not set,
- return <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_skip">FILTER_SKIP</a></code>. 
+ return <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_skip">FILTER_SKIP</a></code>.
     <li>If <a data-link-type="dfn" href="#concept-traversal-filter">filter</a> is null,
- return <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>. 
+ return <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>.
     <li>Let <var>result</var> be the return value of calling <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>’s <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-acceptnode">acceptNode()</a></code> with <var>node</var> as
- argument. Rethrow any exceptions. 
-    <li>Return <var>result</var>. 
+ argument. Rethrow any exceptions.
+    <li>Return <var>result</var>.
    </ol>
    <h3 class="heading settled" data-level="6.1" id="interface-nodeiterator"><span class="secno">6.1. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code></span><a class="self-link" href="#interface-nodeiterator"></a></h3>
 <pre class="idl">[Exposed=Window]
@@ -3845,7 +3875,7 @@ associated <a data-link-type="dfn" href="#concept-traversal-root">root</a> <a da
       <li>
        <p>If <var>next</var> is non-null, set <var>nodeIterator</var>’s <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute to <var>next</var> and terminate these steps. </p>
       <li>
-        Otherwise, set <var>nodeIterator</var>’s <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute to false. 
+        Otherwise, set <var>nodeIterator</var>’s <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute to false.
        <p class="note no-backref" role="note">Steps are not terminated here. </p>
      </ol>
     <li>
@@ -3860,30 +3890,30 @@ must return <a data-link-type="dfn" href="#concept-traversal-root">root</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="NodeIterator" data-dfn-type="attribute" data-export="" id="dom-nodeiterator-filter">filter<a class="self-link" href="#dom-nodeiterator-filter"></a></dfn> attribute must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.</p>
    <p>To <dfn data-dfn-for="NodeIterator" data-dfn-type="dfn" data-export="" id="concept-nodeiterator-traverse">traverse<a class="self-link" href="#concept-nodeiterator-traverse"></a></dfn> in direction <var>direction</var> run these steps:</p>
    <ol>
-    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute. 
-    <li>Let <var>before node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute. 
+    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute.
+    <li>Let <var>before node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute.
     <li>
-      Run these substeps: 
+      Run these substeps:
      <ol>
       <li>
        <dl class="switch">
-        <dt>If <var>direction</var> is next 
+        <dt>If <var>direction</var> is next
         <dd> If <var>before node</var> is false, let <var>node</var> be the first <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node</var> in the <span>iterator collection</span>. If
       there is no such <a data-link-type="dfn" href="#concept-node">node</a> return null.
-      If <var>before node</var> is true, set it to false. 
-        <dt>If <var>direction</var> is previous 
+      If <var>before node</var> is true, set it to false.
+        <dt>If <var>direction</var> is previous
         <dd> If <var>before node</var> is true, let <var>node</var> be the first <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>node</var> in the <span>iterator collection</span>. If
       there is no such <a data-link-type="dfn" href="#concept-node">node</a> return null.
-      If <var>before node</var> is false, set it to true. 
+      If <var>before node</var> is false, set it to true.
        </dl>
       <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
-   value. 
+   value.
       <li> If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, go to the
     next step in the overall set of steps.
-    Otherwise, run these substeps again. 
+    Otherwise, run these substeps again.
      </ol>
     <li>Set the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> attribute
- to <var>node</var>, set the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute to <var>before node</var>, and return <var>node</var>. 
+ to <var>node</var>, set the <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attribute to <var>before node</var>, and return <var>node</var>.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="NodeIterator" data-dfn-type="method" data-export="" id="dom-nodeiterator-nextnode">nextNode()<a class="self-link" href="#dom-nodeiterator-nextnode"></a></dfn> method must <a data-link-type="dfn" href="#concept-nodeiterator-traverse">traverse</a> in
 direction next.</p>
@@ -3919,46 +3949,46 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
    <p>Setting the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute must set it to the new value.</p>
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="method" data-export="" id="dom-treewalker-parentnode">parentNode()<a class="self-link" href="#dom-treewalker-parentnode"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute. 
+    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute.
     <li>
-      While <var>node</var> is not null and is not <a data-link-type="dfn" href="#concept-traversal-root">root</a>, run these substeps: 
+      While <var>node</var> is not null and is not <a data-link-type="dfn" href="#concept-traversal-root">root</a>, run these substeps:
      <ol>
-      <li>Let <var>node</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+      <li>Let <var>node</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
       <li>If <var>node</var> is not null and <a data-link-type="dfn" href="#concept-node-filter">filtering</a> <var>node</var> returns <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>,
-   then set the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var>, return <var>node</var>. 
+   then set the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var>, return <var>node</var>.
      </ol>
-    <li>Return null. 
+    <li>Return null.
    </ol>
    <p>To <dfn data-dfn-for="TreeWalker" data-dfn-type="dfn" data-export="" id="concept-traverse-children">traverse children<a class="self-link" href="#concept-traverse-children"></a></dfn> of type <var>type</var>, run these steps:</p>
    <ol>
     <li>Let <var>node</var> be the value
- of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute. 
-    <li>Set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> if <var>type</var> is first, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>type</var> is last. 
-    <li>If <var>node</var> is null, return null. 
+ of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute.
+    <li>Set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> if <var>type</var> is first, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>type</var> is last.
+    <li>If <var>node</var> is null, return null.
     <li>
       <dfn data-dfn-type="dfn" data-export="" data-lt="Traverse children main step" id="concept-traverse-children-main">Main<a class="self-link" href="#concept-traverse-children-main"></a></dfn>:
-  Repeat these substeps: 
+  Repeat these substeps:
      <ol>
       <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
-   value. 
+   value.
       <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
-   the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>. 
+   the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>.
       <li>
         If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_skip">FILTER_SKIP</a></code>, run these
-    subsubsteps: 
+    subsubsteps:
        <ol>
-        <li>Let <var>child</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> if <var>type</var> is first, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>type</var> is last. 
-        <li>If <var>child</var> is not null, set <var>node</var> to <var>child</var> and goto <a data-link-type="dfn" href="#concept-traverse-children-main">Main</a>. 
+        <li>Let <var>child</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> if <var>type</var> is first, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>type</var> is last.
+        <li>If <var>child</var> is not null, set <var>node</var> to <var>child</var> and goto <a data-link-type="dfn" href="#concept-traverse-children-main">Main</a>.
        </ol>
       <li>
-        Repeat these subsubsteps: 
+        Repeat these subsubsteps:
        <ol>
-        <li>Let <var>sibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> if <var>type</var> is first, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> if <var>type</var> is last. 
-        <li>If <var>sibling</var> is not null, set <var>node</var> to <var>sibling</var> and goto <a data-link-type="dfn" href="#concept-traverse-children-main">Main</a>. 
-        <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+        <li>Let <var>sibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> if <var>type</var> is first, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> if <var>type</var> is last.
+        <li>If <var>sibling</var> is not null, set <var>node</var> to <var>sibling</var> and goto <a data-link-type="dfn" href="#concept-traverse-children-main">Main</a>.
+        <li>Let <var>parent</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
         <li>If <var>parent</var> is null, <var>parent</var> is <a data-link-type="dfn" href="#concept-traversal-root">root</a>, or <var>parent</var> is <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute’s
-     value, return null. 
-        <li>Otherwise, set <var>node</var> to <var>parent</var>. 
+     value, return null.
+        <li>Otherwise, set <var>node</var> to <var>parent</var>.
        </ol>
      </ol>
    </ol>
@@ -3966,85 +3996,85 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="method" data-export="" id="dom-treewalker-lastchild">lastChild()<a class="self-link" href="#dom-treewalker-lastchild"></a></dfn> method must <a data-link-type="dfn" href="#concept-traverse-children">traverse children</a> of type last.</p>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-traverse-siblings">traverse siblings<a class="self-link" href="#concept-traverse-siblings"></a></dfn> of type <var>type</var> run these steps:</p>
    <ol>
-    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute. 
-    <li>If <var>node</var> is <a data-link-type="dfn" href="#concept-traversal-root">root</a>, return null. 
+    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute.
+    <li>If <var>node</var> is <a data-link-type="dfn" href="#concept-traversal-root">root</a>, return null.
     <li>
-      Run these substeps: 
+      Run these substeps:
      <ol>
-      <li>Let <var>sibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> if <var>type</var> is next, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> if <var>type</var> is previous. 
+      <li>Let <var>sibling</var> be <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> if <var>type</var> is next, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> if <var>type</var> is previous.
       <li>
-        While <var>sibling</var> is not null, run these subsubsteps: 
+        While <var>sibling</var> is not null, run these subsubsteps:
        <ol>
-        <li>Set <var>node</var> to <var>sibling</var>. 
+        <li>Set <var>node</var> to <var>sibling</var>.
         <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
-     value. 
+     value.
         <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
-     the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>. 
-        <li>Set <var>sibling</var> to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> if <var>type</var> is next, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>type</var> is previous. 
-        <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_reject">FILTER_REJECT</a></code> or <var>sibling</var> is null, then set <var>sibling</var> to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> if <var>type</var> is next, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> if <var>type</var> is previous. 
+     the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>.
+        <li>Set <var>sibling</var> to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a> if <var>type</var> is next, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> if <var>type</var> is previous.
+        <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_reject">FILTER_REJECT</a></code> or <var>sibling</var> is null, then set <var>sibling</var> to <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> if <var>type</var> is next, and <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> if <var>type</var> is previous.
        </ol>
-      <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
-      <li>If <var>node</var> is null or is <a data-link-type="dfn" href="#concept-traversal-root">root</a>, return null. 
+      <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
+      <li>If <var>node</var> is null or is <a data-link-type="dfn" href="#concept-traversal-root">root</a>, return null.
       <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and if the return value is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then
-   return null. 
-      <li>Run these substeps again. 
+   return null.
+      <li>Run these substeps again.
      </ol>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="method" data-export="" id="dom-treewalker-nextsibling">nextSibling()<a class="self-link" href="#dom-treewalker-nextsibling"></a></dfn> method must <a data-link-type="dfn" href="#concept-traverse-siblings">traverse siblings</a> of type next.</p>
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="method" data-export="" id="dom-treewalker-previoussibling">previousSibling()<a class="self-link" href="#dom-treewalker-previoussibling"></a></dfn> method must <a data-link-type="dfn" href="#concept-traverse-siblings">traverse siblings</a> of type previous.</p>
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="method" data-export="" id="dom-treewalker-previousnode">previousNode()<a class="self-link" href="#dom-treewalker-previousnode"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute. 
+    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute.
     <li>
-      While <var>node</var> is not <a data-link-type="dfn" href="#concept-traversal-root">root</a>, run these substeps: 
+      While <var>node</var> is not <a data-link-type="dfn" href="#concept-traversal-root">root</a>, run these substeps:
      <ol>
-      <li>Let <var>sibling</var> be the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> of <var>node</var>. 
+      <li>Let <var>sibling</var> be the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> of <var>node</var>.
       <li>
-        While <var>sibling</var> is not null, run these subsubsteps: 
+        While <var>sibling</var> is not null, run these subsubsteps:
        <ol>
-        <li>Set <var>node</var> to <var>sibling</var>. 
+        <li>Set <var>node</var> to <var>sibling</var>.
         <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and let <var>result</var> be the return
-     value. 
+     value.
         <li>While <var>result</var> is not <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_reject">FILTER_REJECT</a></code> and <var>node</var> has a <a data-link-type="dfn" href="#concept-tree-child">child</a>, set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-last-child">last child</a> and then <a data-link-type="dfn" href="#concept-node-filter">filter</a> <var>node</var> and
-     set <var>result</var> to the return value. 
+     set <var>result</var> to the return value.
         <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
-     the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>. 
-        <li>Set <var>sibling</var> to the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> of <var>node</var>. 
+     the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute to <var>node</var> and return <var>node</var>.
+        <li>Set <var>sibling</var> to the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> of <var>node</var>.
        </ol>
-      <li>If <var>node</var> is <a data-link-type="dfn" href="#concept-traversal-root">root</a> or <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, return null. 
-      <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. 
+      <li>If <var>node</var> is <a data-link-type="dfn" href="#concept-traversal-root">root</a> or <var>node</var>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, return null.
+      <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>.
       <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and if the return value is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
    the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute
-   to <var>node</var> and return <var>node</var>. 
+   to <var>node</var> and return <var>node</var>.
      </ol>
-    <li>Return null. 
+    <li>Return null.
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="TreeWalker" data-dfn-type="method" data-export="" id="dom-treewalker-nextnode">nextNode()<a class="self-link" href="#dom-treewalker-nextnode"></a></dfn> method must run these steps:</p>
    <ol>
-    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute. 
-    <li>Let <var>result</var> be <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>. 
+    <li>Let <var>node</var> be the value of the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute.
+    <li>Let <var>result</var> be <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>.
     <li>
-      Run these substeps: 
+      Run these substeps:
      <ol>
       <li>
         While <var>result</var> is not <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_reject">FILTER_REJECT</a></code> and <var>node</var> has a <a data-link-type="dfn" href="#concept-tree-child">child</a>,
-    run these subsubsteps: 
+    run these subsubsteps:
        <ol>
-        <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. 
+        <li>Set <var>node</var> to its <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>.
         <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and set <var>result</var> to the return
-     value. 
+     value.
         <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
      the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute
-     to <var>node</var> and return <var>node</var>. 
+     to <var>node</var> and return <var>node</var>.
        </ol>
       <li> If a <a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#concept-tree-following">following</a> <var>node</var> and is not <a data-link-type="dfn" href="#concept-tree-following">following</a> <a data-link-type="dfn" href="#concept-traversal-root">root</a>, set <var>node</var> to the first such <a data-link-type="dfn" href="#concept-node">node</a>.
-    Otherwise, return null. 
+    Otherwise, return null.
       <li><a data-link-type="dfn" href="#concept-node-filter">Filter</a> <var>node</var> and set <var>result</var> to the return
-   value. 
+   value.
       <li>If <var>result</var> is <code class="idl"><a data-link-type="idl" href="#dom-nodefilter-filter_accept">FILTER_ACCEPT</a></code>, then set
    the <code class="idl"><a data-link-type="idl" href="#dom-treewalker-currentnode">currentNode</a></code> attribute
-   to <var>node</var> and return <var>node</var>. 
-      <li>Run these substeps again. 
+   to <var>node</var> and return <var>node</var>.
+      <li>Run these substeps again.
      </ol>
    </ol>
    <h3 class="heading settled" data-level="6.3" id="interface-nodefilter"><span class="secno">6.3. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#callbackdef-nodefilter">NodeFilter</a></code></span><a class="self-link" href="#interface-nodefilter"></a></h3>
@@ -4078,20 +4108,20 @@ constants for the <a data-link-type="dfn" href="#concept-traversal-whattoshow">w
    <p class="note no-backref" role="note">It is typically implemented as a JavaScript function. </p>
    <p>These constants can be used as callback return value:</p>
    <ul class="brief">
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-filter_accept">FILTER_ACCEPT<a class="self-link" href="#dom-nodefilter-filter_accept"></a></dfn> (1); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-filter_reject">FILTER_REJECT<a class="self-link" href="#dom-nodefilter-filter_reject"></a></dfn> (2); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-filter_skip">FILTER_SKIP<a class="self-link" href="#dom-nodefilter-filter_skip"></a></dfn> (3). 
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-filter_accept">FILTER_ACCEPT<a class="self-link" href="#dom-nodefilter-filter_accept"></a></dfn> (1);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-filter_reject">FILTER_REJECT<a class="self-link" href="#dom-nodefilter-filter_reject"></a></dfn> (2);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-filter_skip">FILTER_SKIP<a class="self-link" href="#dom-nodefilter-filter_skip"></a></dfn> (3).
    </ul>
    <p>These constants can be used for the <a data-link-type="dfn" href="#concept-traversal-whattoshow">whatToShow</a> bitmask:</p>
    <ul class="brief">
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_all">SHOW_ALL<a class="self-link" href="#dom-nodefilter-show_all"></a></dfn> (4294967295, FFFFFFFF in hexadecimal); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_element">SHOW_ELEMENT<a class="self-link" href="#dom-nodefilter-show_element"></a></dfn> (1); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_text">SHOW_TEXT<a class="self-link" href="#dom-nodefilter-show_text"></a></dfn> (4); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_processing_instruction">SHOW_PROCESSING_INSTRUCTION<a class="self-link" href="#dom-nodefilter-show_processing_instruction"></a></dfn> (64, 40 in hexadecimal); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_comment">SHOW_COMMENT<a class="self-link" href="#dom-nodefilter-show_comment"></a></dfn> (128, 80 in hexadecimal); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_document">SHOW_DOCUMENT<a class="self-link" href="#dom-nodefilter-show_document"></a></dfn> (256, 100 in hexadecimal); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_document_type">SHOW_DOCUMENT_TYPE<a class="self-link" href="#dom-nodefilter-show_document_type"></a></dfn> (512, 200 in hexadecimal); 
-    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_document_fragment">SHOW_DOCUMENT_FRAGMENT<a class="self-link" href="#dom-nodefilter-show_document_fragment"></a></dfn> (1024, 400 in hexadecimal). 
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_all">SHOW_ALL<a class="self-link" href="#dom-nodefilter-show_all"></a></dfn> (4294967295, FFFFFFFF in hexadecimal);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_element">SHOW_ELEMENT<a class="self-link" href="#dom-nodefilter-show_element"></a></dfn> (1);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_text">SHOW_TEXT<a class="self-link" href="#dom-nodefilter-show_text"></a></dfn> (4);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_processing_instruction">SHOW_PROCESSING_INSTRUCTION<a class="self-link" href="#dom-nodefilter-show_processing_instruction"></a></dfn> (64, 40 in hexadecimal);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_comment">SHOW_COMMENT<a class="self-link" href="#dom-nodefilter-show_comment"></a></dfn> (128, 80 in hexadecimal);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_document">SHOW_DOCUMENT<a class="self-link" href="#dom-nodefilter-show_document"></a></dfn> (256, 100 in hexadecimal);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_document_type">SHOW_DOCUMENT_TYPE<a class="self-link" href="#dom-nodefilter-show_document_type"></a></dfn> (512, 200 in hexadecimal);
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_document_fragment">SHOW_DOCUMENT_FRAGMENT<a class="self-link" href="#dom-nodefilter-show_document_fragment"></a></dfn> (1024, 400 in hexadecimal).
    </ul>
    <h2 class="heading settled" data-level="7" id="sets"><span class="secno">7. </span><span class="content">Sets</span><a class="self-link" href="#sets"></a></h2>
    <p class="note no-backref" role="note">Yes, the name <code class="idl"><a data-link-type="idl" href="#domtokenlist">DOMTokenList</a></code> is an unfortunate legacy mishap. </p>
@@ -4141,29 +4171,29 @@ to <a data-link-type="dfn" href="#concept-element-attributes-set-value">set an a
 associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-named-attribute"><var>associated attribute’s local name</var> attribute</a> is <a data-link-type="dfn" href="#attribute-is-set">set</a>, set <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a> to the new <a data-link-type="dfn" href="#concept-attribute-value">value</a>, <a data-link-type="dfn" href="#concept-ordered-set-parser">parsed</a>. </p>
    <p>When an associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-named-attribute"><var>associated attribute’s local name</var> attribute</a> is <a data-link-type="dfn" href="#attribute-is-removed">removed</a>, set <a data-link-type="dfn" href="#concept-dtl-tokens">tokens</a> to the empty set. </p>
    <dl class="domintro">
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-length">length</a></code></code> 
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-length">length</a></code></code>
     <dd>
      <p>Returns the number of tokens. </p>
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-item">item(index)</a></code></code> 
-    <dt><code><var>tokenlist</var>[<var>index</var>]</code> 
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-item">item(index)</a></code></code>
+    <dt><code><var>tokenlist</var>[<var>index</var>]</code>
     <dd>
      <p>Returns the token with index <var>index</var>. </p>
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-contains">contains(token)</a></code></code> 
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-contains">contains(token)</a></code></code>
     <dd>
      <p>Returns true if <var>token</var> is present, and false otherwise. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if <var>token</var> is the empty string. </p>
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if <var>token</var> contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. </p>
-    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-add">add(<var>tokens</var>…)</a></code> 
+    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-add">add(<var>tokens</var>…)</a></code>
     <dd>
      <p>Adds all arguments passed, except those already present. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if one of the arguments is the empty string. </p>
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if one of the arguments contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. </p>
-    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-remove">remove(<var>tokens</var>…)</a></code> 
+    <dt><code><var>tokenlist</var> . <a data-link-type="functionish" href="#dom-domtokenlist-remove">remove(<var>tokens</var>…)</a></code>
     <dd>
      <p>Removes arguments passed, if they are present. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if one of the arguments is the empty string. </p>
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if one of the arguments contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. </p>
-    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-toggle">toggle(<var>token</var> [, <var>force</var>])</a></code> 
+    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-toggle">toggle(<var>token</var> [, <var>force</var>])</a></code>
     <dd>
      <p>If <var>force</var> is not given, "toggles" <var>token</var>, removing it if it’s present and
   adding it if it’s not present. If <var>force</var> is true, adds <var>token</var> (same as <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-add">add()</a></code>). If <var>force</var> is false, removes <var>token</var> (same
@@ -4171,17 +4201,17 @@ associated <a data-link-type="dfn" href="#concept-element">element</a>’s <a da
      <p>Returns true if <var>token</var> is now present, and false otherwise. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if <var>token</var> is empty. </p>
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if <var>token</var> contains any spaces. </p>
-    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-replace">replace(<var>token</var>, <var>newToken</var>)</a></code> 
+    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-replace">replace(<var>token</var>, <var>newToken</var>)</a></code>
     <dd>
      <p>Replaces <var>token</var> with <var>newToken</var>. </p>
      <p>Throws a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code> exception if one of the arguments is the empty string. </p>
      <p>Throws an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code> exception if one of the arguments contains any <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#ascii-whitespace">ASCII whitespace</a>. </p>
-    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-supports">supports(<var>token</var>)</a></code> 
+    <dt><code><var>tokenlist</var> . <a class="idl-code" data-link-type="method" href="#dom-domtokenlist-supports">supports(<var>token</var>)</a></code>
     <dd>
      <p>Returns true if <var>token</var> is in the associated attribute’s supported tokens. Returns
   false otherwise. </p>
      <p>Throws a <code>TypeError</code> exception if the associated attribute has no supported tokens defined. </p>
-    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-value">value</a></code></code> 
+    <dt><code><var>tokenlist</var> . <code class="idl"><a data-link-type="idl" href="#dom-domtokenlist-value">value</a></code></code>
     <dd>
      <p>Returns the associated set as string. </p>
      <p>Can be set, to change the associated attribute. </p>
@@ -4299,12 +4329,12 @@ enumerate the changes.</p>
 "Mutation Name Event Types" chapters of <cite>DOM Level 3 Events</cite>. The
 other chapters are defined by the <cite>UI Events</cite> specification. <a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a></p>
    <ul class="brief">
-    <li>Events have constructors now. 
-    <li>Removes <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mutationevent">MutationEvent<a class="self-link" href="#mutationevent"></a></dfn>, and <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mutationnameevent">MutationNameEvent<a class="self-link" href="#mutationnameevent"></a></dfn>. 
+    <li>Events have constructors now.
+    <li>Removes <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mutationevent">MutationEvent<a class="self-link" href="#mutationevent"></a></dfn>, and <dfn class="idl-code" data-dfn-type="interface" data-export="" id="mutationnameevent">MutationNameEvent<a class="self-link" href="#mutationnameevent"></a></dfn>.
     <li>Fire is no longer synonymous with dispatch, but includes initializing
- an event. 
+ an event.
     <li>The propagation and canceled flags are unset when invoking <code class="idl"><a data-link-type="idl" href="#dom-event-initevent">initEvent()</a></code> rather than after
- dispatch. 
+ dispatch.
    </ul>
    <h3 class="heading settled" data-level="8.2" id="dom-core-changes"><span class="secno">8.2. </span><span class="content">DOM Core</span><a class="self-link" href="#dom-core-changes"></a></h3>
    <p>These are the changes made to the features described in <cite>DOM Level 3 Core</cite>.</p>
@@ -4324,88 +4354,88 @@ remove all the following features. The editors welcome any data showing that
 some of these features should be reintroduced. </p>
    <p>Interfaces:</p>
    <ul class="brief">
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="cdatasection"><code>CDATASection</code><a class="self-link" href="#cdatasection"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domconfiguration"><code>DOMConfiguration</code><a class="self-link" href="#domconfiguration"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerror"><code>DOMError</code><a class="self-link" href="#domerror"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerrorhandler"><code>DOMErrorHandler</code><a class="self-link" href="#domerrorhandler"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationlist"><code>DOMImplementationList</code><a class="self-link" href="#domimplementationlist"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationsource"><code>DOMImplementationSource</code><a class="self-link" href="#domimplementationsource"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domlocator"><code>DOMLocator</code><a class="self-link" href="#domlocator"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domobject"><code>DOMObject</code><a class="self-link" href="#domobject"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domstringlist"><code>DOMStringList</code><a class="self-link" href="#domstringlist"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domuserdata"><code>DOMUserData</code><a class="self-link" href="#domuserdata"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entity"><code>Entity</code><a class="self-link" href="#entity"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entityreference"><code>EntityReference</code><a class="self-link" href="#entityreference"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="namelist"><code>NameList</code><a class="self-link" href="#namelist"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="notation"><code>Notation</code><a class="self-link" href="#notation"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="typeinfo"><code>TypeInfo</code><a class="self-link" href="#typeinfo"></a></dfn> 
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="userdatahandler"><code>UserDataHandler</code><a class="self-link" href="#userdatahandler"></a></dfn> 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="cdatasection"><code>CDATASection</code><a class="self-link" href="#cdatasection"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domconfiguration"><code>DOMConfiguration</code><a class="self-link" href="#domconfiguration"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerror"><code>DOMError</code><a class="self-link" href="#domerror"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerrorhandler"><code>DOMErrorHandler</code><a class="self-link" href="#domerrorhandler"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationlist"><code>DOMImplementationList</code><a class="self-link" href="#domimplementationlist"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domimplementationsource"><code>DOMImplementationSource</code><a class="self-link" href="#domimplementationsource"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domlocator"><code>DOMLocator</code><a class="self-link" href="#domlocator"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domobject"><code>DOMObject</code><a class="self-link" href="#domobject"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domstringlist"><code>DOMStringList</code><a class="self-link" href="#domstringlist"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domuserdata"><code>DOMUserData</code><a class="self-link" href="#domuserdata"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entity"><code>Entity</code><a class="self-link" href="#entity"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="entityreference"><code>EntityReference</code><a class="self-link" href="#entityreference"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="namelist"><code>NameList</code><a class="self-link" href="#namelist"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="notation"><code>Notation</code><a class="self-link" href="#notation"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="typeinfo"><code>TypeInfo</code><a class="self-link" href="#typeinfo"></a></dfn>
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="userdatahandler"><code>UserDataHandler</code><a class="self-link" href="#userdatahandler"></a></dfn>
    </ul>
    <p>Interface members:</p>
    <dl>
-    <dt><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#node">Node</a></code>
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-issupported">isSupported<a class="self-link" href="#dom-node-issupported"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getfeature">getFeature()<a class="self-link" href="#dom-node-getfeature"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getuserdata">getUserData()<a class="self-link" href="#dom-node-getuserdata"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-setuserdata">setUserData()<a class="self-link" href="#dom-node-setuserdata"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-issamenode">isSameNode()<a class="self-link" href="#dom-node-issamenode"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-issupported">isSupported<a class="self-link" href="#dom-node-issupported"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getfeature">getFeature()<a class="self-link" href="#dom-node-getfeature"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-getuserdata">getUserData()<a class="self-link" href="#dom-node-getuserdata"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-setuserdata">setUserData()<a class="self-link" href="#dom-node-setuserdata"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-issamenode">isSameNode()<a class="self-link" href="#dom-node-issamenode"></a></dfn>
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcdatasection">createCDATASection()<a class="self-link" href="#dom-document-createcdatasection"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createentityreference">createEntityReference()<a class="self-link" href="#dom-document-createentityreference"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlencoding">xmlEncoding<a class="self-link" href="#dom-document-xmlencoding"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlstandalone">xmlStandalone<a class="self-link" href="#dom-document-xmlstandalone"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlversion">xmlVersion<a class="self-link" href="#dom-document-xmlversion"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-stricterrorchecking">strictErrorChecking<a class="self-link" href="#dom-document-stricterrorchecking"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-domconfig">domConfig<a class="self-link" href="#dom-document-domconfig"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-normalizedocument">normalizeDocument()<a class="self-link" href="#dom-document-normalizedocument"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-renamenode">renameNode()<a class="self-link" href="#dom-document-renamenode"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcdatasection">createCDATASection()<a class="self-link" href="#dom-document-createcdatasection"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createentityreference">createEntityReference()<a class="self-link" href="#dom-document-createentityreference"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlencoding">xmlEncoding<a class="self-link" href="#dom-document-xmlencoding"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlstandalone">xmlStandalone<a class="self-link" href="#dom-document-xmlstandalone"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlversion">xmlVersion<a class="self-link" href="#dom-document-xmlversion"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-stricterrorchecking">strictErrorChecking<a class="self-link" href="#dom-document-stricterrorchecking"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-domconfig">domConfig<a class="self-link" href="#dom-document-domconfig"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-normalizedocument">normalizeDocument()<a class="self-link" href="#dom-document-normalizedocument"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-renamenode">renameNode()<a class="self-link" href="#dom-document-renamenode"></a></dfn>
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#domimplementation">DOMImplementation</a></code>
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-getfeature">getFeature()<a class="self-link" href="#dom-domimplementation-getfeature"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-getfeature">getFeature()<a class="self-link" href="#dom-domimplementation-getfeature"></a></dfn>
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code>
     <dd> No longer inherits from <code class="idl"><a data-link-type="idl" href="#node">Node</a></code> and therefore completely
-  changed. 
-    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
+  changed.
+    <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export="" id="dom-element-schematypeinfo">schemaTypeInfo<a class="self-link" href="#dom-element-schematypeinfo"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattribute">setIdAttribute()<a class="self-link" href="#dom-element-setidattribute"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributens">setIdAttributeNS()<a class="self-link" href="#dom-element-setidattributens"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributenode">setIdAttributeNode()<a class="self-link" href="#dom-element-setidattributenode"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="attribute" data-export="" id="dom-element-schematypeinfo">schemaTypeInfo<a class="self-link" href="#dom-element-schematypeinfo"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattribute">setIdAttribute()<a class="self-link" href="#dom-element-setidattribute"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributens">setIdAttributeNS()<a class="self-link" href="#dom-element-setidattributens"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Element" data-dfn-type="method" data-export="" id="dom-element-setidattributenode">setIdAttributeNode()<a class="self-link" href="#dom-element-setidattributenode"></a></dfn>
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-entities">entities<a class="self-link" href="#dom-documenttype-entities"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-notations">notations<a class="self-link" href="#dom-documenttype-notations"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-internalsubset">internalSubset<a class="self-link" href="#dom-documenttype-internalsubset"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-entities">entities<a class="self-link" href="#dom-documenttype-entities"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-notations">notations<a class="self-link" href="#dom-documenttype-notations"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="DocumentType" data-dfn-type="attribute" data-export="" id="dom-documenttype-internalsubset">internalSubset<a class="self-link" href="#dom-documenttype-internalsubset"></a></dfn>
      </ul>
-    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="attribute" data-export="" id="dom-text-iselementcontentwhitespace">isElementContentWhitespace<a class="self-link" href="#dom-text-iselementcontentwhitespace"></a></dfn> 
-      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="method" data-export="" id="dom-text-replacewholetext">replaceWholeText()<a class="self-link" href="#dom-text-replacewholetext"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="attribute" data-export="" id="dom-text-iselementcontentwhitespace">isElementContentWhitespace<a class="self-link" href="#dom-text-iselementcontentwhitespace"></a></dfn>
+      <li><dfn class="idl-code" data-dfn-for="Text" data-dfn-type="method" data-export="" id="dom-text-replacewholetext">replaceWholeText()<a class="self-link" href="#dom-text-replacewholetext"></a></dfn>
      </ul>
    </dl>
    <h3 class="heading settled" data-level="8.3" id="dom-ranges-changes"><span class="secno">8.3. </span><span class="content">DOM Ranges</span><a class="self-link" href="#dom-ranges-changes"></a></h3>
    <p>These are the changes made to the features described in the
 "Document Object Model Range" chapter of <cite>DOM Level 2 Traversal and Range</cite>.</p>
    <ul>
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="rangeexception">RangeException<a class="self-link" href="#rangeexception"></a></dfn> has been removed. 
-    <li><code class="idl"><a data-link-type="idl" href="#range">Range</a></code> objects can now be moved between <a data-link-type="dfn" href="#concept-document">documents</a> and used on <a data-link-type="dfn" href="#concept-node">nodes</a> that are not <a data-link-type="dfn" href="#in-a-document">in a document</a>. 
-    <li>A wild <code class="idl"><a data-link-type="idl" href="#dom-range-range">Range()</a></code> constructor appeared. 
-    <li>New methods <code class="idl"><a data-link-type="idl" href="#dom-range-comparepoint">comparePoint()</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-range-intersectsnode">intersectsNode()</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-range-ispointinrange">isPointInRange()</a></code> have been added. 
-    <li><code class="idl"><a data-link-type="idl" href="#dom-range-detach">detach()</a></code> is now a no-op. 
+    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="rangeexception">RangeException<a class="self-link" href="#rangeexception"></a></dfn> has been removed.
+    <li><code class="idl"><a data-link-type="idl" href="#range">Range</a></code> objects can now be moved between <a data-link-type="dfn" href="#concept-document">documents</a> and used on <a data-link-type="dfn" href="#concept-node">nodes</a> that are not <a data-link-type="dfn" href="#in-a-document">in a document</a>.
+    <li>A wild <code class="idl"><a data-link-type="idl" href="#dom-range-range">Range()</a></code> constructor appeared.
+    <li>New methods <code class="idl"><a data-link-type="idl" href="#dom-range-comparepoint">comparePoint()</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-range-intersectsnode">intersectsNode()</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-range-ispointinrange">isPointInRange()</a></code> have been added.
+    <li><code class="idl"><a data-link-type="idl" href="#dom-range-detach">detach()</a></code> is now a no-op.
     <li><a data-link-type="dfn" href="#dom-range-stringifier"><code>toString</code></a> is now
- defined through IDL. 
+ defined through IDL.
    </ul>
    <h3 class="heading settled" data-level="8.4" id="dom-traversal-changes"><span class="secno">8.4. </span><span class="content">DOM Traversal</span><a class="self-link" href="#dom-traversal-changes"></a></h3>
    <p>These are the changes made to the features described in the
@@ -4413,14 +4443,14 @@ some of these features should be reintroduced. </p>
    <ul>
     <li><code class="idl"><a data-link-type="idl" href="#dom-document-createnodeiterator">createNodeIterator()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-document-createtreewalker">createTreeWalker()</a></code> now have optional
  arguments and lack a fourth argument which is no longer relevant given entity references
- never made it into the DOM. 
+ never made it into the DOM.
     <li>The <dfn class="idl-code" data-dfn-for="NodeIterator, TreeWalker" data-dfn-type="attribute" data-export="" id="dom-nodeiterator-expandentityreferences">expandEntityReferences<a class="self-link" href="#dom-nodeiterator-expandentityreferences"></a></dfn> attribute has been removed from the <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> and <code class="idl"><a data-link-type="idl" href="#treewalker">TreeWalker</a></code> interfaces for the aforementioned
- reason. 
+ reason.
     <li>The <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-referencenode">referenceNode</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a></code> attributes have been added to <code class="idl"><a data-link-type="idl" href="#nodeiterator">NodeIterator</a></code> objects to align with proprietary
- extensions of implementations. 
+ extensions of implementations.
     <li><code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-nextnode">nextNode()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-previousnode">previousNode()</a></code> now throw
- when invoked from a <code class="idl"><a data-link-type="idl" href="#callbackdef-nodefilter">NodeFilter</a></code> to align with user agents. 
-    <li><code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-detach">detach()</a></code> is now a no-op. 
+ when invoked from a <code class="idl"><a data-link-type="idl" href="#callbackdef-nodefilter">NodeFilter</a></code> to align with user agents.
+    <li><code class="idl"><a data-link-type="idl" href="#dom-nodeiterator-detach">detach()</a></code> is now a no-op.
    </ul>
    <h2 class="no-num heading settled" id="acks"><span class="content">Acknowledgments</span><a class="self-link" href="#acks"></a></h2>
    <p>There have been a lot of people that have helped make DOM more interoperable over the


### PR DESCRIPTION
Not sure if I should link up the event type names to the transitions and animations specs, or just having them be strings is preferable.

See here for what Gecko does: https://mxr.mozilla.org/mozilla-central/source/dom/events/EventListenerManager.cpp#1237

And here for what Blink does (which is inherited from WebKit): https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/core/events/EventTarget.cpp&sq=package:chromium&l=351&dr=C&rcl=1452688339

r? @annevk 