### PR TITLE
Shadow: Add "retargeting steps" to the dispatch algorithm

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -651,6 +651,11 @@ list of tuples, each of which consists of an <b>item</b> (an {{EventTarget}} obj
 object). A tuple is formatted as (<b>item</b>, <b>target</b>, <b>relatedTarget</b>). A <a
 for=Event>path</a> is initially the empty list.</p>
 
+<p><a lt="Other applicable specifications">Specifications</a> may define
+<dfn export for=Event>retargeting steps</dfn> for all or some <a>events</a>.
+The algorithm is passed <var>event</var>, as indicated in the <a>dispatch</a>
+algorithm below.
+
 <dl class=domintro>
  <dt><code><var>event</var> = new <a constructor lt="Event()">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
  <dd>Returns a new <var>event</var> whose
@@ -1236,6 +1241,8 @@ for discussion).
 
    <li><p>Set <var>event</var>'s <a>relatedTarget</a> to <var>tuple</var>'s <b>relatedTarget</b>.
 
+   <li><p>Run the <a>retargeting steps</a> with <var>event</var>.
+
    <li><p>If <var>tuple</var>'s <b>target</b> is null, then <a>invoke</a> <var>tuple</var>'s
    <b>item</b> with <var>event</var>.
   </ol>
@@ -1249,6 +1256,8 @@ for discussion).
    <var>tuple</var>, whose <b>target</b> is non-null.
 
    <li><p>Set <var>event</var>'s <a>relatedTarget</a> to <var>tuple</var>'s <b>relatedTarget</b>.
+
+   <li><p>Run the <a>retargeting steps</a> with <var>event</var>.
 
    <li><p>If <var>tuple</var>'s <b>target</b> is non-null, then set <var>event</var>'s
    {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-07-22">22 July 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-04">4 August 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -418,7 +418,7 @@ run these steps:</p>
    <h3 class="heading settled" data-level="3.1" id="introduction-to-dom-events"><span class="secno">3.1. </span><span class="content">Introduction to "DOM Events"</span><a class="self-link" href="#introduction-to-dom-events"></a></h3>
    <p>Throughout the web platform <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to objects to signal an
 occurrence, such as network activity or user interaction. These objects implement the <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> interface and can therefore add <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> to observe <a data-link-type="dfn" href="#concept-event">events</a> by calling <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-addeventlistener">addEventListener()</a></code>:</p>
-<pre class="lang-javascript highlight"><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
+<pre class="lang-javascript highlight"><span></span><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
 
 <span class="kd">function</span> <span class="nx">imgFetched</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span> <span class="p">{</span>
   <span class="c1">// great success</span>
@@ -433,7 +433,7 @@ passed as argument to <a data-link-type="dfn" href="#concept-event-listener">eve
 object to which the <a data-link-type="dfn" href="#concept-event">event</a> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> (<var>obj</var> above).</p>
    <p id="synthetic-events">Now while typically <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent
 as the result of user interaction or the completion of some task, applications can <a data-link-type="dfn" href="#concept-event-dispatch">dispatch</a> <a data-link-type="dfn" href="#concept-event">events</a> themselves, commonly known as synthetic events: </p>
-<pre class="lang-javascript highlight"><span class="c1">// add an appropriate event listener</span>
+<pre class="lang-javascript highlight"><span></span><span class="c1">// add an appropriate event listener</span>
 <span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"cat"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span> <span class="nx">process</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">detail</span><span class="p">)</span> <span class="p">})</span>
 
 <span class="c1">// create and dispatch the event</span>
@@ -447,7 +447,7 @@ operation. For instance as part of form submission an <a data-link-type="dfn" hr
 invoked, form submission will be terminated. Applications who wish to make
 use of this functionality through <a data-link-type="dfn" href="#concept-event">events</a> <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the application
 (synthetic events) can make use of the return value of the <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-dispatchevent">dispatchEvent()</a></code> method:</p>
-<pre class="lang-javascript highlight"><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
+<pre class="lang-javascript highlight"><span></span><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
   <span class="c1">// event was not canceled, time for some magic</span>
   <span class="err">…</span>
 <span class="p">}</span>
@@ -457,14 +457,14 @@ finally, and only if <a data-link-type="dfn" href="#concept-event">event</a>’s
 object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked again,
 but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.</p>
    <p>Lets look at an example of how <a data-link-type="dfn" href="#concept-event">events</a> work in a <a data-link-type="dfn" href="#concept-tree">tree</a>:</p>
-<pre class="lang-markup highlight"><span class="cp">&lt;!doctype html></span>
-<span class="nt">&lt;html></span>
- <span class="nt">&lt;head></span>
-  <span class="nt">&lt;title></span>Boring example<span class="nt">&lt;/title></span>
- <span class="nt">&lt;/head></span>
- <span class="nt">&lt;body></span>
-  <span class="nt">&lt;p></span>Hello <span class="nt">&lt;span</span> <span class="na">id=</span><span class="s">x</span><span class="nt">></span>world<span class="nt">&lt;/span></span>!<span class="nt">&lt;/p></span>
-  <span class="nt">&lt;script></span>
+<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!doctype html></span>
+<span class="p">&lt;</span><span class="nt">html</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">head</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Boring example<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
+ <span class="p">&lt;/</span><span class="nt">head</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello <span class="p">&lt;</span><span class="nt">span</span> <span class="na">id</span><span class="o">=</span><span class="s">x</span><span class="p">></span>world<span class="p">&lt;/</span><span class="nt">span</span><span class="p">></span>!<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
    <span class="kd">function</span> <span class="nx">test</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
      <span class="nx">debug</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">target</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">currentTarget</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">eventPhase</span><span class="p">)</span>
    <span class="p">}</span>
