### PR TITLE
Rename "in a (shadow-including) document"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1521,8 +1521,12 @@ A <a>node</a> is considered
 <p class="note no-backref">Per the <a>node tree</a> constraints, there can be only one such
 <a for="/">element</a>.
 
-<p>An <a for=/>element</a> is <dfn export>in a document</dfn> if its <a for=tree>root</a> is a
+<p>An <a for=/>element</a> is <dfn export>in a document tree</dfn> if its <a for=tree>root</a> is a
 <a>document</a>.
+
+<p>An <a for=/>element</a> is <dfn export>in a document</dfn> if it is <a>in a document tree</a>.
+<span class="note">The term <a>in a document</a> is no longer supposed to be used. It indicates that
+the standard using it has not been updated to account for <a>shadow trees</a>.</span>
 
 
 <h4 id=shadow-trees>Shadow tree</h4>
@@ -1530,7 +1534,7 @@ A <a>node</a> is considered
 <p>A <dfn export id=concept-shadow-tree>shadow tree</dfn> is a <a>node tree</a> whose
 <a for=tree>root</a> is a <a for=/>shadow root</a>.
 
-<p>A <a for=/>shadow root</a> is always connected to another <a>node tree</a> through its
+<p>A <a for=/>shadow root</a> is always attached to another <a>node tree</a> through its
 <a for=DocumentFragment>host</a>. A <a>shadow tree</a> is therefore never alone. The
 <a>node tree</a> of a <a for=/>shadow root</a>'s <a for=DocumentFragment>host</a> is sometimes
 referred to as the <dfn export id=concept-light-tree>light tree</dfn>.</p>
@@ -1538,7 +1542,7 @@ referred to as the <dfn export id=concept-light-tree>light tree</dfn>.</p>
 <p class="note">A <a>shadow tree</a>'s corresponding <a>light tree</a> can be a <a>shadow tree</a>
 itself.</p>
 
-<p>An <a for=/>element</a> is <dfn export>in a shadow-including document</dfn> if its
+<p id="in-a-shadow-including-document">An <a for=/>element</a> is <dfn export>connected</dfn> if its
 <a>shadow-including root</a> is a <a>document</a>.
 
 <h5 id=shadow-tree-slots>Slots</h5>
@@ -1948,7 +1952,7 @@ into a <var>parent</var> before a <var>child</var>, with an optional
      <li><p>Run the <a>insertion steps</a> with <var>inclusiveDescendant</var>.
 
      <li>
-      <p>If <var>inclusiveDescendant</var> is <a>in a shadow-including document</a>, then:
+      <p>If <var>inclusiveDescendant</var> is <a>connected</a>, then:
 
       <ol>
        <li><p>If <var>inclusiveDescendant</var> is <a>custom</a>, then
@@ -3615,8 +3619,7 @@ The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must r
 
 <dl class=domintro>
  <dt><code><var>node</var> . {{Node/isConnected}}</code>
- <dd><p>Returns true if <var>node</var> is <a>in a shadow-including document</a> and false
- otherwise.
+ <dd><p>Returns true if <var>node</var> is <a>connected</a> and false otherwise.
 
  <dt><code><var>node</var> . {{Node/ownerDocument}}</code>
  <dd>
@@ -3658,7 +3661,7 @@ The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must r
 </dl>
 
 <p>The <dfn attribute for=Node><code>isConnected</code></dfn> attribute's getter must return true,
-if <a>context object</a> is <a>in a shadow-including document</a>, and false otherwise.</p>
+if <a>context object</a> is <a>connected</a>, and false otherwise.</p>
 
 <p>The <dfn attribute for=Node><code>ownerDocument</code></dfn> attribute's getter must return null,
 if the <a>context object</a> is a <a>document</a>, and the <a>context object</a>'s
@@ -9756,9 +9759,8 @@ These are the changes made to the features described in the
 <ul>
  <li><dfn interface>RangeException</dfn> has been removed.
 
