### PR TITLE
Fix #227: Make createEvent("touchevent") sometimes throw

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4982,6 +4982,13 @@ invoked, must run these steps:
     <tr><td>"<code>wheelevent</code>"<td>{{WheelEvent}}<td>[[!UIEVENTS]]
   </table>
 
+ <li>
+  If the user agent does not support the <var>constructor</var> interface, or has it disabled
+  in its current configuration, let <var>constructor</var> be null.
+
+  <p class=note>Typically user agents have the {{TouchEvent}} interface disabled in some
+  configurations.
+
  <li>If <var>constructor</var> is null, <a>throw</a> a
  {{NotSupportedError}}.
 

--- a/dom.bs
+++ b/dom.bs
@@ -4928,17 +4928,16 @@ method, when invoked, must run these steps:
 
 <hr>
 
-The <dfn method for=Document><code>createEvent(<var>interface</var>)</code></dfn> method, when
+<p>The <dfn method for=Document><code>createEvent(<var>interface</var>)</code></dfn> method, when
 invoked, must run these steps:
 
 <ol>
- <li>Let <var>constructor</var> be null.
+ <li><p>Let <var>constructor</var> be null.
 
  <li>
-  If <var>interface</var> is an
-  <a>ASCII case-insensitive</a> match for any of the strings in the
-  first column in the following table, set <var>constructor</var> to the
-  interface in the second column on the same row as the matching string:
+  <p>If <var>interface</var> is an <a>ASCII case-insensitive</a> match for any of the strings in the
+  first column in the following table, then set <var>constructor</var> to the interface in the
+  second column on the same row as the matching string:
 
   <table>
    <thead>
@@ -4982,22 +4981,22 @@ invoked, must run these steps:
     <tr><td>"<code>wheelevent</code>"<td>{{WheelEvent}}<td>[[!UIEVENTS]]
   </table>
 
- <li>If <var>constructor</var> is null, <a>throw</a> a
- {{NotSupportedError}}.
+ <li><p>If <var>constructor</var> is null, then <a>throw</a> a {{NotSupportedError}}.
 
  <li>
-  If the initial value of <var>constructor</var> is undefined, <a>throw</a> a {{NotSupportedError}}.
+  <p>If the initial value of <var>constructor</var> is undefined, then <a>throw</a> a
+  {{NotSupportedError}}.
 
   <p class=note>Typically user agents disable support for touch events in some configurations, in
   which case the initial value of {{TouchEvent}} is undefined.
 
- <li>Let <var>event</var> be the result of <a for=Event lt=constructor>invoking</a> the initial
+ <li><p>Let <var>event</var> be the result of <a for=Event lt=constructor>invoking</a> the initial
  value of <var>constructor</var> with the empty string as argument.
  <!-- "initial value" as in before script could get to it -->
 
- <li>Unset <var>event</var>'s <a>initialized flag</a>.
+ <li><p>Unset <var>event</var>'s <a>initialized flag</a>.
 
- <li>Return <var>event</var>.
+ <li><p>Return <var>event</var>.
 </ol>
 
 <p class=note><a>Event</a> constructors ought to be used instead.

--- a/dom.bs
+++ b/dom.bs
@@ -4982,15 +4982,14 @@ invoked, must run these steps:
     <tr><td>"<code>wheelevent</code>"<td>{{WheelEvent}}<td>[[!UIEVENTS]]
   </table>
 
- <li>
-  If the user agent does not support the <var>constructor</var> interface, or has it disabled
-  in its current configuration, let <var>constructor</var> be null.
-
-  <p class=note>Typically user agents have the {{TouchEvent}} interface disabled in some
-  configurations.
-
  <li>If <var>constructor</var> is null, <a>throw</a> a
  {{NotSupportedError}}.
+
+ <li>
+  If the initial value of <var>constructor</var> is undefined, <a>throw</a> a {{NotSupportedError}}.
+
+  <p class=note>Typically user agents disable support for touch events in some configurations, in
+  which case the initial value of {{TouchEvent}} is undefined.
 
  <li>Let <var>event</var> be the result of <a for=Event lt=constructor>invoking</a> the initial
  value of <var>constructor</var> with the empty string as argument.

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-04-18">18 April 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-04-19">19 April 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -2736,13 +2736,14 @@ invoked, must run these steps:</p>
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createevent"><code>createEvent(<var>interface</var>)</code><a class="self-link" href="#dom-document-createevent"></a></dfn> method, when
-invoked, must run these steps:</p>
+invoked, must run these steps: </p>
    <ol>
