### PR TITLE
Use IDL link syntax in NonElementParentNode & ParentNode headings

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1872,7 +1872,7 @@ steps:
 </ol>
 
 
-<h4 id=interface-nonelementparentnode>Interface <code>NonElementParentNode</code></h4>
+<h4 id=interface-nonelementparentnode>Interface {{NonElementParentNode}}</h4>
 
 <p class="note no-backref">The
 {{NonElementParentNode/getElementById()}} method is not
@@ -1906,7 +1906,7 @@ method must return the first <a for="/">element</a>, in
 such <a for="/">element</a> otherwise.
 
 
-<h4 id="interface-parentnode">Interface <code>ParentNode</code></h4>
+<h4 id="interface-parentnode">Interface {{ParentNode}}</h4>
 
 To
 <dfn export lt="converting nodes into a node">convert <var>nodes</var> into a node</dfn>,


### PR DESCRIPTION
For uniformity with all the other "Interface `Foo`" headings.