### PR TITLE
Shadow: define event retargeting for shadow trees

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -627,23 +627,28 @@ interface Event {
   readonly attribute boolean cancelable;
   void preventDefault();
   readonly attribute boolean defaultPrevented;
+  readonly attribute boolean scoped;
 
   [Unforgeable] readonly attribute boolean isTrusted;
   readonly attribute DOMTimeStamp timeStamp;
 
-  void initEvent(DOMString type, boolean bubbles, boolean cancelable);
+  void initEvent(DOMString type, boolean bubbles, boolean cancelable); // historical
 };
 
 dictionary EventInit {
   boolean bubbles = false;
   boolean cancelable = false;
+  boolean scoped = false;
 };
 </pre>
 
-An <dfn export id=concept-event>event</dfn> allows for signaling that
-something has occurred, e.g. that an image has completed downloading. It is
-represented by the {{Event}} interface or an interface that
-inherits from the {{Event}} interface.
+<p>An {{Event}} object is simply named an <dfn export id=concept-event>event</dfn>. It allows for
+signaling that something has occurred, e.g., that an image has completed downloading.</p>
+
+<p>An <a>event</a> has an associated <dfn export for=Event>path</dfn>. A <a for=Event>path</a> is a
+list of tuples, each of which consists of an <b>item</b> (an {{EventTarget}} object) and a
+<b>target</b> (null or an {{EventTarget}} object). A tuple is formatted as (<b>item</b>,
+<b>target</b>). A <a for=Event>path</a> is initially the empty list.</p>
 
 <dl class=domintro>
  <dt><code><var>event</var> = new <a constructor lt="Event()">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
@@ -701,6 +706,11 @@ inherits from the {{Event}} interface.
  <dt><code><var>event</var> . {{Event/defaultPrevented}}</code>
  <dd>Returns true if {{Event/preventDefault()}} was invoked successfully to indicate cancellation,
  and false otherwise.
+
+ <dt><code><var>event</var> . {{Event/scoped}}</code>
+ <dd>Returns true or false depending on how <var>event</var> was initialized. True if
+ <var>event</var> does not invoke listeners past a {{ShadowRoot}} <a>node</a> that is the
+ <a for=tree>root</a> of its {{Event/target}} attribute value, and false otherwise.
 
  <dt><code><var>event</var> . {{Event/isTrusted}}</code>
  <dd>Returns true if <var>event</var> was
@@ -760,9 +770,10 @@ flags that are all initially unset:
  <li><dfn export for=Event id=stop-propagation-flag>stop propagation flag</dfn>
  <li><dfn export for=Event id=stop-immediate-propagation-flag>stop immediate propagation flag</dfn>
  <li><dfn export for=Event id=canceled-flag>canceled flag</dfn>
+ <li><dfn export for=Event id=in-passive-listener-flag>in passive listener flag</dfn>
+ <li><dfn export for=Event id=scoped-flag>scoped flag</dfn>
  <li><dfn export for=Event id=initialized-flag>initialized flag</dfn>
  <li><dfn export for=Event id=dispatch-flag>dispatch flag</dfn>
- <li><dfn export for=Event id=in-passive-listener-flag>in passive listener flag</dfn>
 </ul>
 
 The
@@ -790,6 +801,9 @@ The
 <dfn attribute for=Event>defaultPrevented</dfn>
 attribute must return true if the <a>canceled flag</a> is set and
 false otherwise.
+
+<p>The <dfn attribute for=Event><code>scoped</code></dfn> attribute's getter must return true if
+<a>context object</a>'s <a>scoped flag</a> is set, and false otherwise.</p>
 
 <hr>
 
@@ -844,9 +858,8 @@ method, when invoked, must run these steps:
  <var>cancelable</var>.
 </ol>
 
-<p class="note no-backref">As <a>events</a> have constructors
-{{Event/initEvent()}} is superfluous. However,
-it has to be supported for legacy content.
+<p class="note no-backref">As <a>events</a> have constructors {{Event/initEvent()}} is redundant and
+incapable of setting {{Event/scoped}}. It has to be supported for legacy content.
 
 
 <h3 id=interface-customevent>Interface {{CustomEvent}}</h3>
@@ -987,8 +1000,8 @@ fields above, an <a>event listener</a> is a broader concept.
 which takes an <a>event</a> <var>event</var>, and returns an {{EventTarget}} object. Unless
 specified otherwise it returns null.
 