- <li>{{Range}} objects can now be moved between
- <a>documents</a> and used on
- <a>nodes</a> that are not <a>in a document</a>.
+ <li>{{Range}} objects can now be moved between <a>documents</a> and used on <a>nodes</a> that are
+ not <a>in a document tree</a>.
 
  <li>A wild {{Range/Range()}} constructor appeared.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1542,7 +1542,7 @@ referred to as the <dfn export id=concept-light-tree>light tree</dfn>.</p>
 <p class="note">A <a>shadow tree</a>'s corresponding <a>light tree</a> can be a <a>shadow tree</a>
 itself.</p>
 
-<p id="in-a-shadow-including-document">An <a for=/>element</a> is <dfn export>connected</dfn> if its
+<p id=in-a-shadow-including-document>An <a for=/>element</a> is <dfn export>connected</dfn> if its
 <a>shadow-including root</a> is a <a>document</a>.
 
 <h5 id=shadow-tree-slots>Slots</h5>

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-07-06">6 July 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-07-07">7 July 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -1112,13 +1112,15 @@ concept is clear. Markup goes in, a <a data-link-type="dfn" href="#concept-tree"
    <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-document-tree">document tree<a class="self-link" href="#concept-document-tree"></a></dfn> is a <a data-link-type="dfn" href="#concept-node-tree">node tree</a> whose <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-document">document</a>. </p>
    <p>The <dfn data-dfn-type="dfn" data-export="" id="document-element">document element<a class="self-link" href="#document-element"></a></dfn> of a <a data-link-type="dfn" href="#concept-document">document</a> is the <a data-link-type="dfn" href="#concept-element">element</a> whose <a data-link-type="dfn" href="#concept-tree-parent">parent</a> is that <a data-link-type="dfn" href="#concept-document">document</a>, if it exists, and null otherwise. </p>
    <p class="note no-backref" role="note">Per the <a data-link-type="dfn" href="#concept-node-tree">node tree</a> constraints, there can be only one such <a data-link-type="dfn" href="#concept-element">element</a>. </p>
-   <p>An <a data-link-type="dfn" href="#concept-element">element</a> is <dfn data-dfn-type="dfn" data-export="" id="in-a-document">in a document<a class="self-link" href="#in-a-document"></a></dfn> if its <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-document">document</a>. </p>
+   <p>An <a data-link-type="dfn" href="#concept-element">element</a> is <dfn data-dfn-type="dfn" data-export="" id="in-a-document-tree">in a document tree<a class="self-link" href="#in-a-document-tree"></a></dfn> if its <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-document">document</a>. </p>
+   <p>An <a data-link-type="dfn" href="#concept-element">element</a> is <dfn data-dfn-type="dfn" data-export="" id="in-a-document">in a document<a class="self-link" href="#in-a-document"></a></dfn> if it is <a data-link-type="dfn" href="#in-a-document-tree">in a document tree</a>. <span class="note" role="note">The term <a data-link-type="dfn" href="#in-a-document">in a document</a> is no longer supposed to be used. It indicates that
+the standard using it has not been updated to account for <a data-link-type="dfn" href="#concept-shadow-tree">shadow trees</a>.</span> </p>
    <h4 class="heading settled" data-level="4.2.2" id="shadow-trees"><span class="secno">4.2.2. </span><span class="content">Shadow tree</span><a class="self-link" href="#shadow-trees"></a></h4>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-shadow-tree">shadow tree<a class="self-link" href="#concept-shadow-tree"></a></dfn> is a <a data-link-type="dfn" href="#concept-node-tree">node tree</a> whose <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>. </p>
-   <p>A <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> is always connected to another <a data-link-type="dfn" href="#concept-node-tree">node tree</a> through its <a data-link-type="dfn" href="#concept-documentfragment-host">host</a>. A <a data-link-type="dfn" href="#concept-shadow-tree">shadow tree</a> is therefore never alone. The <a data-link-type="dfn" href="#concept-node-tree">node tree</a> of a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> is sometimes
+   <p>A <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> is always attached to another <a data-link-type="dfn" href="#concept-node-tree">node tree</a> through its <a data-link-type="dfn" href="#concept-documentfragment-host">host</a>. A <a data-link-type="dfn" href="#concept-shadow-tree">shadow tree</a> is therefore never alone. The <a data-link-type="dfn" href="#concept-node-tree">node tree</a> of a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> is sometimes
 referred to as the <dfn data-dfn-type="dfn" data-export="" id="concept-light-tree">light tree<a class="self-link" href="#concept-light-tree"></a></dfn>.</p>
    <p class="note" role="note">A <a data-link-type="dfn" href="#concept-shadow-tree">shadow tree</a>’s corresponding <a data-link-type="dfn" href="#concept-light-tree">light tree</a> can be a <a data-link-type="dfn" href="#concept-shadow-tree">shadow tree</a> itself.</p>