-    <li>Let <var>constructor</var> be null. 
     <li>
-      If <var>interface</var> is an <a data-link-type="dfn" href="#ascii-case-insensitive">ASCII case-insensitive</a> match for any of the strings in the
-  first column in the following table, set <var>constructor</var> to the
-  interface in the second column on the same row as the matching string: 
+     <p>Let <var>constructor</var> be null. </p>
+    <li>
+     <p>If <var>interface</var> is an <a data-link-type="dfn" href="#ascii-case-insensitive">ASCII case-insensitive</a> match for any of the strings in the
+  first column in the following table, then set <var>constructor</var> to the interface in the
+  second column on the same row as the matching string: </p>
      <table>
       <thead>
        <tr>
@@ -2875,15 +2876,19 @@ invoked, must run these steps:</p>
         <td><code class="idl"><a data-link-type="idl">WheelEvent</a></code>
         <td><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
      </table>
-    <li>If <var>constructor</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. 
     <li>
-      If the initial value of <var>constructor</var> is undefined, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. 
+     <p>If <var>constructor</var> is null, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. </p>
+    <li>
+     <p>If the initial value of <var>constructor</var> is undefined, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. </p>
      <p class="note" role="note">Typically user agents disable support for touch events in some configurations, in
   which case the initial value of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/touch-events/#touchevent-interface">TouchEvent</a></code> is undefined. </p>
-    <li>Let <var>event</var> be the result of <a data-link-type="dfn" href="#concept-event-constructor">invoking</a> the initial
- value of <var>constructor</var> with the empty string as argument. 
-    <li>Unset <var>event</var>’s <a data-link-type="dfn" href="#initialized-flag">initialized flag</a>. 
-    <li>Return <var>event</var>. 
+    <li>
+     <p>Let <var>event</var> be the result of <a data-link-type="dfn" href="#concept-event-constructor">invoking</a> the initial
+ value of <var>constructor</var> with the empty string as argument. </p>
+    <li>
+     <p>Unset <var>event</var>’s <a data-link-type="dfn" href="#initialized-flag">initialized flag</a>. </p>
+    <li>
+     <p>Return <var>event</var>. </p>
    </ol>
    <p class="note" role="note"><a data-link-type="dfn" href="#concept-event">Event</a> constructors ought to be used instead. </p>
    <hr>

--- a/dom.html
+++ b/dom.html
@@ -2875,6 +2875,11 @@ invoked, must run these steps:</p>
         <td><code class="idl"><a data-link-type="idl">WheelEvent</a></code>
         <td><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
      </table>
+    <li>
+      If the user agent does not support the <var>constructor</var> interface, or has it disabled
+  in its current configuration, let <var>constructor</var> be null. 
+     <p class="note" role="note">Typically user agents have the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/touch-events/#touchevent-interface">TouchEvent</a></code> interface disabled in some
+  configurations. </p>
     <li>If <var>constructor</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. 
     <li>Let <var>event</var> be the result of <a data-link-type="dfn" href="#concept-event-constructor">invoking</a> the initial
  value of <var>constructor</var> with the empty string as argument. 
@@ -3172,7 +3177,7 @@ given a <var>document</var>, <var>localName</var>, <var>prefix</var>, <var>names
          <p>Set <var>result</var> to <a data-link-type="abstract-op" href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>(<var>C</var>). Rethrow any
      exceptions. </p>
         <li>
-         <p>If <var>result</var> does not implement the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> interface, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> exception. </p>
+         <p>If <var>result</var> does not implement the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> interface, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl">TypeError</a></code> exception. </p>
          <p class="note" role="note">This is meant to be a brand check to ensure that the object was allocated by the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> constructor. See <a href="https://github.com/heycam/webidl/issues/97">webidl #97</a> about making this more
       precise. </p>
         <li>
