### PR TITLE
Change .createElement() namespace to match UAs

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4689,8 +4689,12 @@ invoked, must run these steps:
  <li>If <var>is</var> is non-null and <var>definition</var> is null, then <a>throw</a> a
  {{NotFoundError}}.
 
+ <li>Let <var>namespace</var> be the <a>HTML namespace</a> if the <a>context
+ object</a>'s <a for=Document>content type</a> is "<code>text/html</code>" or
+ "<code>application/xhtml+xml</code>", and null otherwise.
+
  <li>Let <var>element</var> be the result of <a>creating an element</a> given the
- <a>context object</a>, <var>localName</var>, null, the <a>HTML namespace</a>, <var>is</var>, and
+ <a>context object</a>, <var>localName</var>, null, <var>namespace</var>, <var>is</var>, and
  with the <var>synchronous custom elements</var> flag set. Rethrow any exceptions.
 
  <li>If <var>is</var> is non-null, then <a>set an attribute value</a> for <var>element</var> using


### PR DESCRIPTION
Fixes https://www.w3.org/Bugs/Public/show_bug.cgi?id=19431

See comments 12 and 20 there.  Gecko tried switching to the spec's
current wording and immediately had to back out due to extension
breakage.  It does not seem likely the current spec is implementable.