### PR TITLE
Don't set custom element state redundantly

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5723,8 +5723,6 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <var>localName</var>, then <a>throw</a> a {{NotSupportedError}}.
 
      <li><p>Set <var>result</var>'s <a for=Element>namespace prefix</a> to <var>prefix</var>.
-
-     <li><p>Set <var>result</var>'s <a>custom element state</a> to "<code>custom</code>".
     </ol>
    </li>
 

--- a/dom.html
+++ b/dom.html
@@ -219,7 +219,7 @@
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-05-31">31 May 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-06-01">1 June 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -3554,8 +3554,6 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
          <p>If <var>result</var>’s <a data-link-type="dfn" href="#concept-element-local-name">local name</a> is not equal to <var>localName</var>, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. </p>
         <li>
          <p>Set <var>result</var>’s <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> to <var>prefix</var>. </p>
-        <li>
-         <p>Set <var>result</var>’s <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> to "<code>custom</code>". </p>
        </ol>
       <li>
        <p>Otherwise: </p>


### PR DESCRIPTION
As of https://github.com/whatwg/html/pull/1309, this is no longer necessary, as it is taken care of in the Construct(C) step.

Ideally don't merge this until that PR is merged.