### PR TITLE
Fix and clarify more around CDATASection

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3526,6 +3526,9 @@ that is a <a>document</a>.
    <dt>{{Text}}
    <dd>"<code>#text</code>".
 
+   <dt>{{CDATASection}}
+   <dd>"<code>#cdata-section</code>".
+
    <dt>{{ProcessingInstruction}}
    <dd>Its <a for=ProcessingInstruction>target</a>.
 
@@ -3620,6 +3623,9 @@ the first matching statement, switching on the <a>context object</a>:
 
  <dt>{{Text}}
  <dd>"<code>#text</code>".
+
+ <dt>{{CDATASection}}
+ <dd>"<code>#cdata-section</code>".
 
  <dt>{{ProcessingInstruction}}
  <dd>Its <a for=ProcessingInstruction>target</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -1841,7 +1841,7 @@ of a <var>node</var> into a <var>parent</var> before a
 
  <li>
   If <var>parent</var> is a
-  <a>document</a>, and any of the statements below, switched
+  <a>document</a>, and any of the statements below, depending
   on <var>node</var>, are true, <a>throw</a> a
   {{HierarchyRequestError}}.
 
@@ -2061,7 +2061,7 @@ steps:
 
  <li>
   If <var>parent</var> is a
-  <a>document</a>, and any of the statements below, switched
+  <a>document</a>, and any of the statements below, depending
   on <var>node</var>, are true, <a>throw</a> a
   {{HierarchyRequestError}}.
 
@@ -3547,7 +3547,7 @@ that is a <a>document</a>.
 </dl>
 
 The <dfn attribute for=Node>nodeType</dfn> attribute's getter, when invoked, must return
-the first matching statement, switching on the <a>context object</a>:
+the first matching statement, depending on the <a>context object</a>:
 
 <dl class=switch>
  <dt>{{Element}}
@@ -3608,7 +3608,7 @@ must return the local name that is associated with the node, if it has one,
 and null otherwise.-->
 
 The <dfn attribute for=Node>nodeName</dfn> attribute's getter, when invoked, must return
-the first matching statement, switching on the <a>context object</a>:
+the first matching statement, depending on the <a>context object</a>:
 
 <dl class=switch>
  <dt>{{Element}}
@@ -3787,7 +3787,7 @@ instead, and then do as described below, depending on the <a>context object</a>:
 </dl>
 
 <p>The <dfn attribute for=Node><code>textContent</code></dfn> attribute's getter must return the
-following, switching on <a>context object</a>:
+following, depending on the <a>context object</a>:
 
 <dl class=switch>
  <dt>{{DocumentFragment}}
@@ -3810,7 +3810,7 @@ following, switching on <a>context object</a>:
 </dl>
 
 <p>The {{Node/textContent}} attribute's setter must, if the given value is null, act as if it was
-the empty string instead, and then do as described below, switching on <a>context object</a>:
+the empty string instead, and then do as described below, depending on the <a>context object</a>:
 
 <dl class=switch>
  <dt>{{DocumentFragment}}
@@ -4001,7 +4001,7 @@ dom-Range-extractContents, dom-Range-cloneContents -->
 
  <li>
   <p>Otherwise, let <var>copy</var> be a <a>node</a> that implements the same interfaces as
-  <var>node</var>, and fulfills these additional requirements, switching on
+  <var>node</var>, and fulfills these additional requirements, depending on
   <var>node</var>:
 
   <dl class=switch>


### PR DESCRIPTION
 * Make appendChild(cdata) and similar not throw.
 * Let nodeName be #cdata-section.
 * Include CDATASection as a node in an exhaustive enumeration.
 * Collapse cases of Text+PI+Comment to CharacterData where possible
   so that it's more clear that subtypes are included.
 * Say "depending on" instead of "switched" on.

Part of #300.