### PR TITLE
clarify insert mutation algo step 6.1

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1600,8 +1600,8 @@ into a <var>parent</var> before a <var>child</var>, with an optional
   <a>tree order</a>, run these substeps:
 
   <ol>
-   <li>Insert <var>newNode</var> into <var>parent</var> before
-   <var>child</var> or at the end of <var>parent</var> if
+   <li><a for=Node>Insert</a> <var>newNode</var> into <var>parent</var> before
+   <var>child</var> or <a for=Node>append</a> it at the end of <var>parent</var> if
    <var>child</var> is null.
 
    <li>Run the <a>insertion steps</a> with


### PR DESCRIPTION
Step 6.1 of https://dom.spec.whatwg.org/#concept-node-insert is a bit unclear because it does not reference the **insert** and **append** mutation algorithms. This PR adds the links.