-<p class="note no-backref"><a>Nodes</a> and <a>documents</a> override the
-<a>get the parent</a> algorithm.
+<p class="note no-backref"><a>Nodes</a>, <a for=/>shadow roots</a>, and <a>documents</a> override
+the <a>get the parent</a> algorithm.
 
 <dl class=domintro>
  <dt><code><var>target</var> . <a method lt="addEventListener()">addEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code>
@@ -1144,43 +1157,81 @@ for discussion).
 <h3 id=dispatching-events>Dispatching events</h3>
 
 <p>To <dfn export for=Event id=concept-event-dispatch>dispatch</dfn> an <var>event</var> to a
-<var>target</var>, with an optional <var>target override</var>, run these steps:
+<var>target</var>, with an optional <var>targetOverride</var>, run these steps:
 
 <ol>
  <li><p>Set <var>event</var>'s <a>dispatch flag</a>.
 
- <li><p>Initialize <var>event</var>'s {{Event/target}} attribute to
- <var>target override</var>, if it is given, and <var>target</var> otherwise.
+ <li>
+  <p>If <var>targetOverride</var> is not given, let <var>targetOverride</var> be <var>target</var>.
 
- <li><p>Let <var>eventPath</var> be a list containing <var>target</var>.
+  <p class="note">The <var>targetOverride</var> argument is only used by HTML and only under very
+  specific circumstances.
+  <!-- We should consider refactoring it to make it have less of a scope, since we don't really want
+       folks to start using it for non-legacy scenarios. -->
 
- <li><p>While invoking <a>get the parent</a>, given <var>event</var>, on <var>eventPath</var>'s
- last item, does not return null, append the return value to <var>eventPath</var>.
+ <li><p>Append (<var>target</var>, <var>targetOverride</var>) to <var>event</var>'s
+ <a for=Event>path</a>.
 
- <li><p>Initialize <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/CAPTURING_PHASE}}.
-
- <li><p>For each <var>object</var> in <var>eventPath</var>, in reverse order, if <var>object</var>
- is not <var>target</var>, <a>invoke</a> <var>object</var> with <var>event</var>.
-
- <li><p>Initialize <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
-
- <li><p><a>Invoke</a> <var>target</var> with <var>event</var>.
+ <li><p>Let <var>parent</var> be the result of invoking <var>target</var>'s <a>get the parent</a>
+ with <var>event</var>.
 
  <li>
-  <p>If <var>event</var>'s {{Event/bubbles}} attribute value is true, run these substeps:
+  <p>While <var>parent</var> is non-null:</p>
 
   <ol>
-   <li><p>Initialize <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/BUBBLING_PHASE}}.
+   <li><p>If <var>target</var>'s <a for=tree>root</a> is a
+   <a>shadow-including inclusive ancestor</a> of <var>parent</var>, then append
+   (<var>parent</var>, null) to <var>event</var>'s <a for=Event>path</a>.
 