-   <p>An <a data-link-type="dfn" href="#concept-element">element</a> is <dfn data-dfn-type="dfn" data-export="" id="in-a-shadow-including-document">in a shadow-including document<a class="self-link" href="#in-a-shadow-including-document"></a></dfn> if its <a data-link-type="dfn" href="#concept-shadow-including-root">shadow-including root</a> is a <a data-link-type="dfn" href="#concept-document">document</a>. </p>
+   <p id="in-a-shadow-including-document">An <a data-link-type="dfn" href="#concept-element">element</a> is <dfn data-dfn-type="dfn" data-export="" id="connected">connected<a class="self-link" href="#connected"></a></dfn> if its <a data-link-type="dfn" href="#concept-shadow-including-root">shadow-including root</a> is a <a data-link-type="dfn" href="#concept-document">document</a>. </p>
    <h5 class="heading settled" data-level="4.2.2.1" id="shadow-tree-slots"><span class="secno">4.2.2.1. </span><span class="content">Slots</span><a class="self-link" href="#shadow-tree-slots"></a></h5>
    <p>A <a data-link-type="dfn" href="#concept-shadow-tree">shadow tree</a> contains zero or more <a data-link-type="dfn" href="#concept-element">elements</a> that are <dfn data-dfn-type="dfn" data-export="" data-lt="slot" id="concept-slot">slots<a class="self-link" href="#concept-slot"></a></dfn>.</p>
    <p class="note" role="note">A <a data-link-type="dfn" href="#concept-slot">slot</a> can only be created through HTML’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">slot</a></code> element.</p>
@@ -1349,7 +1351,7 @@ The algorithm is passed <var>insertedNode</var>, as indicated in the <a data-lin
         <li>
          <p>Run the <a data-link-type="dfn" href="#concept-node-insert-ext">insertion steps</a> with <var>inclusiveDescendant</var>. </p>
         <li>
-         <p>If <var>inclusiveDescendant</var> is <a data-link-type="dfn" href="#in-a-shadow-including-document">in a shadow-including document</a>, then: </p>
+         <p>If <var>inclusiveDescendant</var> is <a data-link-type="dfn" href="#connected">connected</a>, then: </p>
          <ol>
           <li>
            <p>If <var>inclusiveDescendant</var> is <a data-link-type="dfn" href="#concept-element-custom">custom</a>, then <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>,
@@ -2203,8 +2205,7 @@ the first matching statement, switching on the <a data-link-type="dfn" href="#co
    <dl class="domintro">
     <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-isconnected">isConnected</a></code></code> 
     <dd>
-     <p>Returns true if <var>node</var> is <a data-link-type="dfn" href="#in-a-shadow-including-document">in a shadow-including document</a> and false
- otherwise. </p>
+     <p>Returns true if <var>node</var> is <a data-link-type="dfn" href="#connected">connected</a> and false otherwise. </p>
     <dt><code><var>node</var> . <code class="idl"><a data-link-type="idl" href="#dom-node-ownerdocument">ownerDocument</a></code></code> 
     <dd> Returns the <a data-link-type="dfn" href="#concept-node-document">node document</a>.
   Returns null for <a data-link-type="dfn" href="#concept-document">documents</a>. 
@@ -2230,7 +2231,7 @@ the first matching statement, switching on the <a data-link-type="dfn" href="#co
     <dd>Returns the <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. 
    </dl>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-isconnected"><code>isConnected</code><a class="self-link" href="#dom-node-isconnected"></a></dfn> attribute’s getter must return true,
