### PR TITLE
Set the stage for new custom element adoption semantics

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5043,18 +5043,10 @@ a <var>document</var>, run these steps:
    <a>node document</a> to <var>document</var>.
    <!--AttrExodus as well as any associated {{Attr}} nodes-->
 
-   <li>
-    <p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
-    <a>shadow-including inclusive descendants</a> that is an <a for=/>element</a> with
-    <a>custom element state</a> of "<code>custom</code>", set <var>inclusiveDescendant</var>'s
-    <a>custom element state</a> to "<code>undefined</code>".</p>
-
-    <p class="note">
-     If this adoption is followed by an <a lt="insert" for="Node">insertion</a>, as most are, then
-     the insertion will <a lt="try to upgrade an element">try to upgrade</a>
-     <var>inclusiveDescendant</var>, potentially causing it to become <a>custom</a> again.
-    </p>
-   </li>
+   <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
+   <a>shadow-including inclusive descendants</a> that is a <a>custom</a> <a for=/>element</a>,
+   <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>, callback
+   name "<code>adoptedCallback</code>", and an empty argument list.
 
    <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
    <a>shadow-including inclusive descendants</a>, in <a>shadow-including tree order</a>, run the
@@ -5590,7 +5582,8 @@ dictionary ShadowRootInit {
 <dfn export id=concept-element-namespace for=Element>namespace</dfn>,
 <dfn export id=concept-element-namespace-prefix for=Element>namespace prefix</dfn>,
 <dfn export id=concept-element-local-name for=Element>local name</dfn>,
-<dfn export id=concept-element-custom-element-state for=Element>custom element state</dfn>, and
+<dfn export id=concept-element-custom-element-state for=Element>custom element state</dfn>,
+<dfn export id=concept-element-custom-element-definition for=Element>custom element definition</dfn>,
 <dfn export id=concept-element-is-value for=Element><code>is</code> value</dfn>. When an
 <a for="/">element</a> is <a lt="create an element">created</a>, all of these values are
 initialized.
@@ -5686,8 +5679,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
    with no attributes, <a for=Element>namespace</a> set to the <a>HTML namespace</a>,
    <a for=Element>namespace prefix</a> set to <var>prefix</var>, <a for=Element>local name</a> set
    to <var>localName</var>, <a>custom element state</a> set to "<code>undefined</code>",
-   <a><code>is</code> value</a> set to <var>is</var>, and <a>node document</a> set to
-   <var>document</var>.
+   <a>custom element definition</a> set to null, <a><code>is</code> value</a> set to <var>is</var>,
+   and <a>node document</a> set to <var>document</var>.
 
    <li><p>If the <var>synchronous custom elements flag</var> is set,
    <a lt="upgrade an element">upgrade</a> <var>element</var> using <var>definition</var>.
@@ -5715,10 +5708,15 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
       <p>If <var>result</var> does not implement the {{HTMLElement}} interface, <a>throw</a> a
       <code>TypeError</code>.
 
-      <p class=note>This is meant to be a brand check to ensure that the object was allocated by the
-      {{HTMLElement}} constructor. See
-      <a href="https://github.com/heycam/webidl/issues/97">webidl #97</a> about making this more
-      precise.
+      <div class=note>
+       <p>This is meant to be a brand check to ensure that the object was allocated by the
+       a HTML element constructor. See
+       <a href="https://github.com/heycam/webidl/issues/97">webidl #97</a> about making this more
+       precise.
+
+       <p>If this check passes, then <var>result</var> will already have its <a>custom element
+       state</a> and <a>custom element definition</a> initialized.
+      </div>
      </li>
 
      <li><p>If <var>result</var>'s <a for=Element>attribute list</a> is not empty, then <a>throw</a>
@@ -5760,7 +5758,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      interface, with no attributes, <a for=Element>namespace</a> set to the <a>HTML namespace</a>,
      <a for=Element>namespace prefix</a> set to <var>prefix</var>, <a for=Element>local name</a> set
      to <var>localName</var>, <a>custom element state</a> set to "<code>undefined</code>",
-     <a><code>is</code> value</a> set to null, and <a>node document</a> set to <var>document</var>.
+     <a>custom element definition</a> set to null, <a><code>is</code> value</a> set to null, and
+     <a>node document</a> set to <var>document</var>.
 
      <li><p><a>Enqueue a custom element upgrade reaction</a> given <var>result</var> and
      <var>definition</var>.
@@ -5780,8 +5779,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
    with no attributes, <a for=Element>namespace</a> set to <var>namespace</var>,
    <a for=Element>namespace prefix</a> set to <var>prefix</var>, <a for=Element>local name</a> set
    to <var>localName</var>, <a>custom element state</a> set to "<code>uncustomized</code>",
-   <a><code>is</code> value</a> set to <var>is</var>, and <a>node document</a> set to
-   <var>document</var>.
+   <a>custom element definition</a> set to null, <a><code>is</code> value</a> set to <var>is</var>,
+   and <a>node document</a> set to <var>document</var>.
 
    <li><p>If <var>document</var> has a <a lt=concept-document-bc>browsing context</a>, and
    <var>namespace</var> is the <a>HTML namespace</a>, and either <var>localName</var> is a

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-07-18">18 July 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-07-21">21 July 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -2886,9 +2886,8 @@ a <var>document</var>, run these steps:</p>
       <li>
        <p>For each <var>inclusiveDescendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendants</a>, set <var>inclusiveDescendant</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. </p>
       <li>
-       <p>For each <var>inclusiveDescendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendants</a> that is an <a data-link-type="dfn" href="#concept-element">element</a> with <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> of "<code>custom</code>", set <var>inclusiveDescendant</var>’s <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> to "<code>undefined</code>".</p>
-       <p class="note" role="note"> If this adoption is followed by an <a data-link-type="dfn" href="#concept-node-insert">insertion</a>, as most are, then
-     the insertion will <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#concept-try-upgrade">try to upgrade</a> <var>inclusiveDescendant</var>, potentially causing it to become <a data-link-type="dfn" href="#concept-element-custom">custom</a> again. </p>
+       <p>For each <var>inclusiveDescendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendants</a> that is a <a data-link-type="dfn" href="#concept-element-custom">custom</a> <a data-link-type="dfn" href="#concept-element">element</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>, callback
+   name "<code>adoptedCallback</code>", and an empty argument list. </p>
       <li>
        <p>For each <var>inclusiveDescendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendants</a>, in <a data-link-type="dfn" href="#concept-shadow-including-tree-order">shadow-including tree order</a>, run the <a data-link-type="dfn" href="#concept-node-adopt-ext">adopting steps</a> with <var>inclusiveDescendant</var> and <var>oldDocument</var>. </p>
      </ol>
@@ -3322,14 +3321,14 @@ updated over time to cover more details. </p>
 };
 </pre>
    <p><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> are simply known as <dfn data-dfn-type="dfn" data-export="" data-lt="element" id="concept-element">elements<a class="self-link" href="#concept-element"></a></dfn>. </p>