-   <li><p>For each <var>object</var> in <var>eventPath</var>, if <var>object</var> is not
-   <var>target</var>, <a>invoke</a> <var>object</var> with <var>event</var>.
+   <li><p>Otherwise, set <var>target</var> to <var>parent</var> and append
+   (<var>parent</var>, <var>target</var>) to <var>event</var>'s <a for=Event>path</a>.
+
+   <li><p>Set <var>parent</var> to the result of invoking <var>parent</var>'s <a>get the parent</a>
+   with <var>event</var>.
+  </ol>
+
+ <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/CAPTURING_PHASE}}.
+
+ <li>
+  <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
+
+  <ol>
+   <li><p>Set <var>event</var>'s {{Event//target}} attribute to the <b>target</b> of the last tuple
+   in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or preceding
+   <var>tuple</var>, whose <b>target</b> is non-null.
+
+   <li><p>If <var>tuple</var>'s <b>target</b> is null, then <a>invoke</a> <var>tuple</var>'s
+   <b>item</b> with <var>event</var>.
+  </ol>
+
+ <li>
+  <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in order:
+
+  <ol>
+   <li><p>Set <var>event</var>'s {{Event//target}} attribute to the <b>target</b> of the last tuple
+   in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or preceding
+   <var>tuple</var>, whose <b>target</b> is non-null.
+
+   <li><p>If <var>tuple</var>'s <b>target</b> is non-null, then set <var>event</var>'s
+   {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
+
+   <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
+   {{Event/BUBBLING_PHASE}}.
+
+   <li><p>If either <var>event</var>'s {{Event/eventPhase}} attribute is {{Event/BUBBLING_PHASE}}
+   and <var>event</var>'s {{Event/bubbles}} attribute is true or <var>event</var>'s
+   {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> <var>tuple</var>'s
+   <b>item</b> with <var>event</var>.
   </ol>
 
  <li><p>Unset <var>event</var>'s <a>dispatch flag</a>.
 
- <li><p>Initialize <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
+ <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
- <li><p>Initialize <var>event</var>'s {{Event/currentTarget}} attribute to null.
+ <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
+
+ <li><p>Set <var>event</var>'s <a for=Event>path</a> to the empty list.
 
  <li><p>Return false if <var>event</var>'s <a>canceled flag</a> is set, and true otherwise.
 </ol>
@@ -3365,7 +3416,8 @@ that is a <a>document</a>.
 <a>adopt</a> algorithm.
 
 <p>A <a>node</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns the
-<a>node</a>'s <a>parent</a>.
+<a>node</a>'s <a>assigned slot</a>, if <a>node</a> is <a>assigned</a>, and <a>node</a>'s
+<a>parent</a> otherwise.
 
 <hr>
 
@@ -5388,6 +5440,11 @@ or "<code>closed</code>").</p>
 <p><a for=/>Shadow roots</a>'s associated <a for=DocumentFragment>host</a> is never null.</p>
 <!-- If we ever change this, e.g., add a ShadowRoot object constructor, that would have serious
      consequences for innerHTML. -->
+
+<p>A <a for=/>shadow root</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
+null if <var>event</var>'s <a>scoped flag</a> is set and <a for=/>shadow root</a> is the
+<a for=tree>root</a> of <var>event</var>'s <a for=Event>path</a>'s first tuple's <b>item</b>, and
+<a for=/>shadow root</a>'s <a for=DocumentFragment>host</a> otherwise.
 
 <p>The <dfn attribute for=ShadowRoot><code>mode</code></dfn> attribute's getter must return the
 <a>context object</a>'s <a for=ShadowRoot>mode</a>.</p>

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-04-27">27 April 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-04-28">28 April 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -506,22 +506,24 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="eve
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-cancelable">cancelable</a>;
   void <a class="idl-code" data-link-type="method" href="#dom-event-preventdefault">preventDefault</a>();
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-defaultprevented">defaultPrevented</a>;
+  readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-scoped">scoped</a>;
 
   [Unforgeable] readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-istrusted">isTrusted</a>;
   readonly attribute <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#common-domtimestamp">DOMTimeStamp</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMTimeStamp " href="#dom-event-timestamp">timeStamp</a>;
 
-  void <a class="idl-code" data-link-type="method" href="#dom-event-initevent">initEvent</a>(DOMString <dfn class="idl-code" data-dfn-for="Event/initEvent(type, bubbles, cancelable)" data-dfn-type="argument" data-export="" id="dom-event-initevent-type-bubbles-cancelable-type">type<a class="self-link" href="#dom-event-initevent-type-bubbles-cancelable-type"></a></dfn>, boolean <dfn class="idl-code" data-dfn-for="Event/initEvent(type, bubbles, cancelable)" data-dfn-type="argument" data-export="" id="dom-event-initevent-type-bubbles-cancelable-bubbles">bubbles<a class="self-link" href="#dom-event-initevent-type-bubbles-cancelable-bubbles"></a></dfn>, boolean <dfn class="idl-code" data-dfn-for="Event/initEvent(type, bubbles, cancelable)" data-dfn-type="argument" data-export="" id="dom-event-initevent-type-bubbles-cancelable-cancelable">cancelable<a class="self-link" href="#dom-event-initevent-type-bubbles-cancelable-cancelable"></a></dfn>);
+  void <a class="idl-code" data-link-type="method" href="#dom-event-initevent">initEvent</a>(DOMString <dfn class="idl-code" data-dfn-for="Event/initEvent(type, bubbles, cancelable)" data-dfn-type="argument" data-export="" id="dom-event-initevent-type-bubbles-cancelable-type">type<a class="self-link" href="#dom-event-initevent-type-bubbles-cancelable-type"></a></dfn>, boolean <dfn class="idl-code" data-dfn-for="Event/initEvent(type, bubbles, cancelable)" data-dfn-type="argument" data-export="" id="dom-event-initevent-type-bubbles-cancelable-bubbles">bubbles<a class="self-link" href="#dom-event-initevent-type-bubbles-cancelable-bubbles"></a></dfn>, boolean <dfn class="idl-code" data-dfn-for="Event/initEvent(type, bubbles, cancelable)" data-dfn-type="argument" data-export="" id="dom-event-initevent-type-bubbles-cancelable-cancelable">cancelable<a class="self-link" href="#dom-event-initevent-type-bubbles-cancelable-cancelable"></a></dfn>); // historical
 };
 
 dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-eventinit">EventInit<a class="self-link" href="#dictdef-eventinit"></a></dfn> {
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventinit-bubbles">bubbles<a class="self-link" href="#dom-eventinit-bubbles"></a></dfn> = false;
   boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventinit-cancelable">cancelable<a class="self-link" href="#dom-eventinit-cancelable"></a></dfn> = false;