@@ -472,9 +472,9 @@ but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order
    <span class="nb">document</span><span class="p">.</span><span class="nx">body</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="nx">test</span><span class="p">)</span>
    <span class="kd">var</span> <span class="nx">ev</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Event</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="p">{</span><span class="nx">bubbles</span><span class="o">:</span><span class="kc">true</span><span class="p">})</span>
    <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"x"</span><span class="p">).</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span>
-  <span class="nt">&lt;/script></span>
- <span class="nt">&lt;/body></span>
-<span class="nt">&lt;/html></span>
+  <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+ <span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
 </pre>
    <p>The <code>debug</code> function will be invoked twice. Each time the <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value will be the <code>span</code> <a data-link-type="dfn" href="#concept-element">element</a>. The
 first time <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute’s
@@ -525,6 +525,8 @@ signaling that something has occurred, e.g., that an image has completed downloa
    <p class="note" role="note">Other specifications use <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> to define a <code>relatedTarget</code> attribute. <a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> </p>
    <p>An <a data-link-type="dfn" href="#concept-event">event</a> has an associated <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="event-path">path<a class="self-link" href="#event-path"></a></dfn>. A <a data-link-type="dfn" href="#event-path">path</a> is a
 list of tuples, each of which consists of an <b>item</b> (an <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> object), <b>target</b> (null or an <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> object), and a <b>relatedTarget</b> (null or an <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> object). A tuple is formatted as (<b>item</b>, <b>target</b>, <b>relatedTarget</b>). A <a data-link-type="dfn" href="#event-path">path</a> is initially the empty list.</p>
+   <p><a data-link-type="dfn" href="#other-applicable-specifications">Specifications</a> may define <dfn data-dfn-for="Event" data-dfn-type="dfn" data-export="" id="event-retargeting-steps">retargeting steps<a class="self-link" href="#event-retargeting-steps"></a></dfn> for all or some <a data-link-type="dfn" href="#concept-event">events</a>.
+The algorithm is passed <var>event</var>, as indicated in the <a data-link-type="dfn" href="#concept-event-dispatch">dispatch</a> algorithm below. </p>
    <dl class="domintro">
     <dt><code><var>event</var> = new <a class="idl-code" data-link-type="constructor" href="#dom-event-event">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code> 
     <dd>Returns a new <var>event</var> whose <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute value is set to <var>type</var>. The optional <var>eventInitDict</var> argument
