### PR TITLE
Make Attr inherit from Node again

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3820,7 +3820,6 @@ the empty string instead, and then do as described below, switching on <a>contex
   </ol>
 
  <dt>{{Attr}}
- <dd>
  <dd><p>Set an existing attribute value</a> with <a>context object</a> and new value.
 
  <dt>{{Text}}

--- a/dom.bs
+++ b/dom.bs
@@ -1490,7 +1490,7 @@ can be used to explore this matter in more detail.
 
 <h3 id=node-trees>Node tree</h3>
 
-<p>{{Document}}, {{DocumentType}}, {{DocumentFragment}}, {{Element}}, {{Attr}}, {{Text}},
+<p>{{Document}}, {{DocumentType}}, {{DocumentFragment}}, {{Element}}, {{Text}},
 {{ProcessingInstruction}}, and {{Comment}} objects (simply called
 <dfn export id=concept-node>nodes</dfn>) <a>participate</a> in a <a>tree</a>, simply named the
 <dfn export id=concept-node-tree>node tree</dfn>.
@@ -1514,7 +1514,6 @@ can be used to explore this matter in more detail.
  <dd><p>Zero or more nodes each of which is {{Element}}, {{Text}}, {{ProcessingInstruction}}, or
  {{Comment}}.
  <dt>{{DocumentType}}
- <dt>{{Attr}}
  <dt>{{Text}}
  <dt>{{ProcessingInstruction}}
  <dt>{{Comment}}
@@ -4330,8 +4329,16 @@ To <dfn export>locate a namespace</dfn> for a <var>node</var> using
 
  <dt>{{DocumentType}}
  <dt>{{DocumentFragment}}
- <dt>{{Attr}}
  <dd>Return null.
+
+ <dt>{{Attr}}
+ <dd>
+  <ol>
+   <li><p>If its <a for=Attr>element</a> is null, then return null.
+
+   <li><p>Return the result of running <a>locate a namespace</a> on its <a for=Attr>element</a>
+   using <var>prefix</var>.
+  </ol>
 
  <dt>Any other node
  <dd>
@@ -4367,8 +4374,11 @@ method must run these steps:
 
    <dt>{{DocumentType}}
    <dt>{{DocumentFragment}}
-   <dt>{{Attr}}
    <dd>Return null.
+
+   <dt>{{Attr}}
+   <dd><p>Return the result of <a>locating a namespace prefix</a> for its <a for=Attr>element</a>,
+   if its <a for=Attr>element</a> is non-null, and null otherwise.
 
    <dt>Any other node
    <dd>Return the result of

--- a/dom.bs
+++ b/dom.bs
@@ -1490,7 +1490,7 @@ can be used to explore this matter in more detail.
 
 <h3 id=node-trees>Node tree</h3>
 
-<p>{{Document}}, {{DocumentType}}, {{DocumentFragment}}, {{Element}}, {{Text}},
+<p>{{Document}}, {{DocumentType}}, {{DocumentFragment}}, {{Element}}, {{Attr}}, {{Text}},
 {{ProcessingInstruction}}, and {{Comment}} objects (simply called
 <dfn export id=concept-node>nodes</dfn>) <a>participate</a> in a <a>tree</a>, simply named the
 <dfn export id=concept-node-tree>node tree</dfn>.
@@ -1514,12 +1514,12 @@ can be used to explore this matter in more detail.
  <dd><p>Zero or more nodes each of which is {{Element}}, {{Text}}, {{ProcessingInstruction}}, or
  {{Comment}}.
  <dt>{{DocumentType}}
+ <dt>{{Attr}}
  <dt>{{Text}}
  <dt>{{ProcessingInstruction}}
  <dt>{{Comment}}
  <dd><p>None.
 </dl>
-<!--AttrExodus -->
 
 The <dfn export id=concept-node-length for=Node>length</dfn> of a
 <a>node</a> <var>node</var> depends on
@@ -3523,6 +3523,9 @@ that is a <a>document</a>.
    <dt>{{Element}}
    <dd>Its {{Element/tagName}} attribute value.
 
+   <dt>{{Attr}}
+   <dd>Its <a for=Attr>qualified name</a>.
+
    <dt>{{Text}}
    <dd>"<code>#text</code>".
 
@@ -3553,10 +3556,8 @@ the first matching statement, switching on the <a>context object</a>:
  <dt>{{Element}}
  <dd><dfn const for=Node>ELEMENT_NODE</dfn> (1)
 
- <!--AttrExodus
  <dt>{{Attr}}
- <dd><dfn const for=Node>ATTRIBUTE_NODE</dfn> (2, historical);
- -->
+ <dd><dfn const for=Node>ATTRIBUTE_NODE</dfn> (2);
 
  <dt>{{Text}}
  <dd><dfn const for=Node>TEXT_NODE</dfn> (3);
@@ -3615,11 +3616,8 @@ the first matching statement, switching on the <a>context object</a>:
  <dd>Its {{Element/tagName}} attribute value.
  <!-- XXX internal concept -->
 
- <!--AttrExodus
  <dt>{{Attr}}
- <dd>The <a>context object</a>'s
- {{Attr/name}} attribute.
- -->
+ <dd>Its <a for=Attr>qualified name</a>.
 
  <dt>{{Text}}
  <dd>"<code>#text</code>".
@@ -3715,10 +3713,8 @@ attribute's getter must return <a>context object</a>'s <a>shadow-including root<
 
 <p>The <dfn attribute for=Node><code>parentNode</code></dfn> attribute's getter must return the
 <a>context object</a>'s <a>parent</a>.
-<!-- AttrExodus
-<li>If the <a>context object</a> is an {{Attr}} node,
-return null.
--->
+
+<p class="note">An {{Attr}} <a>node</a> has no <a>parent</a>.
 
 <p>The <dfn attribute for=Node><code>parentElement</code></dfn> attribute's getter must return the
 <a>context object</a>'s <a>parent element</a>.
@@ -3737,17 +3733,11 @@ true if the <a>context object</a> has <a>children</a>, and false otherwise.
 
 <p>The <dfn attribute for=Node><code>previousSibling</code></dfn> attribute's getter must return the
 <a>context object</a>'s <a>previous sibling</a>.
-<!-- AttrExodus
- <li>If the <a>context object</a> is an {{Attr}} node,
- return null.
--->
+
+<p class="note">An {{Attr}} <a>node</a> has no <a for=tree>siblings</a>.
 
 <p>The <dfn attribute for=Node><code>nextSibling</code></dfn> attribute's getter must return the
 <a>context object</a>'s <a>next sibling</a>.
-<!-- AttrExodus
- <li>If the <a>context object</a> is an {{Attr}} node,
- return null.
--->
 
 <hr>
 
@@ -3757,12 +3747,13 @@ The <dfn attribute for=Node>nodeValue</dfn> attribute
 must return the following, depending on the <a>context object</a>:
 
 <dl class=switch>
- <!--AttrExodus <dt>{{Attr}} -->
+ <dt>{{Attr}}
+ <dd><a>Context object</a>'s <a for=Attr>value</a>.
+
  <dt>{{Text}}
  <dt>{{ProcessingInstruction}}
  <dt>{{Comment}}
- <dd>The <a>context object</a>'s
- <a>data</a>.
+ <dd><a>Context object</a>'s <a>data</a>.
 
  <dt>Any other node
  <dd>Null.
@@ -3773,7 +3764,9 @@ on setting, if the new value is null, act as if it was the empty string
 instead, and then do as described below, depending on the <a>context object</a>:
 
 <dl class=switch>
- <!--AttrExodus <dt>{{Attr}} -->
+ <dt>{{Attr}}
+ <dd><p>Set an existing attribute value</a> with <a>context object</a> and new value.
+
  <dt>{{Text}}
  <dt>{{ProcessingInstruction}}
  <dt>{{Comment}}
@@ -3792,18 +3785,19 @@ following, switching on <a>context object</a>:
 <dl class=switch>
  <dt>{{DocumentFragment}}
  <dt>{{Element}}
- <!--AttrExodus <dt>{{Attr}} -->
  <dd>The concatenation of <a>data</a> of all
  the {{Text}} <a>node</a>
  <a>descendants</a> of the
  <a>context object</a>, in
  <a>tree order</a>.
 
+ <dt>{{Attr}}
+ <dd><a>Context object</a>'s <a for=Attr>value</a>.
+
  <dt>{{Text}}
  <dt>{{ProcessingInstruction}}
  <dt>{{Comment}}
- <dd>The <a>context object</a>'s
- <a>data</a>.
+ <dd><a>Context object</a>'s <a>data</a>.
 
  <dt>Any other node
  <dd>Null.
@@ -3815,7 +3809,6 @@ the empty string instead, and then do as described below, switching on <a>contex
 <dl class=switch>
  <dt>{{DocumentFragment}}
  <dt>{{Element}}
- <!--AttrExodus <dt>{{Attr}} -->
  <dd>
   <ol>
    <li><p>Let <var>node</var> be null.
@@ -3826,6 +3819,10 @@ the empty string instead, and then do as described below, switching on <a>contex
 
    <li><p><a>Replace all</a> with <var>node</var> within the <a>context object</a>.
   </ol>
+
+ <dt>{{Attr}}
+ <dd>
+ <dd><p>Set an existing attribute value</a> with <a>context object</a> and new value.
 
  <dt>{{Text}}
  <dt>{{ProcessingInstruction}}
@@ -3986,14 +3983,9 @@ dom-Range-extractContents, dom-Range-cloneContents -->
     <a for=Element>attribute list</a>, in order, run these substeps:
 
     <ol>