+  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventinit-scoped">scoped<a class="self-link" href="#dom-eventinit-scoped"></a></dfn> = false;
 };
 </pre>
-   <p>An <dfn data-dfn-type="dfn" data-export="" id="concept-event">event<a class="self-link" href="#concept-event"></a></dfn> allows for signaling that
-something has occurred, e.g. that an image has completed downloading. It is
-represented by the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface or an interface that
-inherits from the <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> interface.</p>
+   <p>An <code class="idl"><a data-link-type="idl" href="#event">Event</a></code> object is simply named an <dfn data-dfn-type="dfn" data-export="" id="concept-event">event<a class="self-link" href="#concept-event"></a></dfn>. It allows for
+signaling that something has occurred, e.g., that an image has completed downloading.</p>
+   <p>An <a data-link-type="dfn" href="#concept-event">event</a> has an associated <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="event-path">path<a class="self-link" href="#event-path"></a></dfn>. A <a data-link-type="dfn" href="#event-path">path</a> is a
+list of tuples, each of which consists of an <b>item</b> (an <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> object) and a <b>target</b> (null or an <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> object). A tuple is formatted as (<b>item</b>, <b>target</b>). A <a data-link-type="dfn" href="#event-path">path</a> is initially the empty list.</p>
    <dl class="domintro">
     <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-event-event">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code> 
     <dd>Returns a new <var>event</var> whose <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is set to <var>type</var>. The optional <var>eventInitDict</var> argument
@@ -557,6 +559,8 @@ inherits from the <code class="idl"><a data-link-type="idl" href="#event">Event<
     <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-defaultprevented">defaultPrevented</a></code></code> 
     <dd>Returns true if <code class="idl"><a data-link-type="idl" href="#dom-event-preventdefault">preventDefault()</a></code> was invoked successfully to indicate cancellation,
  and false otherwise. 
+    <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-scoped">scoped</a></code></code> 
+    <dd>Returns true or false depending on how <var>event</var> was initialized. True if <var>event</var> does not invoke listeners past a <code class="idl"><a data-link-type="idl" href="#shadowroot">ShadowRoot</a></code> <a data-link-type="dfn" href="#concept-node">node</a> that is the <a data-link-type="dfn" href="#concept-tree-root">root</a> of its <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value, and false otherwise. 
     <dt><code><var>event</var> . <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code></code> 
     <dd>Returns true if <var>event</var> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent, and
  false otherwise. 
@@ -592,9 +596,10 @@ flags that are all initially unset:</p>
     <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-propagation-flag">stop propagation flag<a class="self-link" href="#stop-propagation-flag"></a></dfn> 
     <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="stop-immediate-propagation-flag">stop immediate propagation flag<a class="self-link" href="#stop-immediate-propagation-flag"></a></dfn> 
     <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="canceled-flag">canceled flag<a class="self-link" href="#canceled-flag"></a></dfn> 
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="in-passive-listener-flag">in passive listener flag<a class="self-link" href="#in-passive-listener-flag"></a></dfn> 
+    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="scoped-flag">scoped flag<a class="self-link" href="#scoped-flag"></a></dfn> 
     <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="initialized-flag">initialized flag<a class="self-link" href="#initialized-flag"></a></dfn> 
     <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="dispatch-flag">dispatch flag<a class="self-link" href="#dispatch-flag"></a></dfn> 
-    <li><dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="in-passive-listener-flag">in passive listener flag<a class="self-link" href="#in-passive-listener-flag"></a></dfn> 
    </ul>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="method" data-export="" id="dom-event-stoppropagation">stopPropagation()<a class="self-link" href="#dom-event-stoppropagation"></a></dfn> method must set the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="method" data-export="" id="dom-event-stopimmediatepropagation">stopImmediatePropagation()<a class="self-link" href="#dom-event-stopimmediatepropagation"></a></dfn> method must set both the <a data-link-type="dfn" href="#stop-propagation-flag">stop propagation flag</a> and <a data-link-type="dfn" href="#stop-immediate-propagation-flag">stop immediate propagation flag</a>.</p>
