### PR TITLE
Reinstate CDATASection

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3400,7 +3400,7 @@ interface Node : EventTarget {
   const unsigned short ELEMENT_NODE = 1;
   const unsigned short ATTRIBUTE_NODE = 2; // historical
   const unsigned short TEXT_NODE = 3;
-  const unsigned short CDATA_SECTION_NODE = 4; // historical
+  const unsigned short CDATA_SECTION_NODE = 4;
   const unsigned short ENTITY_REFERENCE_NODE = 5; // historical
   const unsigned short ENTITY_NODE = 6; // historical
   const unsigned short PROCESSING_INSTRUCTION_NODE = 7;
@@ -3489,6 +3489,9 @@ that is a <a>document</a>.
    <dd><var>node</var> is a {{Text}}
    <a>node</a>.
 
+   <dt><code>{{Node}} . {{Node/CDATA_SECTION_NODE}}</code> (4)
+   <dd><var>node</var> is a {{CDATASection}} <a>node</a>.
+
    <dt><code>{{Node}} . {{Node/PROCESSING_INSTRUCTION_NODE}}</code> (7)
    <dd><var>node</var> is a {{ProcessingInstruction}}
    <a>node</a>.
@@ -3553,9 +3556,8 @@ the first matching statement, switching on the <a>context object</a>:
  <dt>{{Text}}
  <dd><dfn const for=Node>TEXT_NODE</dfn> (3);
 
- <!-- XXX CDATA
- <dfn const for=Node>CDATA_SECTION_NODE</dfn> (4, historical);
- -->
+ <dt>{{CDATASection}}
+ <dd><dfn const for=Node>CDATA_SECTION_NODE</dfn> (4);
 
  <dt>{{ProcessingInstruction}}
  <dd><dfn const for=Node>PROCESSING_INSTRUCTION_NODE</dfn> (7);
@@ -4546,6 +4548,7 @@ interface Document : Node {
   [NewObject] Element createElementNS(DOMString? namespace, DOMString qualifiedName, optional ElementCreationOptions options);
   [NewObject] DocumentFragment createDocumentFragment();
   [NewObject] Text createTextNode(DOMString data);
+  [NewObject] CDATASection createCDATASection(DOMString data);
   [NewObject] Comment createComment(DOMString data);
   [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
 
@@ -4868,6 +4871,9 @@ for the <a>context object</a>.
  <dd>Returns a {{Text}} <a>node</a>
  whose <a>data</a> is <var>data</var>.
 
+ <dt><code><var>text</var> = <var>document</var> . {{createCDATASection(data)}}</code>
+ <dd>Returns a {{CDATASection}} <a>node</a> whose <a>data</a> is <var>data</var>.
+
  <dt><code><var>comment</var> = <var>document</var> . {{createComment(data)}}</code>
  <dd>Returns a {{Comment}} <a>node</a>
  whose <a>data</a> is <var>data</var>.
@@ -4973,6 +4979,20 @@ invoked, must return a new {{Text}} <a>node</a> with its <a>data</a> set to <var
 
 <p class="note no-backref">No check is performed that <var>data</var> consists of
 characters that match the <code><a type>Char</a></code> production.
+
+<p>The <dfn method for=Document><code>createCDATASection(<var>data</var>)</code></dfn> method, when
+invoked, must run these steps:
+
+<ol>
+ <li><p>If <a>context object</a> is an <a>HTML document</a>, then <a>throw</a> a
+ {{NotSupportedError}}.
+
+ <li><p>If <var>data</var> contains the string "<code>]]></code>", then <a>throw</a> an
+ {{InvalidCharacterError}}.
+
+ <li><p>Return a new {{CDATASection}} <a>node</a> with its <a>data</a> set to <var>data</var> and
+ <a>node document</a> set to the <a>context object</a>.
+</ol>
 
 The <dfn method for=Document><code>createComment(<var>data</var>)</code></dfn> method, when invoked,
 must return a new {{Comment}} <a>node</a> with its <a>data</a> set to <var>data</var> and
@@ -7105,6 +7125,15 @@ attribute must return a concatenation of the
 <a>contiguous <code>Text</code> nodes</a> of the
 <a>context object</a>, in
 <a>tree order</a>.
+
+
+
+<h3 id=interface-cdatasection>Interface {{CDATASection}}</h3>
+
+<pre class=idl>
+[Exposed=Window]
+interface CDATASection : Text {
+};</pre>
 
 
 
@@ -9315,7 +9344,7 @@ callback interface NodeFilter {
   const unsigned long SHOW_ELEMENT = 0x1;
   const unsigned long SHOW_ATTRIBUTE = 0x2; // historical
   const unsigned long SHOW_TEXT = 0x4;
-  const unsigned long SHOW_CDATA_SECTION = 0x8; // historical
+  const unsigned long SHOW_CDATA_SECTION = 0x8;
   const unsigned long SHOW_ENTITY_REFERENCE = 0x10; // historical
   const unsigned long SHOW_ENTITY = 0x20; // historical
   const unsigned long SHOW_PROCESSING_INSTRUCTION = 0x40;
@@ -9354,9 +9383,7 @@ These constants can be used for the
  <li><dfn const for="NodeFilter">SHOW_ATTRIBUTE</dfn> (2, historical);
  -->
  <li><dfn const for="NodeFilter">SHOW_TEXT</dfn> (4);
- <!-- XXX still questionable
- <li><dfn const for="NodeFilter">SHOW_CDATA_SECTION</dfn> (8; historical);
- -->
+ <li><dfn const for="NodeFilter">SHOW_CDATA_SECTION</dfn> (8);
  <li><dfn const for="NodeFilter">SHOW_PROCESSING_INSTRUCTION</dfn> (64, 40 in hexadecimal);
  <li><dfn const for="NodeFilter">SHOW_COMMENT</dfn> (128, 80 in hexadecimal);
  <li><dfn const for="NodeFilter">SHOW_DOCUMENT</dfn> (256, 100 in hexadecimal);
@@ -9706,7 +9733,6 @@ some of these features should be reintroduced.
 
 Interfaces:
 <ul class=brief dfn-type="interface">
- <li><dfn><code>CDATASection</code></dfn>
  <li><dfn><code>DOMConfiguration</code></dfn>
  <li><dfn><code>DOMError</code></dfn>
  <li><dfn><code>DOMErrorHandler</code></dfn>
@@ -9738,7 +9764,6 @@ Interface members:
  <dt>{{Document}}
  <dd>
   <ul class=brief>
-   <li><dfn method for=Document>createCDATASection()</dfn>
    <li><dfn method for=Document>createEntityReference()</dfn>
    <li><dfn attribute for=Document>xmlEncoding</dfn>
    <li><dfn attribute for=Document>xmlStandalone</dfn>

--- a/dom.html
+++ b/dom.html
@@ -180,8 +180,9 @@ pre.idl.highlight { color: #708090; }
        </ol>
       <li><a href="#interface-characterdata"><span class="secno">4.10</span> <span class="content">Interface <code class="idl"><span>CharacterData</span></code></span></a>
       <li><a href="#interface-text"><span class="secno">4.11</span> <span class="content">Interface <code class="idl"><span>Text</span></code></span></a>
-      <li><a href="#interface-processinginstruction"><span class="secno">4.12</span> <span class="content">Interface <code class="idl"><span>ProcessingInstruction</span></code></span></a>
-      <li><a href="#interface-comment"><span class="secno">4.13</span> <span class="content">Interface <code class="idl"><span>Comment</span></code></span></a>
+      <li><a href="#interface-cdatasection"><span class="secno">4.12</span> <span class="content">Interface <code class="idl"><span>CDATASection</span></code></span></a>
+      <li><a href="#interface-processinginstruction"><span class="secno">4.13</span> <span class="content">Interface <code class="idl"><span>ProcessingInstruction</span></code></span></a>
+      <li><a href="#interface-comment"><span class="secno">4.14</span> <span class="content">Interface <code class="idl"><span>Comment</span></code></span></a>
      </ol>
     <li>
      <a href="#ranges"><span class="secno">5</span> <span class="content">Ranges</span></a>
@@ -2067,7 +2068,7 @@ reference to the <a data-link-type="dfn" href="#concept-node">node</a>.</p>
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-element_node">ELEMENT_NODE</a> = 1;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-attribute_node">ATTRIBUTE_NODE<a class="self-link" href="#dom-node-attribute_node"></a></dfn> = 2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-text_node">TEXT_NODE</a> = 3;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-cdata_section_node">CDATA_SECTION_NODE<a class="self-link" href="#dom-node-cdata_section_node"></a></dfn> = 4; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-cdata_section_node">CDATA_SECTION_NODE</a> = 4;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-entity_reference_node">ENTITY_REFERENCE_NODE<a class="self-link" href="#dom-node-entity_reference_node"></a></dfn> = 5; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-entity_node">ENTITY_NODE<a class="self-link" href="#dom-node-entity_node"></a></dfn> = 6; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE</a> = 7;
@@ -2140,6 +2141,8 @@ that is a <a data-link-type="dfn" href="#concept-document">document</a>.</p>
       <dd><var>node</var> is an <a data-link-type="dfn" href="#concept-element">element</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-text_node">TEXT_NODE</a></code></code> (3) 
       <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
+      <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-cdata_section_node">CDATA_SECTION_NODE</a></code></code> (4) 
+      <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE</a></code></code> (7) 
       <dd><var>node</var> is a <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
       <dt><code><code class="idl"><a data-link-type="idl" href="#node">Node</a></code> . <code class="idl"><a data-link-type="idl" href="#dom-node-comment_node">COMMENT_NODE</a></code></code> (8) 
@@ -2179,6 +2182,8 @@ the first matching statement, switching on the <a data-link-type="dfn" href="#co
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-element_node">ELEMENT_NODE<a class="self-link" href="#dom-node-element_node"></a></dfn> (1) 
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-text_node">TEXT_NODE<a class="self-link" href="#dom-node-text_node"></a></dfn> (3); 
+    <dt><code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code> 
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-cdata_section_node">CDATA_SECTION_NODE<a class="self-link" href="#dom-node-cdata_section_node"></a></dfn> (4); 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE<a class="self-link" href="#dom-node-processing_instruction_node"></a></dfn> (7); 
     <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
@@ -2643,6 +2648,7 @@ returned by an earlier call. </p>
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#element">Element</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createelementns">createElementNS</a>(<span class="kt">DOMString</span>? <dfn class="nv idl-code" data-dfn-for="Document/createElementNS(namespace, qualifiedName, options), Document/createElementNS(namespace, qualifiedName)" data-dfn-type="argument" data-export="" id="dom-document-createelementns-namespace-qualifiedname-options-namespace">namespace<a class="self-link" href="#dom-document-createelementns-namespace-qualifiedname-options-namespace"></a></dfn>, <span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="Document/createElementNS(namespace, qualifiedName, options), Document/createElementNS(namespace, qualifiedName)" data-dfn-type="argument" data-export="" id="dom-document-createelementns-namespace-qualifiedname-options-qualifiedname">qualifiedName<a class="self-link" href="#dom-document-createelementns-namespace-qualifiedname-options-qualifiedname"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-elementcreationoptions">ElementCreationOptions</a> <dfn class="nv idl-code" data-dfn-for="Document/createElementNS(namespace, qualifiedName, options), Document/createElementNS(namespace, qualifiedName)" data-dfn-type="argument" data-export="" id="dom-document-createelementns-namespace-qualifiedname-options-options">options<a class="self-link" href="#dom-document-createelementns-namespace-qualifiedname-options-options"></a></dfn>);
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#documentfragment">DocumentFragment</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createdocumentfragment">createDocumentFragment</a>();
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#text">Text</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createtextnode">createTextNode</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="Document/createTextNode(data)" data-dfn-type="argument" data-export="" id="dom-document-createtextnode-data-data">data<a class="self-link" href="#dom-document-createtextnode-data-data"></a></dfn>);
+  [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#cdatasection">CDATASection</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createcdatasection">createCDATASection</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="Document/createCDATASection(data)" data-dfn-type="argument" data-export="" id="dom-document-createcdatasection-data-data">data<a class="self-link" href="#dom-document-createcdatasection-data-data"></a></dfn>);
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#comment">Comment</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createcomment">createComment</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="Document/createComment(data)" data-dfn-type="argument" data-export="" id="dom-document-createcomment-data-data">data<a class="self-link" href="#dom-document-createcomment-data-data"></a></dfn>);
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#processinginstruction">ProcessingInstruction</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createprocessinginstruction">createProcessingInstruction</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="Document/createProcessingInstruction(target, data)" data-dfn-type="argument" data-export="" id="dom-document-createprocessinginstruction-target-data-target">target<a class="self-link" href="#dom-document-createprocessinginstruction-target-data-target"></a></dfn>, <span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="Document/createProcessingInstruction(target, data)" data-dfn-type="argument" data-export="" id="dom-document-createprocessinginstruction-target-data-data">data<a class="self-link" href="#dom-document-createprocessinginstruction-target-data-data"></a></dfn>);
 
@@ -2793,6 +2799,8 @@ the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
     <dd>Returns a <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> <a data-link-type="dfn" href="#concept-node">node</a>. 
     <dt><code><var>text</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createtextnode">createTextNode(data)</a></code></code> 
     <dd>Returns a <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>. 
+    <dt><code><var>text</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createcdatasection">createCDATASection(data)</a></code></code> 
+    <dd>Returns a <code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>. 
     <dt><code><var>comment</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createcomment">createComment(data)</a></code></code> 
     <dd>Returns a <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> whose <a data-link-type="dfn" href="#concept-cd-data">data</a> is <var>data</var>. 
     <dt><code><var>processingInstruction</var> = <var>document</var> . <code class="idl"><a data-link-type="idl" href="#dom-document-createprocessinginstruction">createProcessingInstruction(target, data)</a></code></code> 
@@ -2845,6 +2853,16 @@ must return a new <code class="idl"><a data-link-type="idl" href="#documentfragm
 invoked, must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-cd-data">data</a> set to <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p class="note no-backref" role="note">No check is performed that <var>data</var> consists of
 characters that match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Char">Char</a></code> production. </p>
+   <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcdatasection"><code>createCDATASection(<var>data</var>)</code><a class="self-link" href="#dom-document-createcdatasection"></a></dfn> method, when
+invoked, must run these steps: </p>
+   <ol>
+    <li>
+     <p>If <a data-link-type="dfn" href="#context-object">context object</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code>. </p>
+    <li>
+     <p>If <var>data</var> contains the string "<code>]]></code>", then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code>. </p>
+    <li>
+     <p>Return a new <code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code> <a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-cd-data">data</a> set to <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>. </p>
+   </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcomment"><code>createComment(<var>data</var>)</code><a class="self-link" href="#dom-document-createcomment"></a></dfn> method, when invoked,
 must return a new <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> <a data-link-type="dfn" href="#concept-node">node</a> with its <a data-link-type="dfn" href="#concept-cd-data">data</a> set to <var>data</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> set to the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p class="note no-backref" role="note">No check is performed that <var>data</var> consists of
@@ -4068,14 +4086,18 @@ must return a new <code class="idl"><a data-link-type="idl" href="#text">Text</a
 itself, the <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a> <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node (if any) and its <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a>, and the <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a> <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> node (if any) and its <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a>,
 avoiding any duplicates.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Text" data-dfn-type="attribute" data-export="" id="dom-text-wholetext">wholeText<a class="self-link" href="#dom-text-wholetext"></a></dfn> attribute must return a concatenation of the <a data-link-type="dfn" href="#concept-cd-data">data</a> of the <a data-link-type="dfn" href="#contiguous-text-nodes">contiguous <code>Text</code> nodes</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.</p>
-   <h3 class="heading settled" data-level="4.12" id="interface-processinginstruction"><span class="secno">4.12. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code></span><a class="self-link" href="#interface-processinginstruction"></a></h3>
+   <h3 class="heading settled" data-level="4.12" id="interface-cdatasection"><span class="secno">4.12. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code></span><a class="self-link" href="#interface-cdatasection"></a></h3>
+<pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
+<span class="kt">interface</span> <dfn class="nv idl-code" data-dfn-type="interface" data-export="" id="cdatasection">CDATASection<a class="self-link" href="#cdatasection"></a></dfn> : <a class="n" data-link-type="idl-name" href="#text">Text</a> {
+};</pre>
+   <h3 class="heading settled" data-level="4.13" id="interface-processinginstruction"><span class="secno">4.13. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code></span><a class="self-link" href="#interface-processinginstruction"></a></h3>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv idl-code" data-dfn-type="interface" data-export="" id="processinginstruction">ProcessingInstruction<a class="self-link" href="#processinginstruction"></a></dfn> : <a class="n" data-link-type="idl-name" href="#characterdata">CharacterData</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-processinginstruction-target">target</a>;
 };</pre>
    <p><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> have an associated <dfn data-dfn-for="ProcessingInstruction" data-dfn-type="dfn" data-export="" id="concept-pi-target">target<a class="self-link" href="#concept-pi-target"></a></dfn>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="ProcessingInstruction" data-dfn-type="attribute" data-export="" id="dom-processinginstruction-target">target<a class="self-link" href="#dom-processinginstruction-target"></a></dfn> attribute must return the <a data-link-type="dfn" href="#concept-pi-target">target</a>.</p>
-   <h3 class="heading settled" data-level="4.13" id="interface-comment"><span class="secno">4.13. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code></span><a class="self-link" href="#interface-comment"></a></h3>
+   <h3 class="heading settled" data-level="4.14" id="interface-comment"><span class="secno">4.14. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code></span><a class="self-link" href="#interface-comment"></a></h3>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="constructor" href="#dom-comment-comment">Constructor</a>(<span class="kt">optional</span> <span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="Comment/Comment(data)" data-dfn-type="argument" data-export="" id="dom-comment-comment-data-data">data<a class="self-link" href="#dom-comment-comment-data-data"></a></dfn> = ""),
  <a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv idl-code" data-dfn-type="interface" data-export="" id="comment">Comment<a class="self-link" href="#comment"></a></dfn> : <a class="n" data-link-type="idl-name" href="#characterdata">CharacterData</a> {
@@ -4934,7 +4956,7 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_element">SHOW_ELEMENT</a> = 0x1;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_attribute">SHOW_ATTRIBUTE<a class="self-link" href="#dom-nodefilter-show_attribute"></a></dfn> = 0x2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_text">SHOW_TEXT</a> = 0x4;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION<a class="self-link" href="#dom-nodefilter-show_cdata_section"></a></dfn> = 0x8; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION</a> = 0x8;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_entity_reference">SHOW_ENTITY_REFERENCE<a class="self-link" href="#dom-nodefilter-show_entity_reference"></a></dfn> = 0x10; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_entity">SHOW_ENTITY<a class="self-link" href="#dom-nodefilter-show_entity"></a></dfn> = 0x20; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_processing_instruction">SHOW_PROCESSING_INSTRUCTION</a> = 0x40;
@@ -4961,6 +4983,7 @@ constants for the <a data-link-type="dfn" href="#concept-traversal-whattoshow">w
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_all">SHOW_ALL<a class="self-link" href="#dom-nodefilter-show_all"></a></dfn> (4294967295, FFFFFFFF in hexadecimal); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_element">SHOW_ELEMENT<a class="self-link" href="#dom-nodefilter-show_element"></a></dfn> (1); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_text">SHOW_TEXT<a class="self-link" href="#dom-nodefilter-show_text"></a></dfn> (4); 
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION<a class="self-link" href="#dom-nodefilter-show_cdata_section"></a></dfn> (8); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_processing_instruction">SHOW_PROCESSING_INSTRUCTION<a class="self-link" href="#dom-nodefilter-show_processing_instruction"></a></dfn> (64, 40 in hexadecimal); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_comment">SHOW_COMMENT<a class="self-link" href="#dom-nodefilter-show_comment"></a></dfn> (128, 80 in hexadecimal); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_document">SHOW_DOCUMENT<a class="self-link" href="#dom-nodefilter-show_document"></a></dfn> (256, 100 in hexadecimal); 
@@ -5196,7 +5219,6 @@ remove all the following features. The editors welcome any data showing that
 some of these features should be reintroduced. </p>
    <p>Interfaces:</p>
    <ul class="brief">
-    <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="cdatasection"><code>CDATASection</code><a class="self-link" href="#cdatasection"></a></dfn> 
     <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domconfiguration"><code>DOMConfiguration</code><a class="self-link" href="#domconfiguration"></a></dfn> 
     <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerror"><code>DOMError</code><a class="self-link" href="#domerror"></a></dfn> 
     <li><dfn class="idl-code" data-dfn-type="interface" data-export="" id="domerrorhandler"><code>DOMErrorHandler</code><a class="self-link" href="#domerrorhandler"></a></dfn> 
@@ -5226,7 +5248,6 @@ some of these features should be reintroduced. </p>
     <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
     <dd>
      <ul class="brief">
-      <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createcdatasection">createCDATASection()<a class="self-link" href="#dom-document-createcdatasection"></a></dfn> 
       <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createentityreference">createEntityReference()<a class="self-link" href="#dom-document-createentityreference"></a></dfn> 
       <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlencoding">xmlEncoding<a class="self-link" href="#dom-document-xmlencoding"></a></dfn> 
       <li><dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-xmlstandalone">xmlStandalone<a class="self-link" href="#dom-document-xmlstandalone"></a></dfn> 
@@ -5515,7 +5536,7 @@ neighboring rights to this work.</p>
    <li><a href="#dom-event-capturing_phase">CAPTURING_PHASE</a><span>, in §3.2</span>
    <li><a href="#case-sensitive">case-sensitive</a><span>, in §2.2</span>
    <li><a href="#case-sensitive">case-sensitively</a><span>, in §2.2</span>
-   <li><a href="#cdatasection">CDATASection</a><span>, in §8.2</span>
+   <li><a href="#cdatasection">CDATASection</a><span>, in §4.12</span>
    <li><a href="#dom-node-cdata_section_node">CDATA_SECTION_NODE</a><span>, in §4.4</span>
    <li><a href="#concept-element-attributes-change">change an attribute</a><span>, in §4.9</span>
    <li><a href="#dom-mutationobserverinit-characterdata">characterData</a><span>, in §4.3.1</span>
@@ -5553,8 +5574,8 @@ neighboring rights to this work.</p>
    <li><a href="#dom-range-collapse">collapse(toStart)</a><span>, in §5.2</span>
    <li><a href="#collect-a-code-point-sequence">collect a code point sequence</a><span>, in §2.3</span>
    <li><a href="#concept-collection">collection</a><span>, in §4.2.10</span>
-   <li><a href="#comment">Comment</a><span>, in §4.13</span>
-   <li><a href="#dom-comment-comment">Comment(data)</a><span>, in §4.13</span>
+   <li><a href="#comment">Comment</a><span>, in §4.14</span>
+   <li><a href="#dom-comment-comment">Comment(data)</a><span>, in §4.14</span>
    <li><a href="#dom-node-comment_node">COMMENT_NODE</a><span>, in §4.4</span>
    <li><a href="#dom-range-commonancestorcontainer">commonAncestorContainer</a><span>, in §5.2</span>
    <li><a href="#dom-range-compareboundarypoints">compareBoundaryPoints(how, sourceRange)</a><span>, in §5.2</span>
@@ -5585,7 +5606,7 @@ neighboring rights to this work.</p>
    <li><a href="#concept-create-element">create an element</a><span>, in §4.9</span>
    <li><a href="#dom-document-createattribute">createAttribute(localName)</a><span>, in §4.5</span>
    <li><a href="#dom-document-createattributens">createAttributeNS(namespace, qualifiedName)</a><span>, in §4.5</span>
-   <li><a href="#dom-document-createcdatasection">createCDATASection()</a><span>, in §8.2</span>
+   <li><a href="#dom-document-createcdatasection">createCDATASection(data)</a><span>, in §4.5</span>
    <li><a href="#dom-document-createcomment">createComment(data)</a><span>, in §4.5</span>
    <li><a href="#dom-document-createdocumentfragment">createDocumentFragment()</a><span>, in §4.5</span>
    <li><a href="#dom-domimplementation-createdocument">createDocument(namespace, qualifiedName)</a><span>, in §4.5.1</span>
@@ -6055,7 +6076,7 @@ neighboring rights to this work.</p>
      <li><a href="#dom-mutationrecord-previoussibling">attribute for MutationRecord</a><span>, in §4.3.3</span>
      <li><a href="#dom-node-previoussibling">attribute for Node</a><span>, in §4.4</span>
     </ul>
-   <li><a href="#processinginstruction">ProcessingInstruction</a><span>, in §4.12</span>
+   <li><a href="#processinginstruction">ProcessingInstruction</a><span>, in §4.13</span>
    <li><a href="#dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE</a><span>, in §4.4</span>
    <li><a href="#dom-documenttype-publicid">publicId</a><span>, in §4.6</span>
    <li><a href="#concept-doctype-publicid">public ID</a><span>, in §4.6</span>
@@ -6232,8 +6253,8 @@ neighboring rights to this work.</p>
     <ul>
      <li><a href="#dom-event-target">attribute for Event</a><span>, in §3.2</span>
      <li><a href="#dom-mutationrecord-target">attribute for MutationRecord</a><span>, in §4.3.3</span>
-     <li><a href="#concept-pi-target">dfn for ProcessingInstruction</a><span>, in §4.12</span>
-     <li><a href="#dom-processinginstruction-target">attribute for ProcessingInstruction</a><span>, in §4.12</span>
+     <li><a href="#concept-pi-target">dfn for ProcessingInstruction</a><span>, in §4.13</span>
+     <li><a href="#dom-processinginstruction-target">attribute for ProcessingInstruction</a><span>, in §4.13</span>
     </ul>
    <li><a href="#text">Text</a><span>, in §4.11</span>
    <li>
@@ -6656,7 +6677,7 @@ neighboring rights to this work.</p>
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-element_node">ELEMENT_NODE</a> = 1;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" href="#dom-node-attribute_node">ATTRIBUTE_NODE</a> = 2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-text_node">TEXT_NODE</a> = 3;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" href="#dom-node-cdata_section_node">CDATA_SECTION_NODE</a> = 4; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-cdata_section_node">CDATA_SECTION_NODE</a> = 4;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" href="#dom-node-entity_reference_node">ENTITY_REFERENCE_NODE</a> = 5; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" href="#dom-node-entity_node">ENTITY_NODE</a> = 6; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-processing_instruction_node">PROCESSING_INSTRUCTION_NODE</a> = 7;
@@ -6736,6 +6757,7 @@ neighboring rights to this work.</p>
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#element">Element</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createelementns">createElementNS</a>(<span class="kt">DOMString</span>? <a class="nv" href="#dom-document-createelementns-namespace-qualifiedname-options-namespace">namespace</a>, <span class="kt">DOMString</span> <a class="nv" href="#dom-document-createelementns-namespace-qualifiedname-options-qualifiedname">qualifiedName</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-elementcreationoptions">ElementCreationOptions</a> <a class="nv" href="#dom-document-createelementns-namespace-qualifiedname-options-options">options</a>);
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#documentfragment">DocumentFragment</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createdocumentfragment">createDocumentFragment</a>();
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#text">Text</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createtextnode">createTextNode</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-document-createtextnode-data-data">data</a>);
+  [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#cdatasection">CDATASection</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createcdatasection">createCDATASection</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-document-createcdatasection-data-data">data</a>);
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#comment">Comment</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createcomment">createComment</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-document-createcomment-data-data">data</a>);
   [<a class="nv idl-code" data-link-type="extended-attribute">NewObject</a>] <a class="n" data-link-type="idl-name" href="#processinginstruction">ProcessingInstruction</a> <a class="nv idl-code" data-link-type="method" href="#dom-document-createprocessinginstruction">createProcessingInstruction</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-document-createprocessinginstruction-target-data-target">target</a>, <span class="kt">DOMString</span> <a class="nv" href="#dom-document-createprocessinginstruction-target-data-data">data</a>);
 
@@ -6884,6 +6906,9 @@ neighboring rights to this work.</p>
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-text-wholetext">wholeText</a>;
 };
 [<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
+<span class="kt">interface</span> <a class="nv" href="#cdatasection">CDATASection</a> : <a class="n" data-link-type="idl-name" href="#text">Text</a> {
+};
+[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#processinginstruction">ProcessingInstruction</a> : <a class="n" data-link-type="idl-name" href="#characterdata">CharacterData</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-processinginstruction-target">target</a>;
 };
@@ -6976,7 +7001,7 @@ neighboring rights to this work.</p>
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_element">SHOW_ELEMENT</a> = 0x1;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-nodefilter-show_attribute">SHOW_ATTRIBUTE</a> = 0x2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_text">SHOW_TEXT</a> = 0x4;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION</a> = 0x8; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION</a> = 0x8;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-nodefilter-show_entity_reference">SHOW_ENTITY_REFERENCE</a> = 0x10; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-nodefilter-show_entity">SHOW_ENTITY</a> = 0x20; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_processing_instruction">SHOW_PROCESSING_INSTRUCTION</a> = 0x40;


### PR DESCRIPTION
I’m thirty now so it’s time to face reality. This fixes
https://www.w3.org/Bugs/Public/show_bug.cgi?id=27386. This also closes
#190 by deciding to not enumerate subclasses of concrete (non-abstract)
interfaces (ShadowRoot and CDATASection in particular).