@@ -904,6 +906,8 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneropti
       <li>
        <p>Set <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> to <var>tuple</var>’s <b>relatedTarget</b>. </p>
       <li>
+       <p>Run the <a data-link-type="dfn" href="#event-retargeting-steps">retargeting steps</a> with <var>event</var>. </p>
+      <li>
        <p>If <var>tuple</var>’s <b>target</b> is null, then <a data-link-type="dfn" href="#concept-event-listener-invoke">invoke</a> <var>tuple</var>’s <b>item</b> with <var>event</var>. </p>
      </ol>
     <li>
@@ -914,6 +918,8 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneropti
    in <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>, that is either <var>tuple</var> or preceding <var>tuple</var>, whose <b>target</b> is non-null. </p>
       <li>
        <p>Set <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> to <var>tuple</var>’s <b>relatedTarget</b>. </p>
+      <li>
+       <p>Run the <a data-link-type="dfn" href="#event-retargeting-steps">retargeting steps</a> with <var>event</var>. </p>
       <li>
        <p>If <var>tuple</var>’s <b>target</b> is non-null, then set <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-eventphase">eventPhase</a></code> attribute to <code class="idl"><a data-link-type="idl" href="#dom-event-at_target">AT_TARGET</a></code>. </p>
       <li>
@@ -1039,11 +1045,11 @@ reports with rich multimedia, as well as to fully-fledged interactive
 applications.</p>
    <p>Each such document is represented as a <a data-link-type="dfn" href="#concept-node-tree">node tree</a>. Some of the <a data-link-type="dfn" href="#concept-node">nodes</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> can have <a data-link-type="dfn" href="#concept-tree-child">children</a>, while others are always leaves.</p>
    <p>To illustrate, consider this HTML document:</p>
-<pre class="lang-markup highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;html</span> <span class="na">class=</span><span class="s">e</span><span class="nt">></span>
- <span class="nt">&lt;head>&lt;title></span>Aliens?<span class="nt">&lt;/title>&lt;/head></span>
- <span class="nt">&lt;body></span>Why yes.<span class="nt">&lt;/body></span>
-<span class="nt">&lt;/html></span>
+<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">html</span> <span class="na">class</span><span class="o">=</span><span class="s">e</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">head</span><span class="p">>&lt;</span><span class="nt">title</span><span class="p">></span>Aliens?<span class="p">&lt;/</span><span class="nt">title</span><span class="p">>&lt;/</span><span class="nt">head</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>Why yes.<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
 </pre>
    <p>It is represented as follows:</p>
    <ul class="domTree">
@@ -2486,7 +2492,7 @@ invoked, must return true if <var>otherNode</var> is <a data-link-type="dfn" hre
   and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>,
   with the constraint that this is to be consistent, together. 
      <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In JavaScript
-  implementations <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
+  implementations <code class="lang-javascript highlight"><span></span><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
     <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
     <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
     <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
@@ -2750,7 +2756,7 @@ return "<code>BackCompat</code>" if <a data-link-type="dfn" href="#context-objec
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-documentelement"><code>documentElement</code><a class="self-link" href="#dom-document-documentelement"></a></dfn> attribute’s getter must return
 the <a data-link-type="dfn" href="#document-element">document element</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagname"><code>getElementsByTagName(<var>qualifiedName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagname">list of elements with qualified name <var>qualifiedName</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
+   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
 the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, but not <code>&lt;FOO></code> elements
 that are in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagnamens"><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagnamens"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagnamens">list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for
@@ -2758,15 +2764,15 @@ the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbyclassname"><code>getElementsByClassName(<var>classNames</var>)</code><a class="self-link" href="#dom-document-getelementsbyclassname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbyclassname">list of elements with class names <var>classNames</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <div class="example" id="example-5ffcda00">
     <a class="self-link" href="#example-5ffcda00"></a> Given the following XHTML fragment: 