-     <li><p>Let <var>copyAttribute</var> be a new <a>attribute</a>.
+     <li><p>Let <var>copyAttribute</var> be a <a>clone</a> of <var>attribute</var>.
 
-     <li><p>Set <var>copyAttribute</var>'s <a for=Attr>namespace</a>,
-     <a for=Attr>namespace prefix</a>, <a for=Attr>local name</a>,
-     and <a for=Attr>value</a>, to those of <var>attribute</var>.
-
-     <li><p><a lt="append an attribute">Append</a> <var>copyAttribute</var> to
-     <var>copy</var>.
+     <li><p><a lt="append an attribute">Append</a> <var>copyAttribute</var> to <var>copy</var>.
     </ol>
    </li>
   </ol>
@@ -4015,10 +4007,9 @@ dom-Range-extractContents, dom-Range-cloneContents -->
    <dd><p>Set <var>copy</var>'s <a for=DocumentType>name</a>, <a>public ID</a>, and
    <a>system ID</a>, to those of <var>node</var>.
 
-   <!--AttrExodus
    <dt>{{Attr}}
-   <dd>{{Attr/value}}
-   -->
+   <dd><p>Set <var>copy</var>'s <a for=Attr>namespace</a>, <a for=Attr>namespace prefix</a>,
+   <a for=Attr>local name</a>, and <a for=Attr>value</a>, to those of <var>node</var>.
 
    <dt>{{Text}}
    <dt>{{Comment}}
@@ -4081,10 +4072,8 @@ A <a>node</a> <var>A</var>
     number of <a>attributes</a> in its
     <a for=Element>attribute list</a>.
 
-   <!--AttrExodus
    <dt>{{Attr}}
-   <dd>{{Attr/value}}
-   -->
+   <dd>Its <a for=Attr>namespace</a>, <a for=Attr>local name</a>, and <a for=Attr>value</a>.
 
    <dt>{{ProcessingInstruction}}
    <dd>Its <a for=ProcessingInstruction>target</a> and
@@ -4097,14 +4086,9 @@ A <a>node</a> <var>A</var>
    <dt>Any other node
    <dd>&mdash;
   </dl>
- <li>If <var>A</var> is an <a for="/">element</a>, each
- <a>attribute</a> in its
- <a for=Element>attribute list</a> has an
- <a>attribute</a> with the same
- <a for=Attr>namespace</a>,
- <a for=Attr>local name</a>, and
- <a for=Attr>value</a> in <var>B</var>'s
- <a for=Element>attribute list</a>.
+ <li>If <var>A</var> is an <a for="/">element</a>, each <a>attribute</a> in its
+ <a for=Element>attribute list</a> has an <a>attribute</a> that <a for=Node>equals</a> an
+ <a>attribute</a> in <var>B</var>'s <a for=Element>attribute list</a>.
  <li><var>A</var> and <var>B</var> have the same number of
  <a>children</a>.
  <li>Each <a>child</a> of <var>A</var>
@@ -4175,56 +4159,79 @@ returns as mask:
  <li><dfn const for=Node>DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</dfn> (32, 20 in hexadecimal).
 </ul>
 
-The <dfn method for=Node>compareDocumentPosition(<var>other</var>)</dfn>
-method must run these steps:
+<p>The <dfn method for=Node><code>compareDocumentPosition(<var>other</var>)</code></dfn> method,
+when invoked, must run these steps:
 
 <ol>
- <li>Let <var>reference</var> be the <a>context object</a>.
- <li>If <var>other</var> and <var>reference</var> are the
- same object, return zero.
+ <li><p>If <a>context object</a> is <var>other</var>, then return zero.
+
+ <li><p>Let <var>node1</var> be <var>other</var> and <var>node2</var> be <a>context object</a>.
+
+ <li><p>Let <var>attr1</var> be null.
 
  <li>
-  If <var>other</var> and <var>reference</var> are not
-  in the same <a>tree</a>, return the result of
-  adding
-  {{Node/DOCUMENT_POSITION_DISCONNECTED}},
-  {{Node/DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC}},
-  and either
-  {{Node/DOCUMENT_POSITION_PRECEDING}} or
-  {{Node/DOCUMENT_POSITION_FOLLOWING}},
-  with the constraint that this is to be consistent, together.
+  <p>If <var>node1</var> is an <a>attribute</a>, then:
 
-  <p class="note no-backref">Whether to return
-  {{Node/DOCUMENT_POSITION_PRECEDING}} or
-  {{Node/DOCUMENT_POSITION_FOLLOWING}}
-  is typically implemented via pointer comparison. In JavaScript
-  implementations <code class='lang-javascript'>Math.random()</code> can be used.
+  <ol>
+   <li><p>Set <var>attr1</var> to <var>node1</var>.
 
- <li>If <var>other</var> is an
- <a>ancestor</a> of
- <var>reference</var>, return the result of adding
- {{Node/DOCUMENT_POSITION_CONTAINS}}
- to
+   <li><p>If <var>attr1</var>'s <a for=Attr>element</a> is non-null, then set <var>node1</var> to
+   <var>attr1</var>'s <a for=Attr>element</a>.
+  </ol>
+
+ <li>
+  <p>If <var>node2</var> is an <a>attribute</a>, then:
+
+  <ol>
+   <li><p>Let <var>attr2</var> be <var>node2</var>.
+
+   <li>
+    <p>If <var>attr2</var>'s <a for=Attr>element</a> is <var>node1</var> and <var>attr1</var> is
+    non-null, then:
+
+    <ol>
+     <li>
+      <p>For each <a>attribute</a> <var>node2Attribute</var> in <var>attr2</var>'s
+      <a for=Attr>element</a>'s <a for=Element>attribute list</a>:
+
+      <ol>
+       <li><p>If <var>node2Attribute</var> <a for=Node>equals</a> <var>attr1</var>, then return the
+       result of adding {{Node/DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC}} and
+       {{Node/DOCUMENT_POSITION_PRECEDING}}.
+
+       <li><p>If <var>node2Attribute</var> <a for=Node>equals</a> <var>attr2</var>, then return the
+       result of adding {{Node/DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC}} and
+       {{Node/DOCUMENT_POSITION_FOLLOWING}}.
+      </ol>
+    </ol>
+
+   <li><p>If <var>attr2</var>'s <a for=Attr>element</a> is non-null, then set <var>node2</var> to
+   <var>attr2</var>'s <a for=Attr>element</a>.
+  </ol>
+
+ <li>
+  <p>If <var>node1</var>'s <a for=tree>root</a> is not <var>node2</var>'s <a for=tree>root</a>, then
+  return the result of adding {{Node/DOCUMENT_POSITION_DISCONNECTED}},
+  {{Node/DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC}}, and either
+  {{Node/DOCUMENT_POSITION_PRECEDING}} or {{Node/DOCUMENT_POSITION_FOLLOWING}}, with the constraint
+  that this is to be consistent, together.
+
+  <p class="note no-backref">Whether to return {{Node/DOCUMENT_POSITION_PRECEDING}} or
+  {{Node/DOCUMENT_POSITION_FOLLOWING}} is typically implemented via pointer comparison. In
+  JavaScript implementations a cached <code class='lang-javascript'>Math.random()</code> value can
+  be used.
+
+ <li><p>If <var>node1</var> is an <a>ancestor</a> of <var>node2</var>, then return the result of
+ adding {{Node/DOCUMENT_POSITION_CONTAINS}} to {{Node/DOCUMENT_POSITION_PRECEDING}}.
+
+ <li><p>If <var>node1</var> is a <a>descendant</a> of <var>node2</var>, then return the result of
+ adding {{Node/DOCUMENT_POSITION_CONTAINED_BY}} to {{Node/DOCUMENT_POSITION_FOLLOWING}}.
+
+ <li><p>If <var>node1</var> is <a>preceding</a> <var>node2</var>, then return
  {{Node/DOCUMENT_POSITION_PRECEDING}}.
 
- <li>If <var>other</var> is a
- <a>descendant</a> of
- <var>reference</var>, return the result of adding
- {{Node/DOCUMENT_POSITION_CONTAINED_BY}}
- to
- {{Node/DOCUMENT_POSITION_FOLLOWING}}.
-
- <li>If <var>other</var> is
- <a>preceding</a>
- <var>reference</var> return
- {{Node/DOCUMENT_POSITION_PRECEDING}}.
-
- <li>Return
- {{Node/DOCUMENT_POSITION_FOLLOWING}}.
+ <li><p>Return {{Node/DOCUMENT_POSITION_FOLLOWING}}.
 </ol>
-
-<!-- AttrExodus compareDocumentPosition() works differently if Attr inherits
-     from Node -->
 
 The
 <dfn method for=Node>contains(<var>other</var>)</dfn>
@@ -4312,7 +4319,6 @@ To <dfn export>locate a namespace</dfn> for a <var>node</var> using
    its <a>parent element</a> using <var>prefix</var>.
   </ol>
 
- <!--AttrExodus {{Attr}} -->
  <dt>{{Document}}
  <dd>
   <ol>
@@ -4324,6 +4330,7 @@ To <dfn export>locate a namespace</dfn> for a <var>node</var> using
 
  <dt>{{DocumentType}}
  <dt>{{DocumentFragment}}
+ <dt>{{Attr}}
  <dd>Return null.
 
  <dt>Any other node
@@ -4352,7 +4359,6 @@ method must run these steps:
    <a>locating a namespace prefix</a>
    for the node using <var>namespace</var>.
 
-   <!--AttrExodus {{Attr}} -->
    <dt>{{Document}}
    <dd>Return the result of
    <a>locating a namespace prefix</a>
