### PR TITLE
Editorial: clone a range → clone the contents of a range

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -7376,8 +7376,8 @@ The <dfn method for=Range>extractContents()</dfn> method
 must return the result of <a lt="extract a range">extracting</a>
 <a>context object</a>.
 
-To <dfn export id=concept-range-clone lt="clone a range">clone</dfn> a <a>range</a>
-<var>range</var>, run these steps:
+<p>To <dfn export id=concept-range-clone lt="clone the contents of a range">clone the contents</dfn>
+of a <a>range</a> <var>range</var>, run these steps:
 
 <ol>
  <li>Let <var>fragment</var> be a new {{DocumentFragment}}
@@ -7523,7 +7523,7 @@ To <dfn export id=concept-range-clone lt="clone a range">clone</dfn> a <a>range<
    (<var>first partially contained child</var>, <var>first partially contained child</var>'s <a>length</a>).
 
    <li>Let <var>subfragment</var> be the result of
-   <a lt="clone a range">cloning</a> <var>subrange</var>.
+   <a lt="clone the contents of a range">cloning the contents</a> of <var>subrange</var>.
 
    <li><a>Append</a> <var>subfragment</var> to
    <var>clone</var>.
@@ -7582,7 +7582,7 @@ To <dfn export id=concept-range-clone lt="clone a range">clone</dfn> a <a>range<
    (<var>original end node</var>, <var>original end offset</var>).
 
    <li>Let <var>subfragment</var> be the result of
-   <a lt="clone a range">cloning</a> <var>subrange</var>.
+   <a lt="clone the contents of a range">cloning the contents</a> of <var>subrange</var>.
 
    <li><a>Append</a> <var>subfragment</var> to
    <var>clone</var>.
@@ -7592,8 +7592,8 @@ To <dfn export id=concept-range-clone lt="clone a range">clone</dfn> a <a>range<
 </ol>
 
 The <dfn method for=Range>cloneContents()</dfn>
-method must return the result of <a lt="clone a range">cloning</a>
-<a>context object</a>.
+method must return the result of <a lt="clone the contents of a range">cloning the contents</a>
+of <a>context object</a>.
 
 To <dfn export id=concept-range-insert for=Range>insert</dfn> a <a>node</a>
 <var>node</var> into a <a>range</a>

--- a/dom.html
+++ b/dom.html
@@ -3737,7 +3737,7 @@ run these steps:</p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-extractcontents">extractContents()<a class="self-link" href="#dom-range-extractcontents"></a></dfn> method
 must return the result of <a data-link-type="dfn" href="#concept-range-extract">extracting</a> <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="clone a range" id="concept-range-clone">clone<a class="self-link" href="#concept-range-clone"></a></dfn> a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
+   <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="clone the contents of a range" id="concept-range-clone">clone the contents<a class="self-link" href="#concept-range-clone"></a></dfn> of a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps: </p>
    <ol>
     <li>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start-node">start node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>. 
     <li>If <var>range</var>’s <a data-link-type="dfn" href="#concept-range-start">start</a> is its <a data-link-type="dfn" href="#concept-range-end">end</a>, return <var>fragment</var>. 
@@ -3785,7 +3785,7 @@ must return the result of <a data-link-type="dfn" href="#concept-range-extract">
    (<var>original start node</var>, <var>original start offset</var>) and
    whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
    (<var>first partially contained child</var>, <var>first partially contained child</var>’s <a data-link-type="dfn" href="#concept-node-length">length</a>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>. 
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning the contents</a> of <var>subrange</var>. 
       <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
      </ol>
     <li>
@@ -3811,12 +3811,12 @@ must return the result of <a data-link-type="dfn" href="#concept-range-extract">
       <li>Let <var>subrange</var> be a new <a data-link-type="dfn" href="#concept-range">range</a> whose <a data-link-type="dfn" href="#concept-range-start">start</a> is
    (<var>last partially contained child</var>, 0) and whose <a data-link-type="dfn" href="#concept-range-end">end</a> is
    (<var>original end node</var>, <var>original end offset</var>). 
-      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <var>subrange</var>. 
+      <li>Let <var>subfragment</var> be the result of <a data-link-type="dfn" href="#concept-range-clone">cloning the contents</a> of <var>subrange</var>. 
       <li><a data-link-type="dfn" href="#concept-node-append">Append</a> <var>subfragment</var> to <var>clone</var>. 
      </ol>
     <li>Return <var>fragment</var>. 
    </ol>
-   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-clonecontents">cloneContents()<a class="self-link" href="#dom-range-clonecontents"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-range-clone">cloning</a> <a data-link-type="dfn" href="#context-object">context object</a>.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Range" data-dfn-type="method" data-export="" id="dom-range-clonecontents">cloneContents()<a class="self-link" href="#dom-range-clonecontents"></a></dfn> method must return the result of <a data-link-type="dfn" href="#concept-range-clone">cloning the contents</a> of <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>To <dfn data-dfn-for="Range" data-dfn-type="dfn" data-export="" id="concept-range-insert">insert<a class="self-link" href="#concept-range-insert"></a></dfn> a <a data-link-type="dfn" href="#concept-node">node</a> <var>node</var> into a <a data-link-type="dfn" href="#concept-range">range</a> <var>range</var>, run these steps:</p>
    <ol>
     <li>
@@ -4755,11 +4755,11 @@ neighboring rights to this work.</p>
    <li><a href="#dom-element-classname">className</a><span>, in §4.8</span>
    <li><a href="#concept-node-clone">clone</a><span>, in §4.4</span>
    <li><a href="#concept-node-clone">clone a node</a><span>, in §4.4</span>
-   <li><a href="#concept-range-clone">clone a range</a><span>, in §5.2</span>
    <li><a href="#dom-range-clonecontents">cloneContents()</a><span>, in §5.2</span>
    <li><a href="#dom-node-clonenode">cloneNode()</a><span>, in §4.4</span>
    <li><a href="#dom-node-clonenode">cloneNode(deep)</a><span>, in §4.4</span>
    <li><a href="#dom-range-clonerange">cloneRange()</a><span>, in §5.2</span>
+   <li><a href="#concept-range-clone">clone the contents of a range</a><span>, in §5.2</span>
    <li><a href="#concept-node-clone-ext">cloning steps</a><span>, in §4.4</span>
    <li><a href="#dom-element-closest">closest(selectors)</a><span>, in §4.8</span>
    <li><a href="#dom-range-collapse">collapse()</a><span>, in §5.2</span>


### PR DESCRIPTION
See http://logs.glob.uno/?c=freenode%23whatwg&s=14+Mar+2016&e=14+Mar+2016#c988870 for confusion. In particular:

> yeah probably a confusion because of "clone" ; a "clone" operation that does not return the same object type... hmmm...

Also see https://github.com/tabatkins/bikeshed/issues/630 for the bogus change to UIEvents in the generated references.

Ack @therealglazou 