### PR TITLE
clarify EventTarget.dispatchEvent()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1103,7 +1103,7 @@ invoked, must run these steps:
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to false.
 
- <li><p><a>Dispatch</a> the <var>event</var> and return the value that returns.
+ <li><p><a>Dispatch</a> the <var>event</var> to the <a>context object</a> and return the value that returns.
 </ol>
 
 


### PR DESCRIPTION
https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent item 3 does not say where to dispatch the event while https://dom.spec.whatwg.org/#concept-event-dispatch is expecting at least a target.