@@ -4361,6 +4367,7 @@ method must run these steps:
 
    <dt>{{DocumentType}}
    <dt>{{DocumentFragment}}
+   <dt>{{Attr}}
    <dd>Return null.
 
    <dt>Any other node
@@ -5090,10 +5097,17 @@ a <var>document</var>, run these steps:
   <p>If <var>document</var> is not the same as <var>oldDocument</var>, run these substeps:
 
   <ol>
-   <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
-   <a>shadow-including inclusive descendants</a>, set <var>inclusiveDescendant</var>'s
-   <a>node document</a> to <var>document</var>.
-   <!--AttrExodus as well as any associated {{Attr}} nodes-->
+   <li>
+    <p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
+    <a>shadow-including inclusive descendants</a>, run these subsubsteps:
+
+    <ol>
+     <li><p>Set <var>inclusiveDescendant</var>'s <a>node document</a> to <var>document</var>.
+
+     <li><p>If <var>inclusiveDescendant</var> is an <a for=/>element</a>, then set the
+     <a>node document</a> of each <a>attribute</a> in <var>inclusiveDescendant</var>'s
+     <a for=Element>attribute list</a> to <var>document</var>.
+    </ol>
 
    <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
    <a>shadow-including inclusive descendants</a> that is a <a>custom</a> <a for=/>element</a>,
@@ -5134,8 +5148,8 @@ invoked, must run these steps:
  <li>If the <a>context object</a> is an <a>HTML document</a>, let
  <var>localName</var> be <a>converted to ASCII lowercase</a>.
 
- <li>Return a new <a>attribute</a> whose
- <a for=Attr>local name</a> is <var>localName</var>.
+ <li>Return a new <a>attribute</a> whose <a for=Attr>local name</a> is <var>localName</var> and
+ <a>node document</a> is <a>context object</a>.
 </ol>
 
 The
@@ -5148,8 +5162,8 @@ method, when invoked, must run these steps:
  any exceptions.
 
  <li><p>Return a new <a>attribute</a> whose <a for=Attr>namespace</a> is <var>namespace</var>,
- <a for=Attr>namespace prefix</a> is <var>prefix</var>, and <a for=Attr>local name</a> is
- <var>localName</var>.
+ <a for=Attr>namespace prefix</a> is <var>prefix</var>, <a for=Attr>local name</a> is
+ <var>localName</var>, and <a>node document</a> is <a>context object</a>.
 </ol>
 
 <hr>
@@ -6073,16 +6087,12 @@ using a <var>localName</var> and <var>value</var>, and an optional <var>prefix</
  <a lt="get an attribute by namespace and local name">getting an attribute</a> given
  <var>namespace</var>, <var>localName</var>, and <var>element</var>.
 
- <li>If <var>attribute</var> is null, create an
- <a>attribute</a> whose
- <a for=Attr>namespace</a> is <var>namespace</var>,
- <a for=Attr>namespace prefix</a> is
- <var>prefix</var>, <a for=Attr>local name</a> is
- <var>localName</var>,
- and <a for=Attr>value</a> is <var>value</var>, and then
- <a lt="append an attribute">append</a> this
- <a>attribute</a> to <var>element</var>
- and terminate these steps.
+ <li>If <var>attribute</var> is null, create an <a>attribute</a> whose <a for=Attr>namespace</a> is
+ <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
+ <a for=Attr>local name</a> is <var>localName</var>, <a for=Attr>value</a> is <var>value</var>, and
+ <a>node document</a> is <var>element</var>'s <a>node document</a>, then
+ <a lt="append an attribute">append</a> this <a>attribute</a> to <var>element</var>, and then
+ terminate these steps.
 
  <li><a lt="change an attribute">Change</a>
  <var>attribute</var> from <var>element</var> to
@@ -6231,8 +6241,6 @@ namespace.</p>
 
 <hr>
 
-<!-- all members in this subsection are affected by AttrExodus -->
-
 The <dfn method for="Element">hasAttributes()</dfn> method,
 when invoked, must return false if <a>context object</a>'s
 <a for=Element>attribute list</a> is empty, and true
@@ -6292,9 +6300,10 @@ method, when invoked, must run these steps:
  <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
 
  <li><p>If <var>attribute</var> is null, create an <a>attribute</a> whose
- <a for="Attr">local name</a> is <var>qualifiedName</var> and <a for=Attr>value</a> is
- <var>value</var>, <a lt="append an attribute">append</a> this <a>attribute</a> to the
- <a>context object</a>'s <a for=Element>attribute list</a>, and then terminate these steps.
+ <a for="Attr">local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is
+ <var>value</var>, and <a>node document</a> is <a>context object</a>'s <a>node document</a>, then
+ <a lt="append an attribute">append</a> this <a>attribute</a> to <a>context object</a>, and then
+ terminate these steps.
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> from <a>context object</a> to
  <var>value</var>.
@@ -6697,23 +6706,19 @@ method, when invoked, must run these steps:
 
 <pre class=idl>
 [Exposed=Window]