-   <p><a data-link-type="dfn" href="#concept-element">Elements</a> have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-namespace">namespace<a class="self-link" href="#concept-element-namespace"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-namespace-prefix">namespace prefix<a class="self-link" href="#concept-element-namespace-prefix"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-local-name">local name<a class="self-link" href="#concept-element-local-name"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-custom-element-state">custom element state<a class="self-link" href="#concept-element-custom-element-state"></a></dfn>, and <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-is-value"><code>is</code> value<a class="self-link" href="#concept-element-is-value"></a></dfn>. When an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-create-element">created</a>, all of these values are
+   <p><a data-link-type="dfn" href="#concept-element">Elements</a> have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-namespace">namespace<a class="self-link" href="#concept-element-namespace"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-namespace-prefix">namespace prefix<a class="self-link" href="#concept-element-namespace-prefix"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-local-name">local name<a class="self-link" href="#concept-element-local-name"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-custom-element-state">custom element state<a class="self-link" href="#concept-element-custom-element-state"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-custom-element-definition">custom element definition<a class="self-link" href="#concept-element-custom-element-definition"></a></dfn>, <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-is-value"><code>is</code> value<a class="self-link" href="#concept-element-is-value"></a></dfn>. When an <a data-link-type="dfn" href="#concept-element">element</a> is <a data-link-type="dfn" href="#concept-create-element">created</a>, all of these values are
 initialized. </p>
    <p>An <a data-link-type="dfn" href="#concept-element">element</a>’s <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> is one of "<code>undefined</code>",
 "<code>failed</code>", "<code>uncustomized</code>", or "<code>custom</code>". An <a data-link-type="dfn" href="#concept-element">element</a> whose <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> is "<code>uncustomized</code>" or
 "<code>custom</code>" is said to be <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-defined">defined<a class="self-link" href="#concept-element-defined"></a></dfn>. An <a data-link-type="dfn" href="#concept-element">element</a> whose <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> is "<code>custom</code>" is said to be <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-custom">custom<a class="self-link" href="#concept-element-custom"></a></dfn>. </p>
    <p class="note" role="note">Whether or not an element is <a data-link-type="dfn" href="#concept-element-defined">defined</a> is used to determine the behavior of the <a class="css" data-link-type="maybe" href="https://html.spec.whatwg.org/multipage/scripting.html#selector-defined">:defined</a> pseudo-class. Whether or not an element is <a data-link-type="dfn" href="#concept-element-custom">custom</a> is used to determine the
 behavior of the <a href="#mutation-algorithms">mutation algorithms</a>. The "<code>failed</code>"
-state is used to ensure that if a <a data-link-type="dfn">custom element constructor</a> fails to execute correctly the
+state is used to ensure that if a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#custom-element-constructor">custom element constructor</a> fails to execute correctly the
 first time, it is not executed again by an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#concept-upgrade-an-element">upgrade</a>.</p>
    <div class="example" id="example-c5b21302">
     <a class="self-link" href="#example-c5b21302"></a> 
@@ -3385,7 +3384,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
       <li>
        <p>Set <var>result</var> to a new <a data-link-type="dfn" href="#concept-element">element</a> that implements <var>interface</var>,
    with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> set to <var>prefix</var>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set
