### PR TITLE
Define "participate in a tree" instead of just "participate".

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -234,7 +234,7 @@ A <dfn export id=concept-tree>tree</dfn> is a finite hierarchical tree structure
 traversal of a <a>tree</a>.
 <!-- https://en.wikipedia.org/wiki/Depth-first_search -->
 
-An object that <dfn export for=tree id=concept-tree-participate lt="participate">participates</dfn> in
+An object that <dfn export for=tree id=concept-tree-participate lt="participate|participate in a tree|participates in a tree">participates</dfn> in
 a <a>tree</a> has a
 <dfn export for=tree id=concept-tree-parent>parent</dfn>, which is either another object
 or null, and an ordered list of zero or more

--- a/dom.html
+++ b/dom.html
@@ -292,7 +292,7 @@ attribute getter, attribute setter, or method being discussed was called. When t
    <h3 class="heading settled" data-level="2.1" id="trees"><span class="secno">2.1. </span><span class="content">Trees</span><a class="self-link" href="#trees"></a></h3>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-tree">tree<a class="self-link" href="#concept-tree"></a></dfn> is a finite hierarchical tree structure. In <dfn data-dfn-type="dfn" data-export="" id="concept-tree-order">tree order<a class="self-link" href="#concept-tree-order"></a></dfn> is preorder, depth-first
 traversal of a <a data-link-type="dfn" href="#concept-tree">tree</a>.</p>
-   <p>An object that <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" data-lt="participate" id="concept-tree-participate">participates<a class="self-link" href="#concept-tree-participate"></a></dfn> in
+   <p>An object that <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" data-lt="participate|participate in a tree|participates in a tree" id="concept-tree-participate">participates<a class="self-link" href="#concept-tree-participate"></a></dfn> in
 a <a data-link-type="dfn" href="#concept-tree">tree</a> has a <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" id="concept-tree-parent">parent<a class="self-link" href="#concept-tree-parent"></a></dfn>, which is either another object
 or null, and an ordered list of zero or more <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" data-lt="child|children" id="concept-tree-child">child<a class="self-link" href="#concept-tree-child"></a></dfn> objects. An object <var>A</var> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is object <var>B</var> is a <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>B</var>.</p>
    <p>The <dfn data-dfn-for="tree" data-dfn-type="dfn" data-export="" id="concept-tree-root">root<a class="self-link" href="#concept-tree-root"></a></dfn> of an object is itself, if its <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null, or else it is the <a data-link-type="dfn" href="#concept-tree-root">root</a> of its <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. The <a data-link-type="dfn" href="#concept-tree-root">root</a> of a <a data-link-type="dfn" href="#concept-tree">tree</a> is any object <a data-link-type="dfn" href="#concept-tree-participate">participating</a> in that <a data-link-type="dfn" href="#concept-tree">tree</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is null. </p>
@@ -3165,7 +3165,7 @@ given a <var>document</var>, <var>localName</var>, <var>prefix</var>, <var>names
          <p>Set <var>result</var> to <a data-link-type="abstract-op" href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>C</var>). Rethrow any
      exceptions. </p>
         <li>
-         <p>If <var>result</var> does not implement the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> interface, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> exception. </p>
+         <p>If <var>result</var> does not implement the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> interface, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl">TypeError</a></code> exception. </p>
          <p class="note" role="note">This is meant to be a brand check to ensure that the object was allocated by the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> constructor. See <a href="https://github.com/heycam/webidl/issues/97">webidl #97</a> about making this more
       precise. </p>
         <li>
@@ -4887,7 +4887,7 @@ other chapters are defined by the <cite>UI Events</cite> specification. <a data-
    </ul>
    <h3 class="heading settled" data-level="8.2" id="dom-core-changes"><span class="secno">8.2. </span><span class="content">DOM Core</span><a class="self-link" href="#dom-core-changes"></a></h3>
    <p>These are the changes made to the features described in <cite>DOM Level 3 Core</cite>.</p>
-   <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-domexception">DOMException</a></code>, and <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#common-domtimestamp">DOMTimeStamp</a></code> are now defined in Web IDL.</p>
+   <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>, and <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#common-domtimestamp">DOMTimeStamp</a></code> are now defined in Web IDL.</p>
    <p><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> now inherits from <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code>.</p>
    <p><a data-link-type="dfn" href="#concept-node">Nodes</a> are implicitly <a data-link-type="dfn" href="#concept-node-adopt">adopted</a> across <a data-link-type="dfn" href="#concept-document">document</a> boundaries.</p>
    <p><a data-link-type="dfn" href="#concept-doctype">Doctypes</a> now always have a <a data-link-type="dfn" href="#concept-node-document">node document</a> and can be moved
@@ -5704,6 +5704,8 @@ namespace and local name localName</a><span>, in §4.4</span>
    <li><a href="#dom-treewalker-parentnode">parentNode()</a><span>, in §6.2</span>
    <li><a href="#partially-contained">partially contained</a><span>, in §5.2</span>
    <li><a href="#concept-tree-participate">participate</a><span>, in §2.1</span>
+   <li><a href="#concept-tree-participate">participate in a tree</a><span>, in §2.1</span>
+   <li><a href="#concept-tree-participate">participates in a tree</a><span>, in §2.1</span>
    <li><a href="#dom-eventlisteneroptions-passive">passive</a><span>, in §3.6</span>
    <li><a href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a><span>, in §6.1</span>
    <li><a href="#concept-range-bp-position">position</a><span>, in §5.2</span>
@@ -5977,7 +5979,6 @@ namespace and local name localName</a><span>, in §4.4</span>
     <a data-link-type="biblio">[ECMASCRIPT]</a> defines the following terms:
     <ul>
      <li><a href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-animations-1]</a> defines the following terms:
@@ -6047,7 +6048,19 @@ namespace and local name localName</a><span>, in §4.4</span>
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
+     <li><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a>
      <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
+     <li><a href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a>
+     <li><a href="https://heycam.github.io/webidl/#inuseattributeerror">InUseAttributeError</a>
+     <li><a href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a>
+     <li><a href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a>
+     <li><a href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a>
+     <li><a href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a>
+     <li><a href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a>
+     <li><a href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a>
+     <li><a href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a>
+     <li><a href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a>
+     <li><a href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>


### PR DESCRIPTION
This makes linking from other specs simpler, since they have to mention
trees in the human-readable text anyway. For example, https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-tree.

That said, it's not a big problem if you reject this.

Demo at https://rawgit.com/jyasskin/dom/participate-linking/dom.html#concept-tree-participate.

@tabatkins, the UI of a link inside another definition is bad: the click handler on the `<dfn>`that shows the dfnPanel prevents clicks on the `<a>` from working.