-interface Attr {
+interface Attr : Node {
   readonly attribute DOMString? namespaceURI;
   readonly attribute DOMString? prefix;
   readonly attribute DOMString localName;
   readonly attribute DOMString name;
-  readonly attribute DOMString nodeName; // historical alias of .name
   [CEReactions] attribute DOMString value;
-  [CEReactions, TreatNullAs=EmptyString] attribute DOMString nodeValue; // historical alias of .value
-  [CEReactions, TreatNullAs=EmptyString] attribute DOMString textContent; // historical alias of .value
 
   readonly attribute Element? ownerElement;
 
   readonly attribute boolean specified; // useless; always returns true
 };</pre>
 
-
-{{Attr}} objects are simply known as
+<p>{{Attr}} <a>nodes</a> are simply known as
 <dfn export id=concept-attribute lt="attribute">attributes</dfn>. They are sometimes referred
 to as <em>content attributes</em> to avoid confusion with IDL attributes.
 
@@ -6764,31 +6769,25 @@ null.
 <p>The <dfn attribute for="Attr"><code>localName</code></dfn> attribute's getter must return the
 <a for=Attr>local name</a>.
 
-<p>The <dfn attribute for="Attr"><code>name</code></dfn> attribute's getter, and
-<dfn attribute for="Attr"><code>nodeName</code></dfn> attribute's getter, must return the
+<p>The <dfn attribute for="Attr"><code>name</code></dfn> attribute's getter must return the
 <a for=Attr>qualified name</a>.
 
-<p>The <dfn attribute for="Attr"><code>value</code></dfn> attribute's getter,
-<dfn attribute for="Attr"><code>nodeValue</code></dfn> attribute's getter, and
-<dfn attribute for="Attr"><code>textContent</code></dfn> attribute's getter, must return the
+<p>The <dfn attribute for="Attr"><code>value</code></dfn> attribute's getter must return the
 <a for=Attr>value</a>.
 
-<p>The {{Attr/value}} attribute's setter, {{Attr/nodeValue}} attribute's setter, and
-{{Attr/textContent}} attribute's setter, must run these steps:
+<p>To <dfn>set an existing attribute value</dfn>, given an <a>attribute</a> <var>attribute</var> and
+string <var>value</var>, run these steps:
 
 <ol>
- <li>If <a>context object</a>'s
- <a for=Attr>element</a> is null, set
- <a>context object</a>'s <a for=Attr>value</a> to the
- given value.
+ <li>If <var>attribute</var>'s <a for=Attr>element</a> is null, then set <var>attribute</var>'s
+ <a for=Attr>value</a> to <var>value</var>.
 
- <li>Otherwise, <a lt="change an attribute">change</a> the
- <a>context object</a> from <a>context object</a>'s
- <a for=Attr>element</a> to the given value.
+ <li>Otherwise, <a lt="change an attribute">change</a> <var>attribute</var> from
+ <var>attribute</var>'s <a for=Attr>element</a> to <var>value</var>.
 </ol>
 
-<p class="note no-backref">Unlike <a>node</a>'s {{Node/textContent}}, no special null
-handling is required.
+<p>The {{Attr/value}} attribute's setter must <a>set an existing attribute value</a> with
+<a>context object</a> and the given value.
 
 <hr>
 
@@ -9389,9 +9388,7 @@ These constants can be used for the
 <ul class="brief">
  <li><dfn const for="NodeFilter">SHOW_ALL</dfn> (4294967295, FFFFFFFF in hexadecimal);
  <li><dfn const for="NodeFilter">SHOW_ELEMENT</dfn> (1);
- <!-- AttrExodus
- <li><dfn const for="NodeFilter">SHOW_ATTRIBUTE</dfn> (2, historical);
- -->
+ <li><dfn const for="NodeFilter">SHOW_ATTRIBUTE</dfn> (2);
  <li><dfn const for="NodeFilter">SHOW_TEXT</dfn> (4);
  <li><dfn const for="NodeFilter">SHOW_CDATA_SECTION</dfn> (8);
  <li><dfn const for="NodeFilter">SHOW_PROCESSING_INSTRUCTION</dfn> (64, 40 in hexadecimal);
@@ -9792,12 +9789,10 @@ Interface members:
 
  <dt>{{Attr}}
  <dd>
-  No longer inherits from {{Node}} and therefore completely
-  changed.
-  <!--AttrExodus
-  <dfn attribute for="Attr">schemaTypeInfo</dfn>
-  <dfn attribute for="Attr">isId</dfn>
-  -->
+  <ul class=brief>
+   <li><dfn attribute for="Attr">schemaTypeInfo</dfn>
+   <li><dfn attribute for="Attr">isId</dfn>
+  </ul>
 
  <dt>{{Element}}
  <dd>

--- a/dom.bs
+++ b/dom.bs
@@ -4208,11 +4208,11 @@ when invoked, must run these steps:
   </ol>
 
  <li>
-  <p>If <var>node1</var>'s <a for=tree>root</a> is not <var>node2</var>'s <a for=tree>root</a>, then
-  return the result of adding {{Node/DOCUMENT_POSITION_DISCONNECTED}},
-  {{Node/DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC}}, and either
-  {{Node/DOCUMENT_POSITION_PRECEDING}} or {{Node/DOCUMENT_POSITION_FOLLOWING}}, with the constraint
-  that this is to be consistent, together.
+  <p>If <var>node1</var>'s <a for=tree>root</a> is not <var>node2</var>'s <a for=tree>root</a> or
+  <var>node1</var> and <var>node2</var> are <a>attributes</a>, then return the result of adding
+  {{Node/DOCUMENT_POSITION_DISCONNECTED}}, {{Node/DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC}}, and
+  either {{Node/DOCUMENT_POSITION_PRECEDING}} or {{Node/DOCUMENT_POSITION_FOLLOWING}}, with the
+  constraint that this is to be consistent, together.
 
   <p class="note no-backref">Whether to return {{Node/DOCUMENT_POSITION_PRECEDING}} or
   {{Node/DOCUMENT_POSITION_FOLLOWING}} is typically implemented via pointer comparison. In

--- a/dom.html
+++ b/dom.html
@@ -2332,7 +2332,6 @@ the empty string instead, and then do as described below, switching on <a data-l
      </ol>
     <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
     <dd>
-    <dd>
      <p>Set an existing attribute value with <a data-link-type="dfn" href="#context-object">context object</a> and new value. </p>
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 

--- a/dom.html
+++ b/dom.html
@@ -1080,7 +1080,7 @@ applications.</p>
 concept is clear. Markup goes in, a <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-type="dfn" href="#concept-node">nodes</a> comes out.</p>
    <p class="note no-backref" role="note">The most excellent <a href="http://software.hixie.ch/utilities/js/live-dom-viewer/">Live DOM Viewer</a> can be used to explore this matter in more detail. </p>
    <h3 class="heading settled" data-level="4.2" id="node-trees"><span class="secno">4.2. </span><span class="content">Node tree</span><a class="self-link" href="#node-trees"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, and <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> objects (simply called <dfn data-dfn-type="dfn" data-export="" id="concept-node">nodes<a class="self-link" href="#concept-node"></a></dfn>) <a data-link-type="dfn" href="#concept-tree-participate">participate</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, simply named the <dfn data-dfn-type="dfn" data-export="" id="concept-node-tree">node tree<a class="self-link" href="#concept-node-tree"></a></dfn>. </p>
+   <p><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, and <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> objects (simply called <dfn data-dfn-type="dfn" data-export="" id="concept-node">nodes<a class="self-link" href="#concept-node"></a></dfn>) <a data-link-type="dfn" href="#concept-tree-participate">participate</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, simply named the <dfn data-dfn-type="dfn" data-export="" id="concept-node-tree">node tree<a class="self-link" href="#concept-node-tree"></a></dfn>. </p>
    <p>A <a data-link-type="dfn" href="#concept-node-tree">node tree</a> is constrained as follows, expressed as a relationship between the type of <a data-link-type="dfn" href="#concept-node">node</a> and its allowed <a data-link-type="dfn" href="#concept-tree-child">children</a>: </p>
    <dl>
     <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
@@ -1103,7 +1103,6 @@ concept is clear. Markup goes in, a <a data-link-type="dfn" href="#concept-tree"
     <dd>
      <p>Zero or more nodes each of which is <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>. </p>
     <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
@@ -2601,8 +2600,15 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
      </ol>
     <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
     <dd>Return null. 
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dd>
+     <ol>
+      <li>
+       <p>If its <a data-link-type="dfn" href="#concept-attribute-element">element</a> is null, then return null. </p>
+      <li>
+       <p>Return the result of running <a data-link-type="dfn" href="#locate-a-namespace">locate a namespace</a> on its <a data-link-type="dfn" href="#concept-attribute-element">element</a> using <var>prefix</var>. </p>
+     </ol>
     <dt>Any other node 
     <dd>
      <ol>
@@ -2624,8 +2630,11 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
    otherwise. 
       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
       <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
-      <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
       <dd>Return null. 
+      <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+      <dd>
+       <p>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#concept-attribute-element">element</a>,
+   if its <a data-link-type="dfn" href="#concept-attribute-element">element</a> is non-null, and null otherwise. </p>
       <dt>Any other node 
       <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#parent-element">parent element</a>, or if that is null, null. 
      </dl>

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-18">18 August 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-19">19 August 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -2541,9 +2541,9 @@ when invoked, must run these steps: </p>
        <p>If <var>attr2</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is non-null, then set <var>node2</var> to <var>attr2</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a>. </p>
      </ol>
     <li>
-     <p>If <var>node1</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is not <var>node2</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>, then
-  return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</a></code>, and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>, with the constraint
-  that this is to be consistent, together. </p>
+     <p>If <var>node1</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is not <var>node2</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> or <var>node1</var> and <var>node2</var> are <a data-link-type="dfn" href="#concept-attribute">attributes</a>, then return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</a></code>, and
+  either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>, with the
+  constraint that this is to be consistent, together. </p>
      <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In
   JavaScript implementations a cached <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> value can
   be used. </p>

--- a/dom.html
+++ b/dom.html
@@ -1080,7 +1080,7 @@ applications.</p>
 concept is clear. Markup goes in, a <a data-link-type="dfn" href="#concept-tree">tree</a> of <a data-link-type="dfn" href="#concept-node">nodes</a> comes out.</p>
    <p class="note no-backref" role="note">The most excellent <a href="http://software.hixie.ch/utilities/js/live-dom-viewer/">Live DOM Viewer</a> can be used to explore this matter in more detail. </p>
    <h3 class="heading settled" data-level="4.2" id="node-trees"><span class="secno">4.2. </span><span class="content">Node tree</span><a class="self-link" href="#node-trees"></a></h3>
-   <p><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, and <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> objects (simply called <dfn data-dfn-type="dfn" data-export="" id="concept-node">nodes<a class="self-link" href="#concept-node"></a></dfn>) <a data-link-type="dfn" href="#concept-tree-participate">participate</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, simply named the <dfn data-dfn-type="dfn" data-export="" id="concept-node-tree">node tree<a class="self-link" href="#concept-node-tree"></a></dfn>. </p>
+   <p><code class="idl"><a data-link-type="idl" href="#document">Document</a></code>, <code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code>, <code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code>, <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, and <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> objects (simply called <dfn data-dfn-type="dfn" data-export="" id="concept-node">nodes<a class="self-link" href="#concept-node"></a></dfn>) <a data-link-type="dfn" href="#concept-tree-participate">participate</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a>, simply named the <dfn data-dfn-type="dfn" data-export="" id="concept-node-tree">node tree<a class="self-link" href="#concept-node-tree"></a></dfn>. </p>
    <p>A <a data-link-type="dfn" href="#concept-node-tree">node tree</a> is constrained as follows, expressed as a relationship between the type of <a data-link-type="dfn" href="#concept-node">node</a> and its allowed <a data-link-type="dfn" href="#concept-tree-child">children</a>: </p>
    <dl>
     <dt><code class="idl"><a data-link-type="idl" href="#document">Document</a></code> 
@@ -1103,6 +1103,7 @@ concept is clear. Markup goes in, a <a data-link-type="dfn" href="#concept-tree"
     <dd>
      <p>Zero or more nodes each of which is <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>, <code class="idl"><a data-link-type="idl" href="#text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code>, or <code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code>. </p>
     <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
@@ -2063,7 +2064,7 @@ reference to the <a data-link-type="dfn" href="#concept-node">node</a>.</p>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv idl-code" data-dfn-type="interface" data-export="" id="node">Node<a class="self-link" href="#node"></a></dfn> : <a class="n" data-link-type="idl-name" href="#eventtarget">EventTarget</a> {
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-element_node">ELEMENT_NODE</a> = 1;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-attribute_node">ATTRIBUTE_NODE<a class="self-link" href="#dom-node-attribute_node"></a></dfn> = 2; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-attribute_node">ATTRIBUTE_NODE</a> = 2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-text_node">TEXT_NODE</a> = 3;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-cdata_section_node">CDATA_SECTION_NODE</a> = 4;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-entity_reference_node">ENTITY_REFERENCE_NODE<a class="self-link" href="#dom-node-entity_reference_node"></a></dfn> = 5; // historical
@@ -2158,6 +2159,8 @@ that is a <a data-link-type="dfn" href="#concept-document">document</a>.</p>
      <dl>
       <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
       <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value. 
+      <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+      <dd>Its <a data-link-type="dfn" href="#concept-attribute-qualified-name">qualified name</a>. 
       <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
       <dd>"<code>#text</code>". 
       <dt><code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code> 
@@ -2179,6 +2182,8 @@ the first matching statement, switching on the <a data-link-type="dfn" href="#co
    <dl class="switch">
     <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-element_node">ELEMENT_NODE<a class="self-link" href="#dom-node-element_node"></a></dfn> (1) 
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-attribute_node">ATTRIBUTE_NODE<a class="self-link" href="#dom-node-attribute_node"></a></dfn> (2); 
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dd><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-text_node">TEXT_NODE<a class="self-link" href="#dom-node-text_node"></a></dfn> (3); 
     <dt><code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code> 
@@ -2199,6 +2204,8 @@ the first matching statement, switching on the <a data-link-type="dfn" href="#co
    <dl class="switch">
     <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>Its <code class="idl"><a data-link-type="idl" href="#dom-element-tagname">tagName</a></code> attribute value. 
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dd>Its <a data-link-type="dfn" href="#concept-attribute-qualified-name">qualified name</a>. 
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dd>"<code>#text</code>". 
     <dt><code class="idl"><a data-link-type="idl" href="#cdatasection">CDATASection</a></code> 
@@ -2256,6 +2263,7 @@ if the <a data-link-type="dfn" href="#context-object">context object</a> is a <a
    <p class="note" role="note">The <a data-link-type="dfn" href="#concept-node-document">node document</a> of a <a data-link-type="dfn" href="#concept-document">document</a> is that <a data-link-type="dfn" href="#concept-document">document</a> itself. All <a data-link-type="dfn" href="#concept-node">nodes</a> have a <a data-link-type="dfn" href="#concept-node-document">node document</a> at all times. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" data-lt="getRootNode(options)|getRootNode()" id="dom-node-getrootnode"><code>getRootNode(<var>options</var>)</code><a class="self-link" href="#dom-node-getrootnode"></a></dfn> attribute’s getter must return <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-shadow-including-root">shadow-including root</a> if <var>options</var>’s <code for="GetRootNodeOptions">composed</code> is true, and <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> otherwise. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-parentnode"><code>parentNode</code><a class="self-link" href="#dom-node-parentnode"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. </p>
+   <p class="note" role="note">An <code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> <a data-link-type="dfn" href="#concept-node">node</a> has no <a data-link-type="dfn" href="#concept-tree-parent">parent</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-parentelement"><code>parentElement</code><a class="self-link" href="#dom-node-parentelement"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#parent-element">parent element</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-haschildnodes"><code>hasChildNodes()</code><a class="self-link" href="#dom-node-haschildnodes"></a></dfn> method, when invoked, must return
 true if the <a data-link-type="dfn" href="#context-object">context object</a> has <a data-link-type="dfn" href="#concept-tree-child">children</a>, and false otherwise. </p>
@@ -2263,15 +2271,18 @@ true if the <a data-link-type="dfn" href="#context-object">context object</a> ha
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" data-lt="firstChild" id="dom-node-firstchild"><code>firstChild</code> <a class="self-link" href="#dom-node-firstchild"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-first-child">first child</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-lastchild"><code>lastChild</code><a class="self-link" href="#dom-node-lastchild"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-last-child">last child</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-previoussibling"><code>previousSibling</code><a class="self-link" href="#dom-node-previoussibling"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-previous-sibling">previous sibling</a>. </p>
+   <p class="note" role="note">An <code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> <a data-link-type="dfn" href="#concept-node">node</a> has no <a data-link-type="dfn" href="#concept-tree-sibling">siblings</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nextsibling"><code>nextSibling</code><a class="self-link" href="#dom-node-nextsibling"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-tree-next-sibling">next sibling</a>. </p>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="attribute" data-export="" id="dom-node-nodevalue">nodeValue<a class="self-link" href="#dom-node-nodevalue"></a></dfn> attribute
 must return the following, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dd><a data-link-type="dfn" href="#context-object">Context object</a>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
+    <dd><a data-link-type="dfn" href="#context-object">Context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
     <dt>Any other node 
     <dd>Null. 
    </dl>
@@ -2279,6 +2290,9 @@ must return the following, depending on the <a data-link-type="dfn" href="#conte
 on setting, if the new value is null, act as if it was the empty string
 instead, and then do as described below, depending on the <a data-link-type="dfn" href="#context-object">context object</a>:</p>
    <dl class="switch">
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dd>
+     <p>Set an existing attribute value with <a data-link-type="dfn" href="#context-object">context object</a> and new value. </p>
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
@@ -2294,10 +2308,12 @@ following, switching on <a data-link-type="dfn" href="#context-object">context o
     <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>The concatenation of <a data-link-type="dfn" href="#concept-cd-data">data</a> of all
  the <code class="idl"><a data-link-type="idl" href="#text">Text</a></code> <a data-link-type="dfn" href="#concept-node">node</a> <a data-link-type="dfn" href="#concept-tree-descendant">descendants</a> of the <a data-link-type="dfn" href="#context-object">context object</a>, in <a data-link-type="dfn" href="#concept-tree-order">tree order</a>. 
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dd><a data-link-type="dfn" href="#context-object">Context object</a>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
-    <dd>The <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
+    <dd><a data-link-type="dfn" href="#context-object">Context object</a>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
     <dt>Any other node 
     <dd>Null. 
    </dl>
@@ -2315,6 +2331,10 @@ the empty string instead, and then do as described below, switching on <a data-l
       <li>
        <p><a data-link-type="dfn" href="#concept-node-replace-all">Replace all</a> with <var>node</var> within the <a data-link-type="dfn" href="#context-object">context object</a>. </p>
      </ol>
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+    <dd>
+    <dd>
+     <p>Set an existing attribute value with <a data-link-type="dfn" href="#context-object">context object</a> and new value. </p>
     <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
@@ -2381,10 +2401,7 @@ run these steps:</p>
         <p>For each <var>attribute</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, in order, run these substeps: </p>
         <ol>
          <li>
-          <p>Let <var>copyAttribute</var> be a new <a data-link-type="dfn" href="#concept-attribute">attribute</a>. </p>
-         <li>
-          <p>Set <var>copyAttribute</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>,
-     and <a data-link-type="dfn" href="#concept-attribute-value">value</a>, to those of <var>attribute</var>. </p>
+          <p>Let <var>copyAttribute</var> be a <a data-link-type="dfn" href="#concept-node-clone">clone</a> of <var>attribute</var>. </p>
          <li>
           <p><a data-link-type="dfn" href="#concept-element-attributes-append">Append</a> <var>copyAttribute</var> to <var>copy</var>. </p>
         </ol>
@@ -2399,6 +2416,9 @@ run these steps:</p>
        <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
        <dd>
         <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-doctype-name">name</a>, <a data-link-type="dfn" href="#concept-doctype-publicid">public ID</a>, and <a data-link-type="dfn" href="#concept-doctype-systemid">system ID</a>, to those of <var>node</var>. </p>
+       <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+       <dd>
+        <p>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, and <a data-link-type="dfn" href="#concept-attribute-value">value</a>, to those of <var>node</var>. </p>
        <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
        <dt><code class="idl"><a data-link-type="idl" href="#comment">Comment</a></code> 
        <dd>Set <var>copy</var>’s <a data-link-type="dfn" href="#concept-cd-data">data</a>, to that of <var>node</var>. 
@@ -2433,6 +2453,8 @@ invoked, must run these steps: </p>
        <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
        <dd> Its <a data-link-type="dfn" href="#concept-element-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-element-namespace-prefix">namespace prefix</a>, <a data-link-type="dfn" href="#concept-element-local-name">local name</a>, and its
     number of <a data-link-type="dfn" href="#concept-attribute">attributes</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
+       <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
+       <dd>Its <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, and <a data-link-type="dfn" href="#concept-attribute-value">value</a>. 
        <dt><code class="idl"><a data-link-type="idl" href="#processinginstruction">ProcessingInstruction</a></code> 
        <dd>Its <a data-link-type="dfn" href="#concept-pi-target">target</a> and <a data-link-type="dfn" href="#concept-cd-data">data</a>. 
        <dt><code class="idl"><a data-link-type="idl" href="#text">Text</a></code> 
@@ -2441,7 +2463,7 @@ invoked, must run these steps: </p>
        <dt>Any other node 
        <dd>— 
       </dl>
-     <li>If <var>A</var> is an <a data-link-type="dfn" href="#concept-element">element</a>, each <a data-link-type="dfn" href="#concept-attribute">attribute</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> has an <a data-link-type="dfn" href="#concept-attribute">attribute</a> with the same <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, and <a data-link-type="dfn" href="#concept-attribute-value">value</a> in <var>B</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
+     <li>If <var>A</var> is an <a data-link-type="dfn" href="#concept-element">element</a>, each <a data-link-type="dfn" href="#concept-attribute">attribute</a> in its <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> has an <a data-link-type="dfn" href="#concept-attribute">attribute</a> that <a data-link-type="dfn" href="#concept-node-equals">equals</a> an <a data-link-type="dfn" href="#concept-attribute">attribute</a> in <var>B</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>. 
      <li><var>A</var> and <var>B</var> have the same number of <a data-link-type="dfn" href="#concept-tree-child">children</a>. 
      <li>Each <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>A</var> <a data-link-type="dfn" href="#concept-node-equals">equals</a> the <a data-link-type="dfn" href="#concept-tree-child">child</a> of <var>B</var> at the identical <a data-link-type="dfn" href="#concept-tree-index">index</a>. 
     </ul>
@@ -2480,23 +2502,63 @@ invoked, must return true if <var>otherNode</var> is <a data-link-type="dfn" hre
     <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY<a class="self-link" href="#dom-node-document_position_contained_by"></a></dfn> (16, 10 in hexadecimal); 
     <li><dfn class="idl-code" data-dfn-for="Node" data-dfn-type="const" data-export="" id="dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC<a class="self-link" href="#dom-node-document_position_implementation_specific"></a></dfn> (32, 20 in hexadecimal). 
    </ul>
-   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-comparedocumentposition">compareDocumentPosition(<var>other</var>)<a class="self-link" href="#dom-node-comparedocumentposition"></a></dfn> method must run these steps:</p>
+   <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-comparedocumentposition"><code>compareDocumentPosition(<var>other</var>)</code><a class="self-link" href="#dom-node-comparedocumentposition"></a></dfn> method,
+when invoked, must run these steps: </p>
    <ol>
-    <li>Let <var>reference</var> be the <a data-link-type="dfn" href="#context-object">context object</a>. 
-    <li>If <var>other</var> and <var>reference</var> are the
- same object, return zero. 
     <li>
-      If <var>other</var> and <var>reference</var> are not
-  in the same <a data-link-type="dfn" href="#concept-tree">tree</a>, return the result of
-  adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</a></code>,
-  and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>,
-  with the constraint that this is to be consistent, together. 
-     <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In JavaScript
-  implementations <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
-    <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
-    <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
-    <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
-    <li>Return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
+     <p>If <a data-link-type="dfn" href="#context-object">context object</a> is <var>other</var>, then return zero. </p>
+    <li>
+     <p>Let <var>node1</var> be <var>other</var> and <var>node2</var> be <a data-link-type="dfn" href="#context-object">context object</a>. </p>
+    <li>
+     <p>Let <var>attr1</var> be null. </p>
+    <li>
+     <p>If <var>node1</var> is an <a data-link-type="dfn" href="#concept-attribute">attribute</a>, then: </p>
+     <ol>
+      <li>
+       <p>Set <var>attr1</var> to <var>node1</var>. </p>
+      <li>
+       <p>If <var>attr1</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is non-null, then set <var>node1</var> to <var>attr1</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a>. </p>
+     </ol>
+    <li>
+     <p>If <var>node2</var> is an <a data-link-type="dfn" href="#concept-attribute">attribute</a>, then: </p>
+     <ol>
+      <li>
+       <p>Let <var>attr2</var> be <var>node2</var>. </p>
+      <li>
+       <p>If <var>attr2</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is <var>node1</var> and <var>attr1</var> is
+    non-null, then: </p>
+       <ol>
+        <li>
+         <p>For each <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>node2Attribute</var> in <var>attr2</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>: </p>
+         <ol>
+          <li>
+           <p>If <var>node2Attribute</var> <a data-link-type="dfn" href="#concept-node-equals">equals</a> <var>attr1</var>, then return the
+       result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. </p>
+          <li>
+           <p>If <var>node2Attribute</var> <a data-link-type="dfn" href="#concept-node-equals">equals</a> <var>attr2</var>, then return the
+       result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. </p>
+         </ol>
+       </ol>
+      <li>
+       <p>If <var>attr2</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is non-null, then set <var>node2</var> to <var>attr2</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a>. </p>
+     </ol>
+    <li>
+     <p>If <var>node1</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is not <var>node2</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>, then
+  return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_disconnected">DOCUMENT_POSITION_DISCONNECTED</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_implementation_specific">DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</a></code>, and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>, with the constraint
+  that this is to be consistent, together. </p>
+     <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In
+  JavaScript implementations a cached <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> value can
+  be used. </p>
+    <li>
+     <p>If <var>node1</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>node2</var>, then return the result of
+ adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. </p>
+    <li>
+     <p>If <var>node1</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>node2</var>, then return the result of
+ adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. </p>
+    <li>
+     <p>If <var>node1</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>node2</var>, then return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. </p>
+    <li>
+     <p>Return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. </p>
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Node" data-dfn-type="method" data-export="" id="dom-node-contains">contains(<var>other</var>)<a class="self-link" href="#dom-node-contains"></a></dfn> method must return true if <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-inclusive-descendant">inclusive descendant</a> of
 the <a data-link-type="dfn" href="#context-object">context object</a>, and false otherwise (including when <var>other</var> is null).</p>
@@ -2539,6 +2601,7 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
      </ol>
     <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
     <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
+    <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
     <dd>Return null. 
     <dt>Any other node 
     <dd>
@@ -2561,6 +2624,7 @@ the <a data-link-type="dfn" href="#context-object">context object</a>, and false
    otherwise. 
       <dt><code class="idl"><a data-link-type="idl" href="#documenttype">DocumentType</a></code> 
       <dt><code class="idl"><a data-link-type="idl" href="#documentfragment">DocumentFragment</a></code> 
+      <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
       <dd>Return null. 
       <dt>Any other node 
       <dd>Return the result of <a data-link-type="dfn" href="#locate-a-namespace-prefix">locating a namespace prefix</a> for its <a data-link-type="dfn" href="#parent-element">parent element</a>, or if that is null, null. 
@@ -2911,7 +2975,13 @@ a <var>document</var>, run these steps:</p>
      <p>If <var>document</var> is not the same as <var>oldDocument</var>, run these substeps: </p>
      <ol>
       <li>
-       <p>For each <var>inclusiveDescendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendants</a>, set <var>inclusiveDescendant</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. </p>
+       <p>For each <var>inclusiveDescendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendants</a>, run these subsubsteps: </p>
+       <ol>
+        <li>
+         <p>Set <var>inclusiveDescendant</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a> to <var>document</var>. </p>
+        <li>
+         <p>If <var>inclusiveDescendant</var> is an <a data-link-type="dfn" href="#concept-element">element</a>, then set the <a data-link-type="dfn" href="#concept-node-document">node document</a> of each <a data-link-type="dfn" href="#concept-attribute">attribute</a> in <var>inclusiveDescendant</var>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> to <var>document</var>. </p>
+       </ol>
       <li>
        <p>For each <var>inclusiveDescendant</var> in <var>node</var>’s <a data-link-type="dfn" href="#concept-shadow-including-inclusive-descendant">shadow-including inclusive descendants</a> that is a <a data-link-type="dfn" href="#concept-element-custom">custom</a> <a data-link-type="dfn" href="#concept-element">element</a>, <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#enqueue-a-custom-element-callback-reaction">enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>, callback
    name "<code>adoptedCallback</code>", and an argument list containing <var>oldDocument</var> and <var>document</var>. </p>
@@ -2935,7 +3005,7 @@ invoked, must run these steps:</p>
      <p>If <var>localName</var> does not match the <code><a class="css" data-link-type="type" href="https://www.w3.org/TR/xml/#NT-Name">Name</a></code> production in XML,
  then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidcharactererror">InvalidCharacterError</a></code>. </p>
     <li>If the <a data-link-type="dfn" href="#context-object">context object</a> is an <a data-link-type="dfn" href="#html-document">HTML document</a>, let <var>localName</var> be <a data-link-type="dfn" href="#converted-to-ascii-lowercase">converted to ASCII lowercase</a>. 
-    <li>Return a new <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>. 
+    <li>Return a new <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var> and <a data-link-type="dfn" href="#concept-node-document">node document</a> is <a data-link-type="dfn" href="#context-object">context object</a>. 
    </ol>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createattributens"><code>createAttributeNS(<var>namespace</var>, <var>qualifiedName</var>)</code><a class="self-link" href="#dom-document-createattributens"></a></dfn> method, when invoked, must run these steps:</p>
    <ol>
@@ -2944,7 +3014,7 @@ invoked, must run these steps:</p>
  passing <var>namespace</var> and <var>qualifiedName</var> to <a data-link-type="dfn" href="#validate-and-extract">validate and extract</a>. Rethrow
  any exceptions. </p>
     <li>
-     <p>Return a new <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is <var>prefix</var>, and <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>. </p>
+     <p>Return a new <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is <var>prefix</var>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> is <a data-link-type="dfn" href="#context-object">context object</a>. </p>
    </ol>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-createevent"><code>createEvent(<var>interface</var>)</code><a class="self-link" href="#dom-document-createevent"></a></dfn> method, when
@@ -3599,8 +3669,8 @@ an <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var
     <li>If <var>prefix</var> is not given, set it to null. 
     <li>If <var>namespace</var> is not given, set it to null. 
     <li>Let <var>attribute</var> be the result of <a data-link-type="dfn" href="#concept-element-attributes-get-by-namespace">getting an attribute</a> given <var>namespace</var>, <var>localName</var>, and <var>element</var>. 
-    <li>If <var>attribute</var> is null, create an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is <var>prefix</var>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>,
- and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, and then <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to <var>element</var> and terminate these steps. 
+    <li>If <var>attribute</var> is null, create an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a> is <var>namespace</var>, <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is <var>prefix</var>, <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>localName</var>, <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> is <var>element</var>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>, then <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to <var>element</var>, and then
+ terminate these steps. 
     <li><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a> <var>attribute</var> from <var>element</var> to <var>value</var>. 
    </ol>
    <p>To <dfn data-dfn-type="dfn" data-export="" id="concept-element-attributes-remove-by-name">remove an attribute by name<a class="self-link" href="#concept-element-attributes-remove-by-name"></a></dfn> given a <var>qualifiedName</var> and <a data-link-type="dfn" href="#concept-element">element</a> <var>element</var>, run these steps:</p>
@@ -3724,7 +3794,8 @@ invoked, must run these steps:</p>
      <p>Let <var>attribute</var> be the first <a data-link-type="dfn" href="#concept-attribute">attribute</a> in <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a> whose <a data-link-type="dfn" href="#concept-attribute-qualified-name">qualified name</a> is <var>qualifiedName</var>,
  and null otherwise. </p>
     <li>
-     <p>If <var>attribute</var> is null, create an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>qualifiedName</var> and <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to the <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-element-attribute">attribute list</a>, and then terminate these steps. </p>
+     <p>If <var>attribute</var> is null, create an <a data-link-type="dfn" href="#concept-attribute">attribute</a> whose <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> is <var>qualifiedName</var>, <a data-link-type="dfn" href="#concept-attribute-value">value</a> is <var>value</var>, and <a data-link-type="dfn" href="#concept-node-document">node document</a> is <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-node-document">node document</a>, then <a data-link-type="dfn" href="#concept-element-attributes-append">append</a> this <a data-link-type="dfn" href="#concept-attribute">attribute</a> to <a data-link-type="dfn" href="#context-object">context object</a>, and then
+ terminate these steps. </p>
     <li>
      <p><a data-link-type="dfn" href="#concept-element-attributes-change">Change</a> <var>attribute</var> from <a data-link-type="dfn" href="#context-object">context object</a> to <var>value</var>. </p>
    </ol>
@@ -3948,22 +4019,19 @@ steps: </p>
    </ol>
    <h4 class="heading settled" data-level="4.9.2" id="interface-attr"><span class="secno">4.9.2. </span><span class="content">Interface <code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code></span><a class="self-link" href="#interface-attr"></a></h4>
 <pre class="idl highlight def">[<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv idl-code" data-dfn-type="interface" data-export="" id="attr">Attr<a class="self-link" href="#attr"></a></dfn> {
+<span class="kt">interface</span> <dfn class="nv idl-code" data-dfn-type="interface" data-export="" id="attr">Attr<a class="self-link" href="#attr"></a></dfn> : <a class="n" data-link-type="idl-name" href="#node">Node</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-attr-namespaceuri">namespaceURI</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-attr-prefix">prefix</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-attr-localname">localName</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-attr-name">name</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-attr-nodename">nodeName</a>; // historical alias of .name
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-attr-value">value</a>;
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>, <a class="nv idl-code" data-link-type="extended-attribute">TreatNullAs</a>=<a class="n" data-link-type="idl-name">EmptyString</a>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-attr-nodevalue">nodeValue</a>; // historical alias of .value
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>, <a class="nv idl-code" data-link-type="extended-attribute">TreatNullAs</a>=<a class="n" data-link-type="idl-name">EmptyString</a>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-attr-textcontent">textContent</a>; // historical alias of .value
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#element">Element</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element?" href="#dom-attr-ownerelement">ownerElement</a>;
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-attr-specified">specified</a>; // useless; always returns true
 };</pre>
-   <p><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> objects are simply known as <dfn data-dfn-type="dfn" data-export="" data-lt="attribute" id="concept-attribute">attributes<a class="self-link" href="#concept-attribute"></a></dfn>. They are sometimes referred
-to as <em>content attributes</em> to avoid confusion with IDL attributes.</p>
+   <p><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> <a data-link-type="dfn" href="#concept-node">nodes</a> are simply known as <dfn data-dfn-type="dfn" data-export="" data-lt="attribute" id="concept-attribute">attributes<a class="self-link" href="#concept-attribute"></a></dfn>. They are sometimes referred
+to as <em>content attributes</em> to avoid confusion with IDL attributes. </p>
    <p><a data-link-type="dfn" href="#concept-attribute">Attributes</a> have a <dfn data-dfn-for="Attr" data-dfn-type="dfn" data-export="" id="concept-attribute-namespace">namespace<a class="self-link" href="#concept-attribute-namespace"></a></dfn> (null or a non-empty string), <dfn data-dfn-for="Attr" data-dfn-type="dfn" data-export="" id="concept-attribute-namespace-prefix">namespace prefix<a class="self-link" href="#concept-attribute-namespace-prefix"></a></dfn> (null or a non-empty string), <dfn data-dfn-for="Attr" data-dfn-type="dfn" data-export="" id="concept-attribute-local-name">local name<a class="self-link" href="#concept-attribute-local-name"></a></dfn> (a non-empty string), <dfn data-dfn-for="Attr" data-dfn-type="dfn" data-export="" id="concept-attribute-value">value<a class="self-link" href="#concept-attribute-value"></a></dfn> (a string), and <dfn data-dfn-for="Attr" data-dfn-type="dfn" data-export="" id="concept-attribute-element">element<a class="self-link" href="#concept-attribute-element"></a></dfn> (null or an <a data-link-type="dfn" href="#concept-element">element</a>).</p>
    <p class="note no-backref" role="note">If designed today they would just have a name and value. ☹ </p>
    <p>An <a data-link-type="dfn" href="#concept-attribute">attribute</a>’s <dfn data-dfn-for="Attr" data-dfn-type="dfn" data-export="" id="concept-attribute-qualified-name">qualified name<a class="self-link" href="#concept-attribute-qualified-name"></a></dfn> is its <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a> if its <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a> is null, and its <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a>, followed by "<code>:</code>", followed by its <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>, otherwise. </p>
@@ -3977,16 +4045,15 @@ null.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-namespaceuri"><code>namespaceURI</code><a class="self-link" href="#dom-attr-namespaceuri"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-attribute-namespace">namespace</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-prefix"><code>prefix</code><a class="self-link" href="#dom-attr-prefix"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-attribute-namespace-prefix">namespace prefix</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-localname"><code>localName</code><a class="self-link" href="#dom-attr-localname"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-attribute-local-name">local name</a>. </p>
-   <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-name"><code>name</code><a class="self-link" href="#dom-attr-name"></a></dfn> attribute’s getter, and <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-nodename"><code>nodeName</code><a class="self-link" href="#dom-attr-nodename"></a></dfn> attribute’s getter, must return the <a data-link-type="dfn" href="#concept-attribute-qualified-name">qualified name</a>. </p>
-   <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-value"><code>value</code><a class="self-link" href="#dom-attr-value"></a></dfn> attribute’s getter, <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-nodevalue"><code>nodeValue</code><a class="self-link" href="#dom-attr-nodevalue"></a></dfn> attribute’s getter, and <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-textcontent"><code>textContent</code><a class="self-link" href="#dom-attr-textcontent"></a></dfn> attribute’s getter, must return the <a data-link-type="dfn" href="#concept-attribute-value">value</a>. </p>
-   <p>The <code class="idl"><a data-link-type="idl" href="#dom-attr-value">value</a></code> attribute’s setter, <code class="idl"><a data-link-type="idl" href="#dom-attr-nodevalue">nodeValue</a></code> attribute’s setter, and <code class="idl"><a data-link-type="idl" href="#dom-attr-textcontent">textContent</a></code> attribute’s setter, must run these steps: </p>
+   <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-name"><code>name</code><a class="self-link" href="#dom-attr-name"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-attribute-qualified-name">qualified name</a>. </p>
+   <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-value"><code>value</code><a class="self-link" href="#dom-attr-value"></a></dfn> attribute’s getter must return the <a data-link-type="dfn" href="#concept-attribute-value">value</a>. </p>
+   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="set-an-existing-attribute-value">set an existing attribute value<a class="self-link" href="#set-an-existing-attribute-value"></a></dfn>, given an <a data-link-type="dfn" href="#concept-attribute">attribute</a> <var>attribute</var> and
+string <var>value</var>, run these steps: </p>
    <ol>
-    <li>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is null, set <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a> to the
- given value. 
-    <li>Otherwise, <a data-link-type="dfn" href="#concept-element-attributes-change">change</a> the <a data-link-type="dfn" href="#context-object">context object</a> from <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to the given value. 
+    <li>If <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> is null, then set <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-value">value</a> to <var>value</var>. 
+    <li>Otherwise, <a data-link-type="dfn" href="#concept-element-attributes-change">change</a> <var>attribute</var> from <var>attribute</var>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a> to <var>value</var>. 
    </ol>
-   <p class="note no-backref" role="note">Unlike <a data-link-type="dfn" href="#concept-node">node</a>’s <code class="idl"><a data-link-type="idl" href="#dom-node-textcontent">textContent</a></code>, no special null
-handling is required. </p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-attr-value">value</a></code> attribute’s setter must <a data-link-type="dfn" href="#set-an-existing-attribute-value">set an existing attribute value</a> with <a data-link-type="dfn" href="#context-object">context object</a> and the given value. </p>
    <hr>
    <p>The <dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-ownerelement"><code>ownerElement</code><a class="self-link" href="#dom-attr-ownerelement"></a></dfn> attribute’s getter must return <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#concept-attribute-element">element</a>. </p>
    <hr>
@@ -4962,7 +5029,7 @@ must return <a data-link-type="dfn" href="#concept-traversal-filter">filter</a>.
   // Constants for whatToShow
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_all">SHOW_ALL</a> = 0xFFFFFFFF;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_element">SHOW_ELEMENT</a> = 0x1;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_attribute">SHOW_ATTRIBUTE<a class="self-link" href="#dom-nodefilter-show_attribute"></a></dfn> = 0x2; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_attribute">SHOW_ATTRIBUTE</a> = 0x2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_text">SHOW_TEXT</a> = 0x4;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION</a> = 0x8;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_entity_reference">SHOW_ENTITY_REFERENCE<a class="self-link" href="#dom-nodefilter-show_entity_reference"></a></dfn> = 0x10; // historical
@@ -4990,6 +5057,7 @@ constants for the <a data-link-type="dfn" href="#concept-traversal-whattoshow">w
    <ul class="brief">
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_all">SHOW_ALL<a class="self-link" href="#dom-nodefilter-show_all"></a></dfn> (4294967295, FFFFFFFF in hexadecimal); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_element">SHOW_ELEMENT<a class="self-link" href="#dom-nodefilter-show_element"></a></dfn> (1); 
+    <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_attribute">SHOW_ATTRIBUTE<a class="self-link" href="#dom-nodefilter-show_attribute"></a></dfn> (2); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_text">SHOW_TEXT<a class="self-link" href="#dom-nodefilter-show_text"></a></dfn> (4); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION<a class="self-link" href="#dom-nodefilter-show_cdata_section"></a></dfn> (8); 
     <li><dfn class="idl-code" data-dfn-for="NodeFilter" data-dfn-type="const" data-export="" id="dom-nodefilter-show_processing_instruction">SHOW_PROCESSING_INSTRUCTION<a class="self-link" href="#dom-nodefilter-show_processing_instruction"></a></dfn> (64, 40 in hexadecimal); 
@@ -5271,8 +5339,11 @@ some of these features should be reintroduced. </p>
       <li><dfn class="idl-code" data-dfn-for="DOMImplementation" data-dfn-type="method" data-export="" id="dom-domimplementation-getfeature">getFeature()<a class="self-link" href="#dom-domimplementation-getfeature"></a></dfn> 
      </ul>
     <dt><code class="idl"><a data-link-type="idl" href="#attr">Attr</a></code> 
-    <dd> No longer inherits from <code class="idl"><a data-link-type="idl" href="#node">Node</a></code> and therefore completely
-  changed. 
+    <dd>
+     <ul class="brief">
+      <li><dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-schematypeinfo">schemaTypeInfo<a class="self-link" href="#dom-attr-schematypeinfo"></a></dfn> 
+      <li><dfn class="idl-code" data-dfn-for="Attr" data-dfn-type="attribute" data-export="" id="dom-attr-isid">isId<a class="self-link" href="#dom-attr-isid"></a></dfn> 
+     </ul>
     <dt><code class="idl"><a data-link-type="idl" href="#element">Element</a></code> 
     <dd>
      <ul class="brief">
@@ -5882,6 +5953,7 @@ neighboring rights to this work.</p>
    <li><a href="#dom-node-isdefaultnamespace">isDefaultNamespace(namespace)</a><span>, in §4.4</span>
    <li><a href="#dom-text-iselementcontentwhitespace">isElementContentWhitespace</a><span>, in §8.2</span>
    <li><a href="#dom-node-isequalnode">isEqualNode(otherNode)</a><span>, in §4.4</span>
+   <li><a href="#dom-attr-isid">isId</a><span>, in §8.2</span>
    <li><a href="#dom-range-ispointinrange">isPointInRange(node, offset)</a><span>, in §5.2</span>
    <li><a href="#dom-node-issamenode">isSameNode(otherNode)</a><span>, in §4.4</span>
    <li><a href="#dom-node-issupported">isSupported</a><span>, in §8.2</span>
@@ -6005,21 +6077,11 @@ neighboring rights to this work.</p>
    <li><a href="#nodeiterator">NodeIterator</a><span>, in §6.1</span>
    <li><a href="#nodeiterator-pre-removing-steps">NodeIterator pre-removing steps</a><span>, in §6.1</span>
    <li><a href="#nodelist">NodeList</a><span>, in §4.2.10.1</span>
-   <li>
-    nodeName
-    <ul>
-     <li><a href="#dom-node-nodename">attribute for Node</a><span>, in §4.4</span>
-     <li><a href="#dom-attr-nodename">attribute for Attr</a><span>, in §4.9.2</span>
-    </ul>
+   <li><a href="#dom-node-nodename">nodeName</a><span>, in §4.4</span>
    <li><a href="#concept-node">nodes</a><span>, in §4.2</span>
    <li><a href="#concept-node-tree">node tree</a><span>, in §4.2</span>
    <li><a href="#dom-node-nodetype">nodeType</a><span>, in §4.4</span>
-   <li>
-    nodeValue
-    <ul>
-     <li><a href="#dom-node-nodevalue">attribute for Node</a><span>, in §4.4</span>
-     <li><a href="#dom-attr-nodevalue">attribute for Attr</a><span>, in §4.9.2</span>
-    </ul>
+   <li><a href="#dom-node-nodevalue">nodeValue</a><span>, in §4.4</span>
    <li><a href="#nondocumenttypechildnode">NonDocumentTypeChildNode</a><span>, in §4.2.7</span>
    <li><a href="#dom-event-none">NONE</a><span>, in §3.2</span>
    <li><a href="#nonelementparentnode">NonElementParentNode</a><span>, in §4.2.4</span>
@@ -6154,7 +6216,12 @@ neighboring rights to this work.</p>
      <li><a href="#dom-nodeiterator-root">attribute for NodeIterator</a><span>, in §6.1</span>
      <li><a href="#dom-treewalker-root">attribute for TreeWalker</a><span>, in §6.2</span>
     </ul>
-   <li><a href="#dom-element-schematypeinfo">schemaTypeInfo</a><span>, in §8.2</span>
+   <li>
+    schemaTypeInfo
+    <ul>
+     <li><a href="#dom-attr-schematypeinfo">attribute for Attr</a><span>, in §8.2</span>
+     <li><a href="#dom-element-schematypeinfo">attribute for Element</a><span>, in §8.2</span>
+    </ul>
    <li><a href="#scope-match-a-selectors-string">scope-match a selectors string</a><span>, in §2.4</span>
    <li><a href="#concept-range-select">select</a><span>, in §5.2</span>
    <li><a href="#dom-range-selectnodecontents">selectNodeContents(node)</a><span>, in §5.2</span>
@@ -6162,6 +6229,7 @@ neighboring rights to this work.</p>
    <li><a href="#concept-dtl-serialize">serialize steps</a><span>, in §7.1</span>
    <li><a href="#concept-element-attributes-set">set an attribute</a><span>, in §4.9</span>
    <li><a href="#concept-element-attributes-set-value">set an attribute value</a><span>, in §4.9</span>
+   <li><a href="#set-an-existing-attribute-value">set an existing attribute value</a><span>, in §4.9.2</span>
    <li><a href="#dom-element-setattributenode">setAttributeNode(attr)</a><span>, in §4.9</span>
    <li><a href="#dom-element-setattributenodens">setAttributeNodeNS(attr)</a><span>, in §4.9</span>
    <li><a href="#dom-element-setattributens">setAttributeNS(namespace, qualifiedName, value)</a><span>, in §4.9</span>
@@ -6266,12 +6334,7 @@ neighboring rights to this work.</p>
      <li><a href="#dom-processinginstruction-target">attribute for ProcessingInstruction</a><span>, in §4.13</span>
     </ul>
    <li><a href="#text">Text</a><span>, in §4.11</span>
-   <li>
-    textContent
-    <ul>
-     <li><a href="#dom-node-textcontent">attribute for Node</a><span>, in §4.4</span>
-     <li><a href="#dom-attr-textcontent">attribute for Attr</a><span>, in §4.9.2</span>
-    </ul>
+   <li><a href="#dom-node-textcontent">textContent</a><span>, in §4.4</span>
    <li><a href="#dom-text-text">Text(data)</a><span>, in §4.11</span>
    <li><a href="#dom-node-text_node">TEXT_NODE</a><span>, in §4.4</span>
    <li><a href="#dom-event-timestamp">timeStamp</a><span>, in §3.2</span>
@@ -6686,7 +6749,7 @@ neighboring rights to this work.</p>
 [<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#node">Node</a> : <a class="n" data-link-type="idl-name" href="#eventtarget">EventTarget</a> {
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-element_node">ELEMENT_NODE</a> = 1;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" href="#dom-node-attribute_node">ATTRIBUTE_NODE</a> = 2; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-attribute_node">ATTRIBUTE_NODE</a> = 2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-text_node">TEXT_NODE</a> = 3;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="const" href="#dom-node-cdata_section_node">CDATA_SECTION_NODE</a> = 4;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" href="#dom-node-entity_reference_node">ENTITY_REFERENCE_NODE</a> = 5; // historical
@@ -6885,15 +6948,12 @@ neighboring rights to this work.</p>
 };
 
 [<a class="nv idl-code" data-link-type="extended-attribute">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#attr">Attr</a> {
+<span class="kt">interface</span> <a class="nv" href="#attr">Attr</a> : <a class="n" data-link-type="idl-name" href="#node">Node</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-attr-namespaceuri">namespaceURI</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-attr-prefix">prefix</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-attr-localname">localName</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-attr-name">name</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-attr-nodename">nodeName</a>; // historical alias of .name
   [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-attr-value">value</a>;
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>, <a class="nv idl-code" data-link-type="extended-attribute">TreatNullAs</a>=<a class="n" data-link-type="idl-name">EmptyString</a>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-attr-nodevalue">nodeValue</a>; // historical alias of .value
-  [<a class="nv idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions">CEReactions</a>, <a class="nv idl-code" data-link-type="extended-attribute">TreatNullAs</a>=<a class="n" data-link-type="idl-name">EmptyString</a>] <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-type="DOMString" href="#dom-attr-textcontent">textContent</a>; // historical alias of .value
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#element">Element</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="Element?" href="#dom-attr-ownerelement">ownerElement</a>;
 
@@ -7010,7 +7070,7 @@ neighboring rights to this work.</p>
   // Constants for whatToShow
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_all">SHOW_ALL</a> = 0xFFFFFFFF;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_element">SHOW_ELEMENT</a> = 0x1;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-nodefilter-show_attribute">SHOW_ATTRIBUTE</a> = 0x2; // historical
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_attribute">SHOW_ATTRIBUTE</a> = 0x2; // historical
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_text">SHOW_TEXT</a> = 0x4;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-nodefilter-show_cdata_section">SHOW_CDATA_SECTION</a> = 0x8;
   <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-nodefilter-show_entity_reference">SHOW_ENTITY_REFERENCE</a> = 0x10; // historical


### PR DESCRIPTION
Unfortunately AttrExodus never quite became the success we all wished
it would be and the benefits with Attr no longer taking children (yay)
are rather marginal anyway.

The biggest change is to the compareDocumentPosition() algorithm. Other
noteworthy changes are that all attribute creation now needs to set a
node document.

Fixes #102.