### PR TITLE
Swap `prefix, localName` params of create an element

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5389,7 +5389,7 @@ required to do so. The standard has this concept for readability.
 
 <p>To
 <dfn export id=concept-create-element lt="create an element|creating an element">create an element</dfn>,
-given a <var>document</var>, <var>prefix</var>, <var>localName</var>, <var>namespace</var>,
+given a <var>document</var>, <var>localName</var>, <var>prefix</var>, <var>namespace</var>,
 <var>is</var>, and optional <var>synchronous custom elements flag</var>, run these steps:
 
 <ol>


### PR DESCRIPTION
I think these are out of order? At [To **create an element**](https://dom.spec.whatwg.org/#concept-create-element) the signature (partial) is: `document, prefix, localName`. But at the invocations I could find, the order of `prefix, localName` appears to be swapped:

* > creating an element, given *document*, *node’s* local name, *node’s* namespace prefix

* > creating an element given the context object, *localName*, null

* > creating an element given *document*, *localName*, *prefix*

P.S. I haven't figured out the build process so I haven't checked the HTML output.