### PR TITLE
Editorial: flip non-null/otherwise conditions

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2515,9 +2515,9 @@ invoked, must run these steps:
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a>, given
  <var>nodes</var> and <a>context object</a>'s <a>node document</a>. Rethrow any exceptions.
 
- <li><p>If <var>viablePreviousSibling</var> is non-null, set it to
- <var>viablePreviousSibling</var>'s <a>next sibling</a>, and to <var>parent</var>'s
- <a>first child</a> otherwise.
+ <li><p>If <var>viablePreviousSibling</var> is null, set it to
+ <var>parent</var>'s <a>first child</a>, and to <var>viablePreviousSibling</var>'s
+ <a>next sibling</a> otherwise.
 
  <li><p><a>Pre-insert</a> <var>node</var> into <var>parent</var> before
  <var>viablePreviousSibling</var>. Rethrow any exceptions.
@@ -8716,9 +8716,9 @@ The <dfn><code>NodeIterator</code> pre-removing steps</dfn> given a
   </ol>
 
  <li><p>Set <var>nodeIterator</var>'s {{NodeIterator/referenceNode}} attribute to the
- <a>inclusive descendant</a> of <var>toBeRemovedNode</var>'s <a>previous sibling</a> that
- appears last in <a>tree order</a>, if <var>toBeRemovedNode</var>'s
- <a>previous sibling</a> is non-null, and to <var>toBeRemovedNode</var>'s <a>parent</a>
+ <var>toBeRemovedNode</var>'s <a>parent</a>, if <var>toBeRemovedNode</var>'s
+ <a>previous sibling</a> is null, and to <a>inclusive descendant</a> of
+ <var>toBeRemovedNode</var>'s <a>previous sibling</a> that appears last in <a>tree order</a>
  otherwise.
 </ol>
 
@@ -9710,6 +9710,7 @@ making this standard what it is today.
 With that, many thanks to
 Adam Klein,
 Adrian Bateman,
+Aleksey Shvayka,
 Alex Komoroske,
 Alex Russell,
 Anthony Ramine,


### PR DESCRIPTION
Ruby styleguides *generally* disallow usage of `else` clauses in `unless` expressions because of readability.
I find it difficult to read because of double negation (non-null => otherwise => null) and I think that this PR will improve readability and consistency in conditions.