-<pre><code class="lang-html highlight"><span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">"example"</span><span class="nt">></span>
-  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p1"</span> <span class="na">class=</span><span class="s">"aaa bbb"</span><span class="nt">/></span>
-  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p2"</span> <span class="na">class=</span><span class="s">"aaa ccc"</span><span class="nt">/></span>
-  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p3"</span> <span class="na">class=</span><span class="s">"bbb ccc"</span><span class="nt">/></span>
-<span class="nt">&lt;/div></span>
+<pre><code class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"example"</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p1"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa bbb"</span><span class="p">/></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p2"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa ccc"</span><span class="p">/></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p3"</span> <span class="na">class</span><span class="o">=</span><span class="s">"bbb ccc"</span><span class="p">/></span>
+<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
 </code></pre>
-    <p>A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
-    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
-    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
+    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
+    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
+    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
    </div>
    <hr>
    <dl class="domintro">
@@ -3351,8 +3357,8 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
    <div class="example" id="example-c5b21302">
     <a class="self-link" href="#example-c5b21302"></a> 
     <p>The following code illustrates elements in each of these four states:</p>
-<pre><code class="lang-html highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;script></span>
+<pre><code class="lang-html highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-rey"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-finn"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{},</span> <span class="p">{</span> <span class="kr">extends</span><span class="o">:</span> <span class="s2">"p"</span> <span class="p">})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-kylo"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{</span>
@@ -3360,23 +3366,23 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
       <span class="c1">// super() intentionally omitted for this example</span>
     <span class="p">}</span>
   <span class="p">})</span>
-<span class="nt">&lt;/script></span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 
 <span class="c">&lt;!-- "undefined" (not defined, not custom) --></span>
-<span class="nt">&lt;sw-han>&lt;/sw-han></span>
-<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-luke"</span><span class="nt">>&lt;/p></span>
-<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"asdf"</span><span class="nt">>&lt;/p></span>
+<span class="p">&lt;</span><span class="nt">sw-han</span><span class="p">>&lt;/</span><span class="nt">sw-han</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-luke"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"asdf"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
 
 <span class="c">&lt;!-- "failed" (not defined, not custom) --></span>
-<span class="nt">&lt;sw-kylo>&lt;/sw-kylo></span>
+<span class="p">&lt;</span><span class="nt">sw-kylo</span><span class="p">>&lt;/</span><span class="nt">sw-kylo</span><span class="p">></span>
 
 <span class="c">&lt;!-- "uncustomized" (defined, not custom) --></span>
-<span class="nt">&lt;p>&lt;/p></span>
-<span class="nt">&lt;asdf>&lt;/asdf></span>
+<span class="p">&lt;</span><span class="nt">p</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">asdf</span><span class="p">>&lt;/</span><span class="nt">asdf</span><span class="p">></span>
 
 <span class="c">&lt;!-- "custom" (defined, custom) --></span>
-<span class="nt">&lt;sw-rey>&lt;/sw-rey></span>
-<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-finn"</span><span class="nt">>&lt;/p></span>
+<span class="p">&lt;</span><span class="nt">sw-rey</span><span class="p">>&lt;/</span><span class="nt">sw-rey</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-finn"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
 </code></pre>
    </div>
    <p><a data-link-type="dfn" href="#concept-element">Elements</a> also have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-shadow-root">shadow root<a class="self-link" href="#concept-element-shadow-root"></a></dfn> (null or a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>). It is null unless otherwise stated. An <a data-link-type="dfn" href="#concept-element">element</a> is a <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="element-shadow-host">shadow host<a class="self-link" href="#element-shadow-host"></a></dfn> if its <a data-link-type="dfn" href="#concept-element-shadow-root">shadow root</a> is non-null. </p>
@@ -4100,10 +4106,10 @@ for selecting and copying content.</p>
     <li class="t1">
      <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code> 
      <ul>
-      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="nt">></span> </code> 
+      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"insanity-wolf"</span> <span class="na">alt</span><span class="o">=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="p">></span> </code> 
       <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span> 
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span> </code> 
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">em</span><span class="p">></span> </code> 
        <ul>
         <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span> 
        </ul>