@@ -4918,7 +4923,7 @@ other chapters are defined by the <cite>UI Events</cite> specification. <a data-
    </ul>
    <h3 class="heading settled" data-level="8.2" id="dom-core-changes"><span class="secno">8.2. </span><span class="content">DOM Core</span><a class="self-link" href="#dom-core-changes"></a></h3>
    <p>These are the changes made to the features described in <cite>DOM Level 3 Core</cite>.</p>
-   <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-domexception">DOMException</a></code>, and <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#common-domtimestamp">DOMTimeStamp</a></code> are now defined in Web IDL.</p>
+   <p><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a></code>, <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code>, and <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#common-domtimestamp">DOMTimeStamp</a></code> are now defined in Web IDL.</p>
    <p><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> now inherits from <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code>.</p>
    <p><a data-link-type="dfn" href="#concept-node">Nodes</a> are implicitly <a data-link-type="dfn" href="#concept-node-adopt">adopted</a> across <a data-link-type="dfn" href="#concept-document">document</a> boundaries.</p>
    <p><a data-link-type="dfn" href="#concept-doctype">Doctypes</a> now always have a <a data-link-type="dfn" href="#concept-node-document">node document</a> and can be moved
@@ -6008,7 +6013,6 @@ namespace and local name localName</a><span>, in §4.4</span>
     <a data-link-type="biblio">[ECMASCRIPT]</a> defines the following terms:
     <ul>
      <li><a href="https://tc39.github.io/ecma262/#sec-construct">Construct</a>
-     <li><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>
     </ul>
    <li>
     <a data-link-type="biblio">[css-animations-1]</a> defines the following terms:
@@ -6078,7 +6082,19 @@ namespace and local name localName</a><span>, in §4.4</span>
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
+     <li><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a>
      <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
+     <li><a href="https://heycam.github.io/webidl/#hierarchyrequesterror">HierarchyRequestError</a>
+     <li><a href="https://heycam.github.io/webidl/#inuseattributeerror">InUseAttributeError</a>
+     <li><a href="https://heycam.github.io/webidl/#indexsizeerror">IndexSizeError</a>
+     <li><a href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a>
+     <li><a href="https://heycam.github.io/webidl/#invalidnodetypeerror">InvalidNodeTypeError</a>
+     <li><a href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a>
+     <li><a href="https://heycam.github.io/webidl/#namespaceerror">NamespaceError</a>
+     <li><a href="https://heycam.github.io/webidl/#notfounderror">NotFoundError</a>
+     <li><a href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a>
+     <li><a href="https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a>
+     <li><a href="https://heycam.github.io/webidl/#wrongdocumenterror">WrongDocumentError</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>

--- a/dom.html
+++ b/dom.html
@@ -2875,12 +2875,11 @@ invoked, must run these steps:</p>
         <td><code class="idl"><a data-link-type="idl">WheelEvent</a></code>
         <td><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
      </table>
-    <li>
-      If the user agent does not support the <var>constructor</var> interface, or has it disabled
-  in its current configuration, let <var>constructor</var> be null. 
-     <p class="note" role="note">Typically user agents have the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/touch-events/#touchevent-interface">TouchEvent</a></code> interface disabled in some
-  configurations. </p>
     <li>If <var>constructor</var> is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. 
+    <li>
+      If the initial value of <var>constructor</var> is undefined, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. 
+     <p class="note" role="note">Typically user agents disable support for touch events in some configurations, in
+  which case the initial value of <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/touch-events/#touchevent-interface">TouchEvent</a></code> is undefined. </p>
     <li>Let <var>event</var> be the result of <a data-link-type="dfn" href="#concept-event-constructor">invoking</a> the initial
  value of <var>constructor</var> with the empty string as argument. 
     <li>Unset <var>event</var>’s <a data-link-type="dfn" href="#initialized-flag">initialized flag</a>. 


### PR DESCRIPTION
Browsers typically disable touch events on non-touch devices, and
there exists Web content that detects this difference using
createEvent.

----

Also see https://github.com/w3c/touch-events/issues/64 for a possible spec hook for this.

I'm not sure about the wording, happy to tweak it.

I updated bikeshed and got some unrelated differences in the output, FYI.