### PR TITLE
Add more legacy event types for createEvent()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4919,17 +4919,40 @@ invoked, must run these steps:
    <thead>
     <tr><th>String<th>Interface<td>Notes
    <tbody>
-    <tr><td>"<code>customevent</code>"<td>{{CustomEvent}}<td rowspan=4>
-    <tr><td>"<code>event</code><td rowspan=3>{{Event}}
+    <tr><td>"<code>animationevent</code>"<td>{{AnimationEvent}}<td>[[!CSS3-ANIMATIONS]]
+    <tr><td>"<code>beforeunloadevent</code>"<td>{{BeforeUnloadEvent}}<td rowspan=2>[[!HTML]]
+    <tr><td>"<code>closeevent</code>"<td>{{CloseEvent}}
+    <tr><td>"<code>compositionevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]
+    <tr><td>"<code>customevent</code>"<td>{{CustomEvent}}<td>
+    <tr><td>"<code>devicemotionevent</code>"<td>{{DeviceMotionEvent}}<td rowspan=2>[[!DEVICE-ORIENTATION]]
+    <tr><td>"<code>deviceorientationevent</code>"<td>{{DeviceOrientationEvent}}
+    <tr><td>"<code>dragevent</code>"<td>{{DragEvent}}<td rowspan=2>[[!HTML]]
+    <tr><td>"<code>errorevent</code>"<td>{{ErrorEvent}}
+    <tr><td>"<code>event</code>"<td rowspan=2>{{Event}}<td rowspan=2>
     <tr><td>"<code>events</code>"
-    <tr><td>"<code>htmlevents</code>"
+    <tr><td>"<code>focusevent</code>"<td>{{FocusEvent}}<td>[[!UIEVENTS]]
+    <tr><td>"<code>hashchangeevent</code>"<td>{{HashChangeEvent}}<td>[[!HTML]]
+    <tr><td>"<code>htmlevents</code>"<td>{{Event}}<td>
+    <tr><td>"<code>idbversionchangeevent</code>"<td>{{IDBVersionChangeEvent}}<td>[[INDEXEDDB]]
     <tr><td>"<code>keyboardevent</code>"<td>{{KeyboardEvent}}<td>[[!UIEVENTS]]
     <tr><td>"<code>messageevent</code>"<td>{{MessageEvent}}<td>[[!HTML]]
     <tr><td>"<code>mouseevent</code>"<td rowspan=2>{{MouseEvent}}<td rowspan=2>[[!UIEVENTS]]
     <tr><td>"<code>mouseevents</code>"
+    <tr><td>"<code>pagetransitionevent</code>"<td>{{PageTransitionEvent}}<td rowspan=2>[[!HTML]]
+    <tr><td>"<code>popstateevent</code>"<td>{{PopStateEvent}}
+    <tr><td>"<code>progressevent</code>"<td>{{ProgressEvent}}<td>[[!XHR]]
+    <tr><td>"<code>storageevent</code>"<td>{{StorageEvent}}<td>[[!HTML]]
+    <tr><td>"<code>svgevent</code>"<td>{{Event}}<td>
+    <tr><td>"<code>svgzoomevent</code>"<td rowspan=2>{{SVGZoomEvent}}<td rowspan=2>[[!SVG]]
+    <tr><td>"<code>svgzoomevents</code>"
+    <tr><td>"<code>textevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]
     <tr><td>"<code>touchevent</code>"<td>{{TouchEvent}}<td>[[!TOUCH-EVENTS]]
+    <tr><td>"<code>trackevent</code>"<td>{{TrackEvent}}<td>[[!HTML]]
+    <tr><td>"<code>transitionevent</code>"<td>{{TransitionEvent}}<td>[[!CSS3-TRANSITIONS]]
     <tr><td>"<code>uievent</code>"<td rowspan=2>{{UIEvent}}<td rowspan=2>[[!UIEVENTS]]
     <tr><td>"<code>uievents</code>"
+    <tr><td>"<code>webglcontextevent</code>"<td>{{WebGLContextEvent}}<td>[[!WEBGL]]
+    <tr><td>"<code>wheelevent</code>"<td>{{WheelEvent}}<td>[[!UIEVENTS]]
   </table>
   <!-- XXX WebKit's architecture is broken here and both browsers support more than DOM.
        https://trac.webkit.org/browser/trunk/Source/WebCore/dom/EventNames.in

--- a/dom.bs
+++ b/dom.bs
@@ -4923,6 +4923,7 @@ invoked, must run these steps:
     <tr><td>"<code>beforeunloadevent</code>"<td>{{BeforeUnloadEvent}}<td rowspan=2>[[!HTML]]
     <tr><td>"<code>closeevent</code>"<td>{{CloseEvent}}
     <tr><td>"<code>compositionevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]
+    <!-- textevent also maps to CompositionEvent -->
     <tr><td>"<code>customevent</code>"<td>{{CustomEvent}}<td>
     <tr><td>"<code>devicemotionevent</code>"<td>{{DeviceMotionEvent}}<td rowspan=2>[[!DEVICE-ORIENTATION]]
     <tr><td>"<code>deviceorientationevent</code>"<td>{{DeviceOrientationEvent}}
@@ -4930,6 +4931,7 @@ invoked, must run these steps:
     <tr><td>"<code>errorevent</code>"<td>{{ErrorEvent}}
     <tr><td>"<code>event</code>"<td rowspan=2>{{Event}}<td rowspan=2>
     <tr><td>"<code>events</code>"
+    <!-- htmlevents and svgevent also map to Event -->
     <tr><td>"<code>focusevent</code>"<td>{{FocusEvent}}<td>[[!UIEVENTS]]
     <tr><td>"<code>hashchangeevent</code>"<td>{{HashChangeEvent}}<td>[[!HTML]]
     <tr><td>"<code>htmlevents</code>"<td>{{Event}}<td>
@@ -4954,9 +4956,6 @@ invoked, must run these steps:
     <tr><td>"<code>webglcontextevent</code>"<td>{{WebGLContextEvent}}<td>[[!WEBGL]]
     <tr><td>"<code>wheelevent</code>"<td>{{WheelEvent}}<td>[[!UIEVENTS]]
   </table>
-  <!-- XXX WebKit's architecture is broken here and both browsers support more than DOM.
-       https://trac.webkit.org/browser/trunk/Source/WebCore/dom/EventNames.in
-       https://mxr.mozilla.org/mozilla-central/source/content/events/src/nsEventDispatcher.cpp#819 -->
 
  <li>If <var>constructor</var> is null, <a>throw</a> a
  {{NotSupportedError}}.


### PR DESCRIPTION
Approximately as requested at
<https://bugzilla.mozilla.org/show_bug.cgi?id=1251198#c7>.  This is the
list of events supported in createEvent() by at least two of Firefox,
Chrome, and IE 11.  The one exception is I omitted MutationEvent, which
all three support, because apparently spec-land has decided to deny its
existence in the hope that it will go away.

XXX Bikeshed does not know about all of the added interface names and I
don't know how to tell it.  (The error is non-fatal, they just aren't
linked.)