@@ -6116,6 +6122,7 @@ neighboring rights to this work.</p>
    <li><a href="#represented-by-the-collection">represented by the collection</a><span>, in §4.2.10</span>
    <li><a href="#retarget">retarget</a><span>, in §4.8</span>
    <li><a href="#retarget">retargeting</a><span>, in §4.8</span>
+   <li><a href="#event-retargeting-steps">retargeting steps</a><span>, in §3.2</span>
    <li>
     root
     <ul>

--- a/dom.html
+++ b/dom.html
@@ -418,7 +418,7 @@ run these steps:</p>
    <h3 class="heading settled" data-level="3.1" id="introduction-to-dom-events"><span class="secno">3.1. </span><span class="content">Introduction to "DOM Events"</span><a class="self-link" href="#introduction-to-dom-events"></a></h3>
    <p>Throughout the web platform <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to objects to signal an
 occurrence, such as network activity or user interaction. These objects implement the <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> interface and can therefore add <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> to observe <a data-link-type="dfn" href="#concept-event">events</a> by calling <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-addeventlistener">addEventListener()</a></code>:</p>
-<pre class="lang-javascript highlight"><span></span><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
+<pre class="lang-javascript highlight"><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
 
 <span class="kd">function</span> <span class="nx">imgFetched</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span> <span class="p">{</span>
   <span class="c1">// great success</span>
@@ -433,7 +433,7 @@ passed as argument to <a data-link-type="dfn" href="#concept-event-listener">eve
 object to which the <a data-link-type="dfn" href="#concept-event">event</a> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> (<var>obj</var> above).</p>
    <p id="synthetic-events">Now while typically <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent
 as the result of user interaction or the completion of some task, applications can <a data-link-type="dfn" href="#concept-event-dispatch">dispatch</a> <a data-link-type="dfn" href="#concept-event">events</a> themselves, commonly known as synthetic events: </p>
-<pre class="lang-javascript highlight"><span></span><span class="c1">// add an appropriate event listener</span>
+<pre class="lang-javascript highlight"><span class="c1">// add an appropriate event listener</span>
 <span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"cat"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span> <span class="nx">process</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">detail</span><span class="p">)</span> <span class="p">})</span>
 
 <span class="c1">// create and dispatch the event</span>
@@ -447,7 +447,7 @@ operation. For instance as part of form submission an <a data-link-type="dfn" hr
 invoked, form submission will be terminated. Applications who wish to make
 use of this functionality through <a data-link-type="dfn" href="#concept-event">events</a> <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the application
 (synthetic events) can make use of the return value of the <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-dispatchevent">dispatchEvent()</a></code> method:</p>
-<pre class="lang-javascript highlight"><span></span><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
+<pre class="lang-javascript highlight"><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
   <span class="c1">// event was not canceled, time for some magic</span>
   <span class="err">…</span>
 <span class="p">}</span>
@@ -457,14 +457,14 @@ finally, and only if <a data-link-type="dfn" href="#concept-event">event</a>’s
 object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked again,
 but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.</p>
    <p>Lets look at an example of how <a data-link-type="dfn" href="#concept-event">events</a> work in a <a data-link-type="dfn" href="#concept-tree">tree</a>:</p>
-<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!doctype html></span>
-<span class="p">&lt;</span><span class="nt">html</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">head</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Boring example<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
- <span class="p">&lt;/</span><span class="nt">head</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello <span class="p">&lt;</span><span class="nt">span</span> <span class="na">id</span><span class="o">=</span><span class="s">x</span><span class="p">></span>world<span class="p">&lt;/</span><span class="nt">span</span><span class="p">></span>!<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre class="lang-markup highlight"><span class="cp">&lt;!doctype html></span>
+<span class="nt">&lt;html></span>
+ <span class="nt">&lt;head></span>
+  <span class="nt">&lt;title></span>Boring example<span class="nt">&lt;/title></span>
+ <span class="nt">&lt;/head></span>
+ <span class="nt">&lt;body></span>
+  <span class="nt">&lt;p></span>Hello <span class="nt">&lt;span</span> <span class="na">id=</span><span class="s">x</span><span class="nt">></span>world<span class="nt">&lt;/span></span>!<span class="nt">&lt;/p></span>
+  <span class="nt">&lt;script></span>
    <span class="kd">function</span> <span class="nx">test</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
      <span class="nx">debug</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">target</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">currentTarget</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">eventPhase</span><span class="p">)</span>
    <span class="p">}</span>
