### PR TITLE
Mark more elements in browsing-context-less documents as "undefined"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5824,8 +5824,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
    <a>custom element definition</a> set to null, <a><code>is</code> value</a> set to <var>is</var>,
    and <a>node document</a> set to <var>document</var>.
 
-   <li><p>If <var>document</var> has a <a lt=concept-document-bc>browsing context</a>, and
-   <var>namespace</var> is the <a>HTML namespace</a>, and either <var>localName</var> is a
+   <li><p>If <var>namespace</var> is the <a>HTML namespace</a>, and either <var>localName</var> is a
    <a>valid custom element name</a> or <var>is</var> is is non-null, set <var>result</var>'s
    <a>custom element state</a> to "<code>undefined</code>".
   </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -5825,7 +5825,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
    and <a>node document</a> set to <var>document</var>.
 
    <li><p>If <var>namespace</var> is the <a>HTML namespace</a>, and either <var>localName</var> is a
-   <a>valid custom element name</a> or <var>is</var> is is non-null, set <var>result</var>'s
+   <a>valid custom element name</a> or <var>is</var> is non-null, then set <var>result</var>'s
    <a>custom element state</a> to "<code>undefined</code>".
   </ol>
  </li>

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-04">4 August 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-15">15 August 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -2966,7 +2966,7 @@ invoked, must run these steps: </p>
         <td><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/comms.html#closeevent">CloseEvent</a></code> 
        <tr>
         <td>"<code>compositionevent</code>"
-        <td><code class="idl"><a data-link-type="idl">CompositionEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#compositionevent">CompositionEvent</a></code>
         <td><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
        <tr>
         <td>"<code>customevent</code>"
@@ -2994,7 +2994,7 @@ invoked, must run these steps: </p>
         <td>"<code>events</code>" 
        <tr>
         <td>"<code>focusevent</code>"
-        <td><code class="idl"><a data-link-type="idl">FocusEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#focusevent">FocusEvent</a></code>
         <td><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
        <tr>
         <td>"<code>hashchangeevent</code>"
@@ -3049,7 +3049,7 @@ invoked, must run these steps: </p>
         <td>"<code>svgzoomevents</code>" 
        <tr>
         <td>"<code>textevent</code>"
-        <td><code class="idl"><a data-link-type="idl">CompositionEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#compositionevent">CompositionEvent</a></code>
         <td><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
        <tr>
         <td>"<code>touchevent</code>"
@@ -3075,7 +3075,7 @@ invoked, must run these steps: </p>
         <td><a data-link-type="biblio" href="#biblio-webgl">[WEBGL]</a> 
        <tr>
         <td>"<code>wheelevent</code>"
-        <td><code class="idl"><a data-link-type="idl">WheelEvent</a></code>
+        <td><code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#wheelevent">WheelEvent</a></code>
         <td><a data-link-type="biblio" href="#biblio-uievents">[UIEVENTS]</a> 
      </table>
     <li>
@@ -3478,7 +3478,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
    to <var>localName</var>, <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> set to "<code>uncustomized</code>", <a data-link-type="dfn" href="#concept-element-custom-element-definition">custom element definition</a> set to null, <a data-link-type="dfn" href="#concept-element-is-value"><code>is</code> value</a> set to <var>is</var>,
    and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to <var>document</var>. </p>
       <li>
-       <p>If <var>document</var> has a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">browsing context</a>, and <var>namespace</var> is the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and either <var>localName</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#valid-custom-element-name">valid custom element name</a> or <var>is</var> is is non-null, set <var>result</var>’s <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> to "<code>undefined</code>". </p>
+       <p>If <var>namespace</var> is the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and either <var>localName</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#valid-custom-element-name">valid custom element name</a> or <var>is</var> is non-null, then set <var>result</var>’s <a data-link-type="dfn" href="#concept-element-custom-element-state">custom element state</a> to "<code>undefined</code>". </p>
      </ol>
     <li>
      <p>Return <var>result</var>. </p>
@@ -6388,6 +6388,13 @@ neighboring rights to this work.</p>
      <li><a href="https://www.w3.org/TR/SVG/script.html#InterfaceSVGZoomEvent">SVGZoomEvent</a>
     </ul>
    <li>
+    <a data-link-type="biblio">[UIEVENTS]</a> defines the following terms:
+    <ul>
+     <li><a href="https://www.w3.org/TR/uievents/#compositionevent">CompositionEvent</a>
+     <li><a href="https://www.w3.org/TR/uievents/#focusevent">FocusEvent</a>
+     <li><a href="https://www.w3.org/TR/uievents/#wheelevent">WheelEvent</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org/#concept-url">url</a>
@@ -6443,7 +6450,7 @@ neighboring rights to this work.</p>
    <dt id="biblio-touch-events">[TOUCH-EVENTS]
    <dd>Doug Schepers; et al. <a href="http://dvcs.w3.org/hg/webevents/raw-file/v1/touchevents.html">Touch Events</a>. 10 October 2013. REC. URL: <a href="http://dvcs.w3.org/hg/webevents/raw-file/v1/touchevents.html">http://dvcs.w3.org/hg/webevents/raw-file/v1/touchevents.html</a>
    <dt id="biblio-uievents">[UIEVENTS]
-   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://w3c.github.io/uievents/">UI Events Specification</a>. 15 December 2015. WD. URL: <a href="https://w3c.github.io/uievents/">https://w3c.github.io/uievents/</a>
+   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://github.com/w3c/uievents/">UI Events</a>. 4 August 2016. WD. URL: <a href="https://github.com/w3c/uievents/">https://github.com/w3c/uievents/</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-webgl">[WEBGL]


### PR DESCRIPTION
This means in particular that they will not match :defined. Fixes https://github.com/w3c/webcomponents/issues/540.