@@ -606,6 +611,7 @@ effect. User agents are encouraged to log the precise cause in a developer conso
 debugging. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="attribute" data-export="" id="dom-event-defaultprevented">defaultPrevented<a class="self-link" href="#dom-event-defaultprevented"></a></dfn> attribute must return true if the <a data-link-type="dfn" href="#canceled-flag">canceled flag</a> is set and
 false otherwise.</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="attribute" data-export="" id="dom-event-scoped"><code>scoped</code><a class="self-link" href="#dom-event-scoped"></a></dfn> attribute’s getter must return true if <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#scoped-flag">scoped flag</a> is set, and false otherwise.</p>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Event" data-dfn-type="attribute" data-export="" id="dom-event-istrusted">isTrusted<a class="self-link" href="#dom-event-istrusted"></a></dfn> attribute
 must return the value it was initialized to. When an <a data-link-type="dfn" href="#concept-event">event</a> is created the attribute must be
@@ -636,8 +642,8 @@ Please see <a href="https://github.com/whatwg/dom/issues/23">dom #23</a> for mor
  these steps. 
     <li><a data-link-type="dfn" href="#concept-event-initialize">Initialize</a> the <a data-link-type="dfn" href="#context-object">context object</a> with <var>type</var>, <var>bubbles</var>, and <var>cancelable</var>. 
    </ol>
-   <p class="note no-backref" role="note">As <a data-link-type="dfn" href="#concept-event">events</a> have constructors <code class="idl"><a data-link-type="idl" href="#dom-event-initevent">initEvent()</a></code> is superfluous. However,
-it has to be supported for legacy content. </p>
+   <p class="note no-backref" role="note">As <a data-link-type="dfn" href="#concept-event">events</a> have constructors <code class="idl"><a data-link-type="idl" href="#dom-event-initevent">initEvent()</a></code> is redundant and
+incapable of setting <code class="idl"><a data-link-type="idl" href="#dom-event-scoped">scoped</a></code>. It has to be supported for legacy content. </p>
    <h3 class="heading settled" data-level="3.3" id="interface-customevent"><span class="secno">3.3. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#customevent">CustomEvent</a></code></span><a class="self-link" href="#interface-customevent"></a></h3>
 <pre class="idl def">[<dfn class="idl-code" data-dfn-for="CustomEvent" data-dfn-type="constructor" data-export="" data-lt="CustomEvent(type, eventInitDict)|CustomEvent(type)" id="dom-customevent-customevent">Constructor<a class="self-link" href="#dom-customevent-customevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="CustomEvent/CustomEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-customevent-customevent-type-eventinitdict-type">type<a class="self-link" href="#dom-customevent-customevent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-customeventinit">CustomEventInit</a> <dfn class="idl-code" data-dfn-for="CustomEvent/CustomEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-customevent-customevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-customevent-customevent-type-eventinitdict-eventinitdict"></a></dfn>),
  Exposed=(Window,Worker)]
@@ -732,7 +738,8 @@ fields above, an <a data-link-type="dfn" href="#concept-event-listener">event li
    <p>Each <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> object also has an associated <dfn data-dfn-type="dfn" data-export="" id="get-the-parent">get the parent<a class="self-link" href="#get-the-parent"></a></dfn> algorithm,
 which takes an <a data-link-type="dfn" href="#concept-event">event</a> <var>event</var>, and returns an <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> object. Unless
 specified otherwise it returns null. </p>
-   <p class="note no-backref" role="note"><a data-link-type="dfn" href="#concept-node">Nodes</a> and <a data-link-type="dfn" href="#concept-document">documents</a> override the <a data-link-type="dfn" href="#get-the-parent">get the parent</a> algorithm. </p>
+   <p class="note no-backref" role="note"><a data-link-type="dfn" href="#concept-node">Nodes</a>, <a data-link-type="dfn" href="#concept-shadow-root">shadow roots</a>, and <a data-link-type="dfn" href="#concept-document">documents</a> override
+the <a data-link-type="dfn" href="#get-the-parent">get the parent</a> algorithm. </p>
    <dl class="domintro">
     <dt><code><var>target</var> . <a class="idl-code" data-link-type="method" href="#dom-eventtarget-addeventlistener">addEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code> 
     <dd>
@@ -832,39 +839,62 @@ listeners are <code class="idl"><a data-link-type="idl" href="#dom-addeventliste
 of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneroptions-passive">passive</a></code> listeners, and use that to clear the <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> property of the event being dispatched. </p>
    <p>Ideally, any new event APIs are defined such that they do not need this property (use <a href="https://lists.w3.org/Archives/Public/public-script-coord/">public-scrip-coord@w3.org</a> for discussion). </p>
    <h3 class="heading settled" data-level="3.8" id="dispatching-events"><span class="secno">3.8. </span><span class="content">Dispatching events</span><a class="self-link" href="#dispatching-events"></a></h3>