@@ -472,9 +472,9 @@ but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order
    <span class="nb">document</span><span class="p">.</span><span class="nx">body</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="nx">test</span><span class="p">)</span>
    <span class="kd">var</span> <span class="nx">ev</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Event</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="p">{</span><span class="nx">bubbles</span><span class="o">:</span><span class="kc">true</span><span class="p">})</span>
    <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"x"</span><span class="p">).</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span>
-  <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
- <span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
+  <span class="nt">&lt;/script></span>
+ <span class="nt">&lt;/body></span>
+<span class="nt">&lt;/html></span>
 </pre>
    <p>The <code>debug</code> function will be invoked twice. Each time the <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value will be the <code>span</code> <a data-link-type="dfn" href="#concept-element">element</a>. The
 first time <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute’s
@@ -1045,11 +1045,11 @@ reports with rich multimedia, as well as to fully-fledged interactive
 applications.</p>
    <p>Each such document is represented as a <a data-link-type="dfn" href="#concept-node-tree">node tree</a>. Some of the <a data-link-type="dfn" href="#concept-node">nodes</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> can have <a data-link-type="dfn" href="#concept-tree-child">children</a>, while others are always leaves.</p>
    <p>To illustrate, consider this HTML document:</p>
-<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">html</span> <span class="na">class</span><span class="o">=</span><span class="s">e</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">head</span><span class="p">>&lt;</span><span class="nt">title</span><span class="p">></span>Aliens?<span class="p">&lt;/</span><span class="nt">title</span><span class="p">>&lt;/</span><span class="nt">head</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>Why yes.<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
+<pre class="lang-markup highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="nt">&lt;html</span> <span class="na">class=</span><span class="s">e</span><span class="nt">></span>
+ <span class="nt">&lt;head>&lt;title></span>Aliens?<span class="nt">&lt;/title>&lt;/head></span>
+ <span class="nt">&lt;body></span>Why yes.<span class="nt">&lt;/body></span>
+<span class="nt">&lt;/html></span>
 </pre>
    <p>It is represented as follows:</p>
    <ul class="domTree">
@@ -2492,7 +2492,7 @@ invoked, must return true if <var>otherNode</var> is <a data-link-type="dfn" hre
   and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>,
   with the constraint that this is to be consistent, together. 
      <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In JavaScript
-  implementations <code class="lang-javascript highlight"><span></span><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
+  implementations <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
     <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
     <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
     <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
@@ -2756,7 +2756,7 @@ return "<code>BackCompat</code>" if <a data-link-type="dfn" href="#context-objec
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-documentelement"><code>documentElement</code><a class="self-link" href="#dom-document-documentelement"></a></dfn> attribute’s getter must return
 the <a data-link-type="dfn" href="#document-element">document element</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagname"><code>getElementsByTagName(<var>qualifiedName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagname">list of elements with qualified name <var>qualifiedName</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
+   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
 the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, but not <code>&lt;FOO></code> elements
 that are in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagnamens"><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagnamens"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagnamens">list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for
@@ -2764,15 +2764,15 @@ the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbyclassname"><code>getElementsByClassName(<var>classNames</var>)</code><a class="self-link" href="#dom-document-getelementsbyclassname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbyclassname">list of elements with class names <var>classNames</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <div class="example" id="example-5ffcda00">
     <a class="self-link" href="#example-5ffcda00"></a> Given the following XHTML fragment: 