-   to <var>localName</var>, <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> set to "<code>undefined</code>", <a data-link-type="dfn" href="#concept-element-is-value"><code>is</code> value</a> set to <var>is</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>document</var>. </p>
+   to <var>localName</var>, <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> set to "<code>undefined</code>", <a data-link-type="dfn" href="#concept-element-custom-element-definition">custom element definition</a> set to null, <a data-link-type="dfn" href="#concept-element-is-value"><code>is</code> value</a> set to <var>is</var>,
+   and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>document</var>. </p>
       <li>
        <p>If the <var>synchronous custom elements flag</var> is set, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#concept-upgrade-an-element">upgrade</a> <var>element</var> using <var>definition</var>. </p>
       <li>
@@ -3404,8 +3404,13 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      exceptions. </p>
         <li>
          <p>If <var>result</var> does not implement the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> interface, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. </p>
-         <p class="note" role="note">This is meant to be a brand check to ensure that the object was allocated by the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> constructor. See <a href="https://github.com/heycam/webidl/issues/97">webidl #97</a> about making this more
-      precise. </p>
+         <div class="note" role="note">
+          <p>This is meant to be a brand check to ensure that the object was allocated by the
+       a HTML element constructor. See <a href="https://github.com/heycam/webidl/issues/97">webidl #97</a> about making this more
+       precise. </p>
+          <p>If this check passes, then <var>result</var> will already have its <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element
+       state</a> and <a data-link-type="dfn" href="#concept-element-custom-element-definition">custom element definition</a> initialized. </p>
+         </div>
         <li>
          <p>If <var>result</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> is not empty, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. </p>
         <li>
@@ -3433,7 +3438,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
        <ol>
         <li>
          <p>Set <var>result</var> to a new <a data-link-type="dfn" href="#concept-element">element</a> that implements the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">HTMLElement</a></code> interface, with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> set to <var>prefix</var>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set
-     to <var>localName</var>, <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> set to "<code>undefined</code>", <a data-link-type="dfn" href="#concept-element-is-value"><code>is</code> value</a> set to null, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>document</var>. </p>
+     to <var>localName</var>, <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> set to "<code>undefined</code>", <a data-link-type="dfn" href="#concept-element-custom-element-definition">custom element definition</a> set to null, <a data-link-type="dfn" href="#concept-element-is-value"><code>is</code> value</a> set to null, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>document</var>. </p>
         <li>
          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#enqueue-a-custom-element-upgrade-reaction">Enqueue a custom element upgrade reaction</a> given <var>result</var> and <var>definition</var>. </p>
        </ol>
@@ -3446,7 +3451,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
       <li>
        <p>Set <var>result</var> to a new <a data-link-type="dfn" href="#concept-element">element</a> that implements <var>interface</var>,
    with no attributes, <a data-link-type="dfn" href="#concept-element-namespace">namespace</a> set to <var>namespace</var>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a> set to <var>prefix</var>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a> set
-   to <var>localName</var>, <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> set to "<code>uncustomized</code>", <a data-link-type="dfn" href="#concept-element-is-value"><code>is</code> value</a> set to <var>is</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>document</var>. </p>
+   to <var>localName</var>, <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> set to "<code>uncustomized</code>", <a data-link-type="dfn" href="#concept-element-custom-element-definition">custom element definition</a> set to null, <a data-link-type="dfn" href="#concept-element-is-value"><code>is</code> value</a> set to <var>is</var>,
+   and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>document</var>. </p>
       <li>
        <p>If <var>document</var> has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context</a>, and <var>namespace</var> is the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and either <var>localName</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#valid-custom-element-name">valid custom element name</a> or <var>is</var> is is non-null, set <var>result</var>’s <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> to "<code>undefined</code>". </p>
      </ol>
@@ -5590,6 +5596,7 @@ neighboring rights to this work.</p>
    <li><a href="#dom-treewalker-currentnode">currentNode</a><span>, in §6.2</span>
    <li><a href="#dom-event-currenttarget">currentTarget</a><span>, in §3.2</span>
    <li><a href="#concept-element-custom">custom</a><span>, in §4.9</span>
+   <li><a href="#concept-element-custom-element-definition">custom element definition</a><span>, in §4.9</span>
    <li><a href="#concept-element-custom-element-state">custom element state</a><span>, in §4.9</span>
    <li><a href="#customevent">CustomEvent</a><span>, in §3.3</span>
    <li><a href="#dictdef-customeventinit">CustomEventInit</a><span>, in §3.3</span>
@@ -6318,6 +6325,7 @@ neighboring rights to this work.</p>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-body-element">body</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#concept-custom-element-definition-constructor">constructor</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#custom-element-constructor">custom element constructor</a>
      <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#customized-built-in-element">customized built-in element</a>
      <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a>
      <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#enqueue-a-custom-element-upgrade-reaction">enqueue a custom element upgrade reaction</a>


### PR DESCRIPTION
This is part of implementing the consensus arrived at in https://github.com/w3c/webcomponents/issues/512. Now each custom element carries with it a custom element definition. Adoption now enqueues an adoptedCallback call.