-   <p>To <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="concept-event-dispatch">dispatch<a class="self-link" href="#concept-event-dispatch"></a></dfn> an <var>event</var> to a <var>target</var>, with an optional <var>target override</var>, run these steps: </p>
+   <p>To <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="concept-event-dispatch">dispatch<a class="self-link" href="#concept-event-dispatch"></a></dfn> an <var>event</var> to a <var>target</var>, with an optional <var>targetOverride</var>, run these steps: </p>
    <ol>
     <li>
      <p>Set <var>event</var>’s <a data-link-type="dfn" href="#dispatch-flag">dispatch flag</a>. </p>
     <li>
-     <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute to <var>target override</var>, if it is given, and <var>target</var> otherwise. </p>
+     <p>If <var>targetOverride</var> is not given, let <var>targetOverride</var> be <var>target</var>. </p>
+     <p class="note" role="note">The <var>targetOverride</var> argument is only used by HTML and only under very
+  specific circumstances. </p>
     <li>
-     <p>Let <var>eventPath</var> be a list containing <var>target</var>. </p>
+     <p>Append (<var>target</var>, <var>targetOverride</var>) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
     <li>
-     <p>While invoking <a data-link-type="dfn" href="#get-the-parent">get the parent</a>, given <var>event</var>, on <var>eventPath</var>’s
- last item, does not return null, append the return value to <var>eventPath</var>. </p>
+     <p>Let <var>parent</var> be the result of invoking <var>target</var>’s <a data-link-type="dfn" href="#get-the-parent">get the parent</a> with <var>event</var>. </p>
     <li>
-     <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code>. </p>
-    <li>
-     <p>For each <var>object</var> in <var>eventPath</var>, in reverse order, if <var>object</var> is not <var>target</var>, <a data-link-type="dfn" href="#concept-event-listener-invoke">invoke</a> <var>object</var> with <var>event</var>. </p>
-    <li>
-     <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>. </p>
-    <li>
-     <p><a data-link-type="dfn" href="#concept-event-listener-invoke">Invoke</a> <var>target</var> with <var>event</var>. </p>
-    <li>
-     <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> attribute value is true, run these substeps: </p>
+     <p>While <var>parent</var> is non-null:</p>
      <ol>
       <li>
-       <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-bubbling_phase">BUBBLING_PHASE</a></code>. </p>
+       <p>If <var>target</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</a> of <var>parent</var>, then append
+   (<var>parent</var>, null) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
       <li>
-       <p>For each <var>object</var> in <var>eventPath</var>, if <var>object</var> is not <var>target</var>, <a data-link-type="dfn" href="#concept-event-listener-invoke">invoke</a> <var>object</var> with <var>event</var>. </p>
+       <p>Otherwise, set <var>target</var> to <var>parent</var> and append
+   (<var>parent</var>, <var>target</var>) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
+      <li>
+       <p>Set <var>parent</var> to the result of invoking <var>parent</var>’s <a data-link-type="dfn" href="#get-the-parent">get the parent</a> with <var>event</var>. </p>
+     </ol>
+    <li>
+     <p>Set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-capturing_phase">CAPTURING_PHASE</a></code>. </p>
+    <li>
+     <p>For each <var>tuple</var> in <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>, in reverse order: </p>
+     <ol>
+      <li>
+       <p>Set <var>event</var>’s <code class="idl"><a data-link-type="idl">target</a></code> attribute to the <b>target</b> of the last tuple
+   in <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>, that is either <var>tuple</var> or preceding <var>tuple</var>, whose <b>target</b> is non-null. </p>
+      <li>
+       <p>If <var>tuple</var>’s <b>target</b> is null, then <a data-link-type="dfn" href="#concept-event-listener-invoke">invoke</a> <var>tuple</var>’s <b>item</b> with <var>event</var>. </p>
+     </ol>
+    <li>
+     <p>For each <var>tuple</var> in <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>, in order: </p>
+     <ol>
+      <li>
+       <p>Set <var>event</var>’s <code class="idl"><a data-link-type="idl">target</a></code> attribute to the <b>target</b> of the last tuple
+   in <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>, that is either <var>tuple</var> or preceding <var>tuple</var>, whose <b>target</b> is non-null. </p>
+      <li>
+       <p>If <var>tuple</var>’s <b>target</b> is non-null, then set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>. </p>
+      <li>
+       <p>Otherwise, set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-bubbling_phase">BUBBLING_PHASE</a></code>. </p>
+      <li>
+       <p>If either <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute is <code class="idl"><a data-link-type="idl" href="#dom-event-bubbling_phase">BUBBLING_PHASE</a></code> and <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> attribute is true or <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute is <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>, then <a data-link-type="dfn" href="#concept-event-listener-invoke">invoke</a> <var>tuple</var>’s <b>item</b> with <var>event</var>. </p>
      </ol>
     <li>
      <p>Unset <var>event</var>’s <a data-link-type="dfn" href="#dispatch-flag">dispatch flag</a>. </p>
     <li>