-<pre><code class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"example"</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p1"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa bbb"</span><span class="p">/></span>
-  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p2"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa ccc"</span><span class="p">/></span>
-  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p3"</span> <span class="na">class</span><span class="o">=</span><span class="s">"bbb ccc"</span><span class="p">/></span>
-<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
+<pre><code class="lang-html highlight"><span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">"example"</span><span class="nt">></span>
+  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p1"</span> <span class="na">class=</span><span class="s">"aaa bbb"</span><span class="nt">/></span>
+  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p2"</span> <span class="na">class=</span><span class="s">"aaa ccc"</span><span class="nt">/></span>
+  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p3"</span> <span class="na">class=</span><span class="s">"bbb ccc"</span><span class="nt">/></span>
+<span class="nt">&lt;/div></span>
 </code></pre>
-    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
-    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
-    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
+    <p>A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
+    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
+    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
    </div>
    <hr>
    <dl class="domintro">
@@ -3357,8 +3357,8 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
    <div class="example" id="example-c5b21302">
     <a class="self-link" href="#example-c5b21302"></a> 
     <p>The following code illustrates elements in each of these four states:</p>
-<pre><code class="lang-html highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre><code class="lang-html highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="nt">&lt;script></span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-rey"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-finn"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{},</span> <span class="p">{</span> <span class="kr">extends</span><span class="o">:</span> <span class="s2">"p"</span> <span class="p">})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-kylo"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{</span>
@@ -3366,23 +3366,23 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
       <span class="c1">// super() intentionally omitted for this example</span>
     <span class="p">}</span>
   <span class="p">})</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
 
 <span class="c">&lt;!-- "undefined" (not defined, not custom) --></span>
-<span class="p">&lt;</span><span class="nt">sw-han</span><span class="p">>&lt;/</span><span class="nt">sw-han</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-luke"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"asdf"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="nt">&lt;sw-han>&lt;/sw-han></span>
+<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-luke"</span><span class="nt">>&lt;/p></span>
+<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"asdf"</span><span class="nt">>&lt;/p></span>
 
 <span class="c">&lt;!-- "failed" (not defined, not custom) --></span>
-<span class="p">&lt;</span><span class="nt">sw-kylo</span><span class="p">>&lt;/</span><span class="nt">sw-kylo</span><span class="p">></span>
+<span class="nt">&lt;sw-kylo>&lt;/sw-kylo></span>
 
 <span class="c">&lt;!-- "uncustomized" (defined, not custom) --></span>
-<span class="p">&lt;</span><span class="nt">p</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">asdf</span><span class="p">>&lt;/</span><span class="nt">asdf</span><span class="p">></span>
+<span class="nt">&lt;p>&lt;/p></span>
+<span class="nt">&lt;asdf>&lt;/asdf></span>
 
 <span class="c">&lt;!-- "custom" (defined, custom) --></span>
-<span class="p">&lt;</span><span class="nt">sw-rey</span><span class="p">>&lt;/</span><span class="nt">sw-rey</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-finn"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="nt">&lt;sw-rey>&lt;/sw-rey></span>
+<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-finn"</span><span class="nt">>&lt;/p></span>
 </code></pre>
    </div>
    <p><a data-link-type="dfn" href="#concept-element">Elements</a> also have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-shadow-root">shadow root<a class="self-link" href="#concept-element-shadow-root"></a></dfn> (null or a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>). It is null unless otherwise stated. An <a data-link-type="dfn" href="#concept-element">element</a> is a <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="element-shadow-host">shadow host<a class="self-link" href="#element-shadow-host"></a></dfn> if its <a data-link-type="dfn" href="#concept-element-shadow-root">shadow root</a> is non-null. </p>
@@ -4106,10 +4106,10 @@ for selecting and copying content.</p>
     <li class="t1">
      <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code> 
      <ul>
-      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"insanity-wolf"</span> <span class="na">alt</span><span class="o">=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="p">></span> </code> 
+      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="nt">></span> </code> 
       <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span> 
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">em</span><span class="p">></span> </code> 
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span> </code> 
        <ul>
         <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span> 
        </ul>


### PR DESCRIPTION
Fix #286. Add the minimum hook to an event dispatch so other
specifications, such as TouchEvents spec, can retarget the event's
attributes, before invoking an event.