-if <a data-link-type="dfn" href="#context-object">context object</a> is <a data-link-type="dfn" href="#in-a-shadow-including-document">in a shadow-including document</a>, and false otherwise.</p>
+if <a data-link-type="dfn" href="#context-object">context object</a> is <a data-link-type="dfn" href="#connected">connected</a>, and false otherwise.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-ownerdocument"><code>ownerDocument</code><a class="self-link" href="#dom-node-ownerdocument"></a></dfn> attribute’s getter must return null,
 if the <a data-link-type="dfn" href="#context-object">context object</a> is a <a data-link-type="dfn" href="#concept-document">document</a>, and the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> otherwise. </p>
    <p class="note" role="note">The <a data-link-type="dfn" href="#concept-node-document">node document</a> of a <a data-link-type="dfn" href="#concept-document">document</a> is that <a data-link-type="dfn" href="#concept-document">document</a> itself. All <a data-link-type="dfn" href="#concept-node">nodes</a> have a <a data-link-type="dfn" href="#concept-node-document">node document</a> at all times. </p>
@@ -5243,7 +5244,8 @@ some of these features should be reintroduced. </p>
 "Document Object Model Range" chapter of <cite>DOM Level 2 Traversal and Range</cite>.</p>
    <ul>
     <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="rangeexception">RangeException<a class="self-link" href="#rangeexception"></a></dfn> has been removed. 
-    <li><code class="idl"><a data-link-type="idl" href="#range">Range</a></code> objects can now be moved between <a data-link-type="dfn" href="#concept-document">documents</a> and used on <a data-link-type="dfn" href="#concept-node">nodes</a> that are not <a data-link-type="dfn" href="#in-a-document">in a document</a>. 
+    <li><code class="idl"><a data-link-type="idl" href="#range">Range</a></code> objects can now be moved between <a data-link-type="dfn" href="#concept-document">documents</a> and used on <a data-link-type="dfn" href="#concept-node">nodes</a> that are
+ not <a data-link-type="dfn" href="#in-a-document-tree">in a document tree</a>. 
     <li>A wild <code class="idl"><a data-link-type="idl" href="#dom-range-range">Range()</a></code> constructor appeared. 
     <li>New methods <code class="idl"><a data-link-type="idl" href="#dom-range-comparepoint">comparePoint()</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-range-intersectsnode">intersectsNode()</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-range-ispointinrange">isPointInRange()</a></code> have been added. 
     <li><code class="idl"><a data-link-type="idl" href="#dom-range-detach">detach()</a></code> is now a no-op. 
@@ -5541,6 +5543,7 @@ neighboring rights to this work.</p>
     </ul>
    <li><a href="#composed-flag">composed flag</a><span>, in §3.2</span>
    <li><a href="#dom-event-composedpath">composedPath()</a><span>, in §3.2</span>
+   <li><a href="#connected">connected</a><span>, in §4.2.2</span>
    <li><a href="#concept-event-constructor">constructor</a><span>, in §3.4</span>
    <li><a href="#contained">contained</a><span>, in §5.2</span>
    <li><a href="#dom-node-contains">contains(other)</a><span>, in §4.4</span>
@@ -5787,7 +5790,7 @@ neighboring rights to this work.</p>
    <li><a href="#dom-document-importnode">importNode(node)</a><span>, in §4.5</span>
    <li><a href="#dom-document-importnode">importNode(node, deep)</a><span>, in §4.5</span>
    <li><a href="#in-a-document">in a document</a><span>, in §4.2.1</span>
-   <li><a href="#in-a-shadow-including-document">in a shadow-including document</a><span>, in §4.2.2</span>
+   <li><a href="#in-a-document-tree">in a document tree</a><span>, in §4.2.1</span>
    <li><a href="#concept-tree-inclusive-ancestor">inclusive ancestor</a><span>, in §2.1</span>
    <li><a href="#concept-tree-inclusive-descendant">inclusive descendant</a><span>, in §2.1</span>
    <li><a href="#concept-tree-inclusive-sibling">inclusive sibling</a><span>, in §2.1</span>


### PR DESCRIPTION
Now we have “in a document tree” and “is connected” instead. Fixes part
of #238.