-     <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-none">NONE</a></code>. </p>
+     <p>Set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-none">NONE</a></code>. </p>
     <li>
-     <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute to null. </p>
+     <p>Set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute to null. </p>
+    <li>
+     <p>Set <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a> to the empty list. </p>
     <li>
      <p>Return false if <var>event</var>’s <a data-link-type="dfn" href="#canceled-flag">canceled flag</a> is set, and true otherwise. </p>
    </ol>
@@ -2053,7 +2083,7 @@ is used by all <a data-link-type="dfn" href="#concept-node">nodes</a> (<code cla
    <p>Each <a data-link-type="dfn" href="#concept-node">node</a> has an associated <dfn data-dfn-for="Node" data-dfn-type="dfn" data-export="" id="concept-node-document">node document<a class="self-link" href="#concept-node-document"></a></dfn>, set upon creation,
 that is a <a data-link-type="dfn" href="#concept-document">document</a>.</p>
    <p class="note no-backref" role="note">A <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> can be changed by the <a data-link-type="dfn" href="#concept-node-adopt">adopt</a> algorithm. </p>
-   <p>A <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#get-the-parent">get the parent</a> algorithm, given an <var>event</var>, returns the <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. </p>
+   <p>A <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#get-the-parent">get the parent</a> algorithm, given an <var>event</var>, returns the <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#slotable-assigned-slot">assigned slot</a>, if <a data-link-type="dfn" href="#concept-node">node</a> is <a data-link-type="dfn" href="#slotable-assigned">assigned</a>, and <a data-link-type="dfn" href="#concept-node">node</a>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a> otherwise. </p>
    <hr>
    <dl class="domintro">
     <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-nodetype">nodeType</a></code></code> 
@@ -3189,6 +3219,8 @@ enum <dfn class="idl-code" data-dfn-type="enum" data-export="" id="enumdef-shado
    <p><a data-link-type="dfn" href="#concept-shadow-root">Shadow roots</a> have an associated <dfn data-dfn-for="ShadowRoot" data-dfn-type="dfn" data-noexport="" id="shadowroot-mode">mode<a class="self-link" href="#shadowroot-mode"></a></dfn> ("<code>open</code>"
 or "<code>closed</code>").</p>
    <p><a data-link-type="dfn" href="#concept-shadow-root">Shadow roots</a>’s associated <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> is never null.</p>
+   <p>A <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>’s <a data-link-type="dfn" href="#get-the-parent">get the parent</a> algorithm, given an <var>event</var>, returns
+null if <var>event</var>’s <a data-link-type="dfn" href="#scoped-flag">scoped flag</a> is set and <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> is the <a data-link-type="dfn" href="#concept-tree-root">root</a> of <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>’s first tuple’s <b>item</b>, and <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> otherwise. </p>
    <p>The <dfn class="idl-code" data-dfn-for="ShadowRoot" data-dfn-type="attribute" data-export="" id="dom-shadowroot-mode"><code>mode</code><a class="self-link" href="#dom-shadowroot-mode"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#shadowroot-mode">mode</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ShadowRoot" data-dfn-type="attribute" data-export="" id="dom-shadowroot-host"><code>host</code><a class="self-link" href="#dom-shadowroot-host"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a>. </p>
    <hr>
@@ -5538,9 +5570,9 @@ neighboring rights to this work.</p>
      <li><a href="#dom-document-doctype">attribute for Document</a><span>, in §4.5</span>
      <li><a href="#concept-doctype">definition of</a><span>, in §4.6</span>
     </ul>
+   <li><a href="#dom-document-document">Document()</a><span>, in §4.5</span>
    <li><a href="#document">Document</a><span>, in §4.5</span>
    <li><a href="#concept-document">document</a><span>, in §4.5</span>
-   <li><a href="#dom-document-document">Document()</a><span>, in §4.5</span>
    <li><a href="#dom-document-documentelement">documentElement</a><span>, in §4.5</span>
    <li><a href="#document-element">document element</a><span>, in §4.2.1</span>
    <li><a href="#documentfragment">DocumentFragment</a><span>, in §4.7</span>
@@ -5907,6 +5939,7 @@ namespace and local name localName</a><span>, in §4.4</span>
    <li><a href="#concept-tree-participate">participate in a tree</a><span>, in §2.1</span>
    <li><a href="#concept-tree-participate">participates in a tree</a><span>, in §2.1</span>
    <li><a href="#dom-addeventlisteneroptions-passive">passive</a><span>, in §3.6</span>
+   <li><a href="#event-path">path</a><span>, in §3.2</span>
    <li><a href="#dom-nodeiterator-pointerbeforereferencenode">pointerBeforeReferenceNode</a><span>, in §6.1</span>
    <li><a href="#concept-range-bp-position">position</a><span>, in §5.2</span>
    <li><a href="#concept-tree-preceding">preceding</a><span>, in §2.1</span>
@@ -6005,6 +6038,13 @@ namespace and local name localName</a><span>, in §4.4</span>
     </ul>
    <li><a href="#dom-node-rootnode">rootNode</a><span>, in §4.4</span>
    <li><a href="#dom-element-schematypeinfo">schemaTypeInfo</a><span>, in §8.2</span>
+   <li>
+    scoped
+    <ul>
+     <li><a href="#dom-eventinit-scoped">dict-member for EventInit</a><span>, in §3.2</span>
+     <li><a href="#dom-event-scoped">attribute for Event</a><span>, in §3.2</span>
+    </ul>
+   <li><a href="#scoped-flag">scoped flag</a><span>, in §3.2</span>
    <li><a href="#scope-match-a-selectors-string">scope-match a selectors string</a><span>, in §2.4</span>
    <li><a href="#concept-range-select">select</a><span>, in §5.2</span>
    <li><a href="#dom-range-selectnodecontents">selectNodeContents(node)</a><span>, in §5.2</span>
@@ -6368,16 +6408,18 @@ interface <a href="#event">Event</a> {
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-cancelable">cancelable</a>;
   void <a class="idl-code" data-link-type="method" href="#dom-event-preventdefault">preventDefault</a>();
   readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-defaultprevented">defaultPrevented</a>;
+  readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-scoped">scoped</a>;
 
   [Unforgeable] readonly attribute boolean <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="boolean " href="#dom-event-istrusted">isTrusted</a>;
   readonly attribute <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#common-domtimestamp">DOMTimeStamp</a> <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="DOMTimeStamp " href="#dom-event-timestamp">timeStamp</a>;
 
-  void <a class="idl-code" data-link-type="method" href="#dom-event-initevent">initEvent</a>(DOMString <a href="#dom-event-initevent-type-bubbles-cancelable-type">type</a>, boolean <a href="#dom-event-initevent-type-bubbles-cancelable-bubbles">bubbles</a>, boolean <a href="#dom-event-initevent-type-bubbles-cancelable-cancelable">cancelable</a>);
+  void <a class="idl-code" data-link-type="method" href="#dom-event-initevent">initEvent</a>(DOMString <a href="#dom-event-initevent-type-bubbles-cancelable-type">type</a>, boolean <a href="#dom-event-initevent-type-bubbles-cancelable-bubbles">bubbles</a>, boolean <a href="#dom-event-initevent-type-bubbles-cancelable-cancelable">cancelable</a>); // historical
 };
 
 dictionary <a href="#dictdef-eventinit">EventInit</a> {
   boolean <a data-default="false" data-type="boolean " href="#dom-eventinit-bubbles">bubbles</a> = false;
   boolean <a data-default="false" data-type="boolean " href="#dom-eventinit-cancelable">cancelable</a> = false;
+  boolean <a data-default="false" data-type="boolean " href="#dom-eventinit-scoped">scoped</a> = false;
 };
 
 [<a href="#dom-customevent-customevent">Constructor</a>(DOMString <a href="#dom-customevent-customevent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="#dictdef-customeventinit">CustomEventInit</a> <a href="#dom-customevent-customevent-type-eventinitdict-eventinitdict">eventInitDict</a>),

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-04-28">28 April 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-04-29">29 April 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>


### PR DESCRIPTION
Includes support for scoped events that a number of HTML features
require. The invocation order handles CAPTURE first, then TARGET and
BUBBLE. Retargeting happens during the BUBBLE phase as developers
mostly use BUBBLE listeners and therefore it would be unexpected if
it was interleaved with the CAPTURE phase.

A split approach where capture listeners for the targets are invoked
during CAPTURE and bubble listeners are invoked during BUBBLE was
also considered, but eventually dismissed as it would make shadow
hosts observable.

Fixes #237 and fixes https://github.com/w3c/webcomponents/issues/485.