### PR TITLE
Shadow: Rename "unclosed node"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -757,9 +757,10 @@ steps:
  <li>
   <p>For each <var>tuple</var> in <a>context object</a>'s <a for=Event>path</a>:
 
-  <ol><li><p>If <var>currentTarget</var> is a <a>node</a> and <var>tuple</var>'s <b>item</b> is an
-  <a>unclosed node</a> of <var>currentTarget</var>, or <var>currentTarget</var> is <em>not</em> a
-  <a>node</a>, then append <var>tuple</var>'s <b>item</b> to <var>composedPath</var>.</p></li></ol>
+  <ol><li><p>If <var>currentTarget</var> is a <a>node</a> and <var>tuple</var>'s <b>item</b> is not
+  a <a>closed-shadow-hidden</a> <a>node</a> of <var>currentTarget</var>, or <var>currentTarget</var>
+  is <em>not</em> a <a>node</a>, then append <var>tuple</var>'s <b>item</b> to
+  <var>composedPath</var>.</p></li></ol>
 
  <li><p>Return <var>composedPath</var>.
 </ol>
@@ -5561,12 +5562,18 @@ is an object or one of its <a>shadow-including descendants</a>.
 <dfn export id=concept-shadow-including-inclusive-ancestor>shadow-including inclusive ancestor</dfn>
 is an object or one of its <a>shadow-including ancestors</a>.
 
-<p>A <a>node</a> <var>A</var> is an <dfn export id=concept-unclosed-node>unclosed node</dfn> of a
-<a>node</a> <var>B</var>, if <var>A</var>'s <a for=tree>root</a> is not a <a for=/>shadow root</a>,
-<var>A</var>'s <a for=tree>root</a> is a <a>shadow-including inclusive ancestor</a> of <var>B</var>,
-or <var>A</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a> whose
-<a for=ShadowRoot>mode</a> is "<code>open</code>" and <a for=DocumentFragment>host</a> is an
-<a>unclosed node</a> of <var>B</var>.
+<p>A <a>node</a> <var>A</var> is a
+<dfn export id=concept-closed-shadow-hidden>closed-shadow-hidden</dfn> <a>node</a> of a <a>node</a>
+<var>B</var> if all of the following conditions are true:
+
+<ul>
+ <li><var>A</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a>
+ <li><var>A</var>'s <a for=tree>root</a> is not a <a>shadow-including inclusive ancestor</a> of
+ <var>B</var>,
+ <li><var>A</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a> whose
+ <a for=ShadowRoot>mode</a> is "<code>closed</code>" or <var>A</var>'s <a for=tree>root</a>'s
+ <a for=DocumentFragment>host</a> is a <a>closed-shadow-hidden</a> node of <var>B</var>.
+</ul>
 
 <p>To <dfn export lt="retarget|retargeting">retarget</dfn> an object <var>A</var> against an object
 <var>B</var>, repeat these steps until they return an object:</p>

--- a/dom.bs
+++ b/dom.bs
@@ -758,9 +758,8 @@ steps:
   <p>For each <var>tuple</var> in <a>context object</a>'s <a for=Event>path</a>:
 
   <ol><li><p>If <var>currentTarget</var> is a <a>node</a> and <var>tuple</var>'s <b>item</b> is not
-  a <a>closed-shadow-hidden</a> <a>node</a> of <var>currentTarget</var>, or <var>currentTarget</var>
-  is <em>not</em> a <a>node</a>, then append <var>tuple</var>'s <b>item</b> to
-  <var>composedPath</var>.</p></li></ol>
+  <a>closed-shadow-hidden</a> from <var>currentTarget</var>, or <var>currentTarget</var> is not a
+  <a>node</a>, then append <var>tuple</var>'s <b>item</b> to <var>composedPath</var>.</p></li></ol>
 
  <li><p>Return <var>composedPath</var>.
 </ol>
@@ -5562,17 +5561,19 @@ is an object or one of its <a>shadow-including descendants</a>.
 <dfn export id=concept-shadow-including-inclusive-ancestor>shadow-including inclusive ancestor</dfn>
 is an object or one of its <a>shadow-including ancestors</a>.
 
-<p>A <a>node</a> <var>A</var> is a
-<dfn export id=concept-closed-shadow-hidden>closed-shadow-hidden</dfn> <a>node</a> of a <a>node</a>
+<p>A <a>node</a> <var>A</var> is
+<dfn export id=concept-closed-shadow-hidden>closed-shadow-hidden</dfn> from a <a>node</a>
 <var>B</var> if all of the following conditions are true:
 
 <ul>
- <li><var>A</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a>
- <li><var>A</var>'s <a for=tree>root</a> is not a <a>shadow-including inclusive ancestor</a> of
- <var>B</var>,
- <li><var>A</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a> whose
+ <li><p><var>A</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a>.
+
+ <li><p><var>A</var>'s <a for=tree>root</a> is not a <a>shadow-including inclusive ancestor</a> of
+ <var>B</var>.
+
+ <li><p><var>A</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a> whose
  <a for=ShadowRoot>mode</a> is "<code>closed</code>" or <var>A</var>'s <a for=tree>root</a>'s
- <a for=DocumentFragment>host</a> is a <a>closed-shadow-hidden</a> node of <var>B</var>.
+ <a for=DocumentFragment>host</a> is <a>closed-shadow-hidden</a> from <var>B</var>.
 </ul>
 
 <p>To <dfn export lt="retarget|retargeting">retarget</dfn> an object <var>A</var> against an object

--- a/dom.html
+++ b/dom.html
@@ -419,7 +419,7 @@ run these steps:</p>
    <h3 class="heading settled" data-level="3.1" id="introduction-to-dom-events"><span class="secno">3.1. </span><span class="content">Introduction to "DOM Events"</span><a class="self-link" href="#introduction-to-dom-events"></a></h3>
    <p>Throughout the web platform <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to objects to signal an
 occurrence, such as network activity or user interaction. These objects implement the <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> interface and can therefore add <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> to observe <a data-link-type="dfn" href="#concept-event">events</a> by calling <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-addeventlistener">addEventListener()</a></code>:</p>
-<pre class="lang-javascript highlight"><span></span><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
+<pre class="lang-javascript highlight"><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
 
 <span class="kd">function</span> <span class="nx">imgFetched</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span> <span class="p">{</span>
   <span class="c1">// great success</span>
@@ -434,7 +434,7 @@ passed as argument to <a data-link-type="dfn" href="#concept-event-listener">eve
 object to which the <a data-link-type="dfn" href="#concept-event">event</a> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> (<var>obj</var> above).</p>
    <p id="synthetic-events">Now while typically <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent
 as the result of user interaction or the completion of some task, applications can <a data-link-type="dfn" href="#concept-event-dispatch">dispatch</a> <a data-link-type="dfn" href="#concept-event">events</a> themselves, commonly known as synthetic events: </p>
-<pre class="lang-javascript highlight"><span></span><span class="c1">// add an appropriate event listener</span>
+<pre class="lang-javascript highlight"><span class="c1">// add an appropriate event listener</span>
 <span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"cat"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span> <span class="nx">process</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">detail</span><span class="p">)</span> <span class="p">})</span>
 
 <span class="c1">// create and dispatch the event</span>
@@ -448,7 +448,7 @@ operation. For instance as part of form submission an <a data-link-type="dfn" hr
 invoked, form submission will be terminated. Applications who wish to make
 use of this functionality through <a data-link-type="dfn" href="#concept-event">events</a> <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the application
 (synthetic events) can make use of the return value of the <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-dispatchevent">dispatchEvent()</a></code> method:</p>
-<pre class="lang-javascript highlight"><span></span><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
+<pre class="lang-javascript highlight"><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
   <span class="c1">// event was not canceled, time for some magic</span>
   <span class="err">…</span>
 <span class="p">}</span>
@@ -458,14 +458,14 @@ finally, and only if <a data-link-type="dfn" href="#concept-event">event</a>’s
 object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked again,
 but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.</p>
    <p>Lets look at an example of how <a data-link-type="dfn" href="#concept-event">events</a> work in a <a data-link-type="dfn" href="#concept-tree">tree</a>:</p>
-<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!doctype html></span>
-<span class="p">&lt;</span><span class="nt">html</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">head</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Boring example<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
- <span class="p">&lt;/</span><span class="nt">head</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello <span class="p">&lt;</span><span class="nt">span</span> <span class="na">id</span><span class="o">=</span><span class="s">x</span><span class="p">></span>world<span class="p">&lt;/</span><span class="nt">span</span><span class="p">></span>!<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre class="lang-markup highlight"><span class="cp">&lt;!doctype html></span>
+<span class="nt">&lt;html></span>
+ <span class="nt">&lt;head></span>
+  <span class="nt">&lt;title></span>Boring example<span class="nt">&lt;/title></span>
+ <span class="nt">&lt;/head></span>
+ <span class="nt">&lt;body></span>
+  <span class="nt">&lt;p></span>Hello <span class="nt">&lt;span</span> <span class="na">id=</span><span class="s">x</span><span class="nt">></span>world<span class="nt">&lt;/span></span>!<span class="nt">&lt;/p></span>
+  <span class="nt">&lt;script></span>
    <span class="kd">function</span> <span class="nx">test</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
      <span class="nx">debug</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">target</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">currentTarget</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">eventPhase</span><span class="p">)</span>
    <span class="p">}</span>
@@ -473,9 +473,9 @@ but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order
    <span class="nb">document</span><span class="p">.</span><span class="nx">body</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="nx">test</span><span class="p">)</span>
    <span class="kd">var</span> <span class="nx">ev</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Event</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="p">{</span><span class="nx">bubbles</span><span class="o">:</span><span class="kc">true</span><span class="p">})</span>
    <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"x"</span><span class="p">).</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span>
-  <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
- <span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
+  <span class="nt">&lt;/script></span>
+ <span class="nt">&lt;/body></span>
+<span class="nt">&lt;/html></span>
 </pre>
    <p>The <code>debug</code> function will be invoked twice. Each time the <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value will be the <code>span</code> <a data-link-type="dfn" href="#concept-element">element</a>. The
 first time <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute’s
@@ -592,8 +592,7 @@ steps: </p>
      <p>For each <var>tuple</var> in <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#event-path">path</a>: </p>
      <ol>
       <li>
-       <p>If <var>currentTarget</var> is a <a data-link-type="dfn" href="#concept-node">node</a> and <var>tuple</var>’s <b>item</b> is not
-  a <a data-link-type="dfn" href="#concept-closed-shadow-hidden">closed-shadow-hidden</a> <a data-link-type="dfn" href="#concept-node">node</a> of <var>currentTarget</var>, or <var>currentTarget</var> is <em>not</em> a <a data-link-type="dfn" href="#concept-node">node</a>, then append <var>tuple</var>’s <b>item</b> to <var>composedPath</var>.</p>
+       <p>If <var>currentTarget</var> is a <a data-link-type="dfn" href="#concept-node">node</a> and <var>tuple</var>’s <b>item</b> is not <a data-link-type="dfn" href="#concept-closed-shadow-hidden">closed-shadow-hidden</a> from <var>currentTarget</var>, or <var>currentTarget</var> is not a <a data-link-type="dfn" href="#concept-node">node</a>, then append <var>tuple</var>’s <b>item</b> to <var>composedPath</var>.</p>
      </ol>
     <li>
      <p>Return <var>composedPath</var>. </p>
@@ -1044,11 +1043,11 @@ reports with rich multimedia, as well as to fully-fledged interactive
 applications.</p>
    <p>Each such document is represented as a <a data-link-type="dfn" href="#concept-node-tree">node tree</a>. Some of the <a data-link-type="dfn" href="#concept-node">nodes</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> can have <a data-link-type="dfn" href="#concept-tree-child">children</a>, while others are always leaves.</p>
    <p>To illustrate, consider this HTML document:</p>
-<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">html</span> <span class="na">class</span><span class="o">=</span><span class="s">e</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">head</span><span class="p">>&lt;</span><span class="nt">title</span><span class="p">></span>Aliens?<span class="p">&lt;/</span><span class="nt">title</span><span class="p">>&lt;/</span><span class="nt">head</span><span class="p">></span>
- <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>Why yes.<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
-<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
+<pre class="lang-markup highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="nt">&lt;html</span> <span class="na">class=</span><span class="s">e</span><span class="nt">></span>
+ <span class="nt">&lt;head>&lt;title></span>Aliens?<span class="nt">&lt;/title>&lt;/head></span>
+ <span class="nt">&lt;body></span>Why yes.<span class="nt">&lt;/body></span>
+<span class="nt">&lt;/html></span>
 </pre>
    <p>It is represented as follows:</p>
    <ul class="domTree">
@@ -2493,7 +2492,7 @@ invoked, must return true if <var>otherNode</var> is <a data-link-type="dfn" hre
   and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>,
   with the constraint that this is to be consistent, together. 
      <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In JavaScript
-  implementations <code class="lang-javascript highlight"><span></span><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
+  implementations <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
     <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
     <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
     <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
@@ -2755,7 +2754,7 @@ return "<code>BackCompat</code>" if <a data-link-type="dfn" href="#context-objec
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-documentelement"><code>documentElement</code><a class="self-link" href="#dom-document-documentelement"></a></dfn> attribute’s getter must return
 the <a data-link-type="dfn" href="#document-element">document element</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagname"><code>getElementsByTagName(<var>qualifiedName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagname">list of elements with qualified name <var>qualifiedName</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
+   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
 the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, but not <code>&lt;FOO></code> elements
 that are in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagnamens"><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagnamens"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagnamens">list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for
@@ -2763,15 +2762,15 @@ the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbyclassname"><code>getElementsByClassName(<var>classNames</var>)</code><a class="self-link" href="#dom-document-getelementsbyclassname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbyclassname">list of elements with class names <var>classNames</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <div class="example" id="example-5ffcda00">
     <a class="self-link" href="#example-5ffcda00"></a> Given the following XHTML fragment: 
-<pre><code class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"example"</span><span class="p">></span>
-  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p1"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa bbb"</span><span class="p">/></span>
-  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p2"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa ccc"</span><span class="p">/></span>
-  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p3"</span> <span class="na">class</span><span class="o">=</span><span class="s">"bbb ccc"</span><span class="p">/></span>
-<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
+<pre><code class="lang-html highlight"><span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">"example"</span><span class="nt">></span>
+  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p1"</span> <span class="na">class=</span><span class="s">"aaa bbb"</span><span class="nt">/></span>
+  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p2"</span> <span class="na">class=</span><span class="s">"aaa ccc"</span><span class="nt">/></span>
+  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p3"</span> <span class="na">class=</span><span class="s">"bbb ccc"</span><span class="nt">/></span>
+<span class="nt">&lt;/div></span>
 </code></pre>
-    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
-    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
-    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
+    <p>A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
+    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
+    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
    </div>
    <hr>
    <dl class="domintro">
@@ -3292,11 +3291,14 @@ object’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a da
    <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-shadow-including-inclusive-descendant">shadow-including inclusive descendant<a class="self-link" href="#concept-shadow-including-inclusive-descendant"></a></dfn> is an object or one of its <a data-link-type="dfn" href="#concept-shadow-including-descendant">shadow-including descendants</a>. </p>
    <p>An object <var>A</var> is a <dfn data-dfn-type="dfn" data-export="" id="concept-shadow-including-ancestor">shadow-including ancestor<a class="self-link" href="#concept-shadow-including-ancestor"></a></dfn> of an object <var>B</var>, if and only if <var>B</var> is a <a data-link-type="dfn" href="#concept-shadow-including-descendant">shadow-including descendant</a> of <var>A</var>. </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor<a class="self-link" href="#concept-shadow-including-inclusive-ancestor"></a></dfn> is an object or one of its <a data-link-type="dfn" href="#concept-shadow-including-ancestor">shadow-including ancestors</a>. </p>
-   <p>A <a data-link-type="dfn" href="#concept-node">node</a> <var>A</var> is a <dfn data-dfn-type="dfn" data-export="" id="concept-closed-shadow-hidden">closed-shadow-hidden<a class="self-link" href="#concept-closed-shadow-hidden"></a></dfn> <a data-link-type="dfn" href="#concept-node">node</a> of a <a data-link-type="dfn" href="#concept-node">node</a> <var>B</var> if all of the following conditions are true: </p>
+   <p>A <a data-link-type="dfn" href="#concept-node">node</a> <var>A</var> is <dfn data-dfn-type="dfn" data-export="" id="concept-closed-shadow-hidden">closed-shadow-hidden<a class="self-link" href="#concept-closed-shadow-hidden"></a></dfn> from a <a data-link-type="dfn" href="#concept-node">node</a> <var>B</var> if all of the following conditions are true: </p>
    <ul>
-    <li><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> 
-    <li><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is not a <a data-link-type="dfn" href="#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</a> of <var>B</var>, 
-    <li><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> whose <a data-link-type="dfn" href="#shadowroot-mode">mode</a> is "<code>closed</code>" or <var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> is a <a data-link-type="dfn" href="#concept-closed-shadow-hidden">closed-shadow-hidden</a> node of <var>B</var>. 
+    <li>
+     <p><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>. </p>
+    <li>
+     <p><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is not a <a data-link-type="dfn" href="#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</a> of <var>B</var>. </p>
+    <li>
+     <p><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> whose <a data-link-type="dfn" href="#shadowroot-mode">mode</a> is "<code>closed</code>" or <var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> is <a data-link-type="dfn" href="#concept-closed-shadow-hidden">closed-shadow-hidden</a> from <var>B</var>. </p>
    </ul>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="retarget|retargeting" id="retarget">retarget<a class="self-link" href="#retarget"></a></dfn> an object <var>A</var> against an object <var>B</var>, repeat these steps until they return an object:</p>
    <ol>
@@ -3371,8 +3373,8 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
    <div class="example" id="example-c5b21302">
     <a class="self-link" href="#example-c5b21302"></a> 
     <p>The following code illustrates elements in each of these four states:</p>
-<pre><code class="lang-html highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
-<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+<pre><code class="lang-html highlight"><span class="cp">&lt;!DOCTYPE html></span>
+<span class="nt">&lt;script></span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-rey"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-finn"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{},</span> <span class="p">{</span> <span class="kr">extends</span><span class="o">:</span> <span class="s2">"p"</span> <span class="p">})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-kylo"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{</span>
@@ -3380,23 +3382,23 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
       <span class="c1">// super() intentionally omitted for this example</span>
     <span class="p">}</span>
   <span class="p">})</span>
-<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+<span class="nt">&lt;/script></span>
 
 <span class="c">&lt;!-- "undefined" (not defined, not custom) --></span>
-<span class="p">&lt;</span><span class="nt">sw-han</span><span class="p">>&lt;/</span><span class="nt">sw-han</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-luke"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"asdf"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="nt">&lt;sw-han>&lt;/sw-han></span>
+<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-luke"</span><span class="nt">>&lt;/p></span>
+<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"asdf"</span><span class="nt">>&lt;/p></span>
 
 <span class="c">&lt;!-- "failed" (not defined, not custom) --></span>
-<span class="p">&lt;</span><span class="nt">sw-kylo</span><span class="p">>&lt;/</span><span class="nt">sw-kylo</span><span class="p">></span>
+<span class="nt">&lt;sw-kylo>&lt;/sw-kylo></span>
 
 <span class="c">&lt;!-- "uncustomized" (defined, not custom) --></span>
-<span class="p">&lt;</span><span class="nt">p</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">asdf</span><span class="p">>&lt;/</span><span class="nt">asdf</span><span class="p">></span>
+<span class="nt">&lt;p>&lt;/p></span>
+<span class="nt">&lt;asdf>&lt;/asdf></span>
 
 <span class="c">&lt;!-- "custom" (defined, custom) --></span>
-<span class="p">&lt;</span><span class="nt">sw-rey</span><span class="p">>&lt;/</span><span class="nt">sw-rey</span><span class="p">></span>
-<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-finn"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="nt">&lt;sw-rey>&lt;/sw-rey></span>
+<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-finn"</span><span class="nt">>&lt;/p></span>
 </code></pre>
    </div>
    <p><a data-link-type="dfn" href="#concept-element">Elements</a> also have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-shadow-root">shadow root<a class="self-link" href="#concept-element-shadow-root"></a></dfn> (null or a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>). It is null unless otherwise stated. An <a data-link-type="dfn" href="#concept-element">element</a> is a <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="element-shadow-host">shadow host<a class="self-link" href="#element-shadow-host"></a></dfn> if its <a data-link-type="dfn" href="#concept-element-shadow-root">shadow root</a> is non-null. </p>
@@ -4125,10 +4127,10 @@ for selecting and copying content.</p>
     <li class="t1">
      <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code> 
      <ul>
-      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"insanity-wolf"</span> <span class="na">alt</span><span class="o">=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="p">></span> </code> 
+      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="nt">></span> </code> 
       <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span> 
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">em</span><span class="p">></span> </code> 
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span> </code> 
        <ul>
         <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span> 
        </ul>
@@ -6452,7 +6454,7 @@ neighboring rights to this work.</p>
    <dt id="biblio-css3-transitions">[CSS3-TRANSITIONS]
    <dd>Dean Jackson; et al. <a href="http://dev.w3.org/csswg/css-transitions/">CSS Transitions</a>. 19 November 2013. WD. URL: <a href="http://dev.w3.org/csswg/css-transitions/">http://dev.w3.org/csswg/css-transitions/</a>
    <dt id="biblio-device-orientation">[DEVICE-ORIENTATION]
-   <dd>Rich Tibbett; et al. <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html">DeviceOrientation Event Specification</a>. 18 August 2016. CR. URL: <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html">https://w3c.github.io/deviceorientation/spec-source-orientation.html</a>
+   <dd>Stephen Block; Andrei Popescu. <a href="https://www.w3.org/TR/orientation-event/">DeviceOrientation Event Specification</a>. 1 December 2011. LCWD. URL: <a href="https://www.w3.org/TR/orientation-event/">https://www.w3.org/TR/orientation-event/</a>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
    <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
    <dt id="biblio-encoding">[ENCODING]

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-17">17 August 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-08-18">18 August 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -419,7 +419,7 @@ run these steps:</p>
    <h3 class="heading settled" data-level="3.1" id="introduction-to-dom-events"><span class="secno">3.1. </span><span class="content">Introduction to "DOM Events"</span><a class="self-link" href="#introduction-to-dom-events"></a></h3>
    <p>Throughout the web platform <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> to objects to signal an
 occurrence, such as network activity or user interaction. These objects implement the <code class="idl"><a data-link-type="idl" href="#eventtarget">EventTarget</a></code> interface and can therefore add <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> to observe <a data-link-type="dfn" href="#concept-event">events</a> by calling <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-addeventlistener">addEventListener()</a></code>:</p>
-<pre class="lang-javascript highlight"><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
+<pre class="lang-javascript highlight"><span></span><span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"load"</span><span class="p">,</span> <span class="nx">imgFetched</span><span class="p">)</span>
 
 <span class="kd">function</span> <span class="nx">imgFetched</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span> <span class="p">{</span>
   <span class="c1">// great success</span>
@@ -434,7 +434,7 @@ passed as argument to <a data-link-type="dfn" href="#concept-event-listener">eve
 object to which the <a data-link-type="dfn" href="#concept-event">event</a> was <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> (<var>obj</var> above).</p>
    <p id="synthetic-events">Now while typically <a data-link-type="dfn" href="#concept-event">events</a> are <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the user agent
 as the result of user interaction or the completion of some task, applications can <a data-link-type="dfn" href="#concept-event-dispatch">dispatch</a> <a data-link-type="dfn" href="#concept-event">events</a> themselves, commonly known as synthetic events: </p>
-<pre class="lang-javascript highlight"><span class="c1">// add an appropriate event listener</span>
+<pre class="lang-javascript highlight"><span></span><span class="c1">// add an appropriate event listener</span>
 <span class="nx">obj</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"cat"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span> <span class="nx">process</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">detail</span><span class="p">)</span> <span class="p">})</span>
 
 <span class="c1">// create and dispatch the event</span>
@@ -448,7 +448,7 @@ operation. For instance as part of form submission an <a data-link-type="dfn" hr
 invoked, form submission will be terminated. Applications who wish to make
 use of this functionality through <a data-link-type="dfn" href="#concept-event">events</a> <a data-link-type="dfn" href="#concept-event-dispatch">dispatched</a> by the application
 (synthetic events) can make use of the return value of the <code class="idl"><a data-link-type="idl" href="#dom-eventtarget-dispatchevent">dispatchEvent()</a></code> method:</p>
-<pre class="lang-javascript highlight"><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
+<pre class="lang-javascript highlight"><span></span><span class="k">if</span><span class="p">(</span><span class="nx">obj</span><span class="p">.</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">event</span><span class="p">))</span> <span class="p">{</span>
   <span class="c1">// event was not canceled, time for some magic</span>
   <span class="err">…</span>
 <span class="p">}</span>
@@ -458,14 +458,14 @@ finally, and only if <a data-link-type="dfn" href="#concept-event">event</a>’s
 object’s <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> <a data-link-type="dfn" href="#concept-event-listener">event listeners</a> are invoked again,
 but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order</a>.</p>
    <p>Lets look at an example of how <a data-link-type="dfn" href="#concept-event">events</a> work in a <a data-link-type="dfn" href="#concept-tree">tree</a>:</p>
-<pre class="lang-markup highlight"><span class="cp">&lt;!doctype html></span>
-<span class="nt">&lt;html></span>
- <span class="nt">&lt;head></span>
-  <span class="nt">&lt;title></span>Boring example<span class="nt">&lt;/title></span>
- <span class="nt">&lt;/head></span>
- <span class="nt">&lt;body></span>
-  <span class="nt">&lt;p></span>Hello <span class="nt">&lt;span</span> <span class="na">id=</span><span class="s">x</span><span class="nt">></span>world<span class="nt">&lt;/span></span>!<span class="nt">&lt;/p></span>
-  <span class="nt">&lt;script></span>
+<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!doctype html></span>
+<span class="p">&lt;</span><span class="nt">html</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">head</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">title</span><span class="p">></span>Boring example<span class="p">&lt;/</span><span class="nt">title</span><span class="p">></span>
+ <span class="p">&lt;/</span><span class="nt">head</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span><span class="p">></span>Hello <span class="p">&lt;</span><span class="nt">span</span> <span class="na">id</span><span class="o">=</span><span class="s">x</span><span class="p">></span>world<span class="p">&lt;/</span><span class="nt">span</span><span class="p">></span>!<span class="p">&lt;/</span><span class="nt">p</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
    <span class="kd">function</span> <span class="nx">test</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
      <span class="nx">debug</span><span class="p">(</span><span class="nx">e</span><span class="p">.</span><span class="nx">target</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">currentTarget</span><span class="p">,</span> <span class="nx">e</span><span class="p">.</span><span class="nx">eventPhase</span><span class="p">)</span>
    <span class="p">}</span>
@@ -473,9 +473,9 @@ but now in reverse <a data-link-type="dfn" href="#concept-tree-order">tree order
    <span class="nb">document</span><span class="p">.</span><span class="nx">body</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="nx">test</span><span class="p">)</span>
    <span class="kd">var</span> <span class="nx">ev</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Event</span><span class="p">(</span><span class="s2">"hey"</span><span class="p">,</span> <span class="p">{</span><span class="nx">bubbles</span><span class="o">:</span><span class="kc">true</span><span class="p">})</span>
    <span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"x"</span><span class="p">).</span><span class="nx">dispatchEvent</span><span class="p">(</span><span class="nx">ev</span><span class="p">)</span>
-  <span class="nt">&lt;/script></span>
- <span class="nt">&lt;/body></span>
-<span class="nt">&lt;/html></span>
+  <span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
+ <span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
 </pre>
    <p>The <code>debug</code> function will be invoked twice. Each time the <a data-link-type="dfn" href="#concept-event">event</a>’s <code class="idl"><a data-link-type="idl" href="#dom-event-target">target</a></code> attribute value will be the <code>span</code> <a data-link-type="dfn" href="#concept-element">element</a>. The
 first time <code class="idl"><a data-link-type="idl" href="#dom-event-currenttarget">currentTarget</a></code> attribute’s
@@ -592,7 +592,8 @@ steps: </p>
      <p>For each <var>tuple</var> in <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="#event-path">path</a>: </p>
      <ol>
       <li>
-       <p>If <var>currentTarget</var> is a <a data-link-type="dfn" href="#concept-node">node</a> and <var>tuple</var>’s <b>item</b> is an <a data-link-type="dfn" href="#concept-unclosed-node">unclosed node</a> of <var>currentTarget</var>, or <var>currentTarget</var> is <em>not</em> a <a data-link-type="dfn" href="#concept-node">node</a>, then append <var>tuple</var>’s <b>item</b> to <var>composedPath</var>.</p>
+       <p>If <var>currentTarget</var> is a <a data-link-type="dfn" href="#concept-node">node</a> and <var>tuple</var>’s <b>item</b> is not
+  a <a data-link-type="dfn" href="#concept-closed-shadow-hidden">closed-shadow-hidden</a> <a data-link-type="dfn" href="#concept-node">node</a> of <var>currentTarget</var>, or <var>currentTarget</var> is <em>not</em> a <a data-link-type="dfn" href="#concept-node">node</a>, then append <var>tuple</var>’s <b>item</b> to <var>composedPath</var>.</p>
      </ol>
     <li>
      <p>Return <var>composedPath</var>. </p>
@@ -1043,11 +1044,11 @@ reports with rich multimedia, as well as to fully-fledged interactive
 applications.</p>
    <p>Each such document is represented as a <a data-link-type="dfn" href="#concept-node-tree">node tree</a>. Some of the <a data-link-type="dfn" href="#concept-node">nodes</a> in a <a data-link-type="dfn" href="#concept-tree">tree</a> can have <a data-link-type="dfn" href="#concept-tree-child">children</a>, while others are always leaves.</p>
    <p>To illustrate, consider this HTML document:</p>
-<pre class="lang-markup highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;html</span> <span class="na">class=</span><span class="s">e</span><span class="nt">></span>
- <span class="nt">&lt;head>&lt;title></span>Aliens?<span class="nt">&lt;/title>&lt;/head></span>
- <span class="nt">&lt;body></span>Why yes.<span class="nt">&lt;/body></span>
-<span class="nt">&lt;/html></span>
+<pre class="lang-markup highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">html</span> <span class="na">class</span><span class="o">=</span><span class="s">e</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">head</span><span class="p">>&lt;</span><span class="nt">title</span><span class="p">></span>Aliens?<span class="p">&lt;/</span><span class="nt">title</span><span class="p">>&lt;/</span><span class="nt">head</span><span class="p">></span>
+ <span class="p">&lt;</span><span class="nt">body</span><span class="p">></span>Why yes.<span class="p">&lt;/</span><span class="nt">body</span><span class="p">></span>
+<span class="p">&lt;/</span><span class="nt">html</span><span class="p">></span>
 </pre>
    <p>It is represented as follows:</p>
    <ul class="domTree">
@@ -2492,7 +2493,7 @@ invoked, must return true if <var>otherNode</var> is <a data-link-type="dfn" hre
   and either <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>,
   with the constraint that this is to be consistent, together. 
      <p class="note no-backref" role="note">Whether to return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code> is typically implemented via pointer comparison. In JavaScript
-  implementations <code class="lang-javascript highlight"><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
+  implementations <code class="lang-javascript highlight"><span></span><span class="nb">Math</span><span class="p">.</span><span class="nx">random</span><span class="p">()</span> </code> can be used. </p>
     <li>If <var>other</var> is an <a data-link-type="dfn" href="#concept-tree-ancestor">ancestor</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contains">DOCUMENT_POSITION_CONTAINS</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
     <li>If <var>other</var> is a <a data-link-type="dfn" href="#concept-tree-descendant">descendant</a> of <var>reference</var>, return the result of adding <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_contained_by">DOCUMENT_POSITION_CONTAINED_BY</a></code> to <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_following">DOCUMENT_POSITION_FOLLOWING</a></code>. 
     <li>If <var>other</var> is <a data-link-type="dfn" href="#concept-tree-preceding">preceding</a> <var>reference</var> return <code class="idl"><a data-link-type="idl" href="#dom-node-document_position_preceding">DOCUMENT_POSITION_PRECEDING</a></code>. 
@@ -2754,7 +2755,7 @@ return "<code>BackCompat</code>" if <a data-link-type="dfn" href="#context-objec
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" id="dom-document-documentelement"><code>documentElement</code><a class="self-link" href="#dom-document-documentelement"></a></dfn> attribute’s getter must return
 the <a data-link-type="dfn" href="#document-element">document element</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagname"><code>getElementsByTagName(<var>qualifiedName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagname">list of elements with qualified name <var>qualifiedName</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
-   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
+   <p class="note no-backref" role="note">Thus, in an <a data-link-type="dfn" href="#html-document">HTML document</a>, <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementsByTagName</span><span class="p">(</span><span class="s2">"FOO"</span><span class="p">)</span> </code> will match <code>&lt;FOO></code> elements that are not in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, and <code>&lt;foo></code> elements that are in
 the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>, but not <code>&lt;FOO></code> elements
 that are in the <a data-link-type="dfn" href="#html-namespace">HTML namespace</a>. </p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbytagnamens"><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code><a class="self-link" href="#dom-document-getelementsbytagnamens"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbytagnamens">list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for
@@ -2762,15 +2763,15 @@ the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <p>The <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" id="dom-document-getelementsbyclassname"><code>getElementsByClassName(<var>classNames</var>)</code><a class="self-link" href="#dom-document-getelementsbyclassname"></a></dfn> method, when invoked, must return the <a data-link-type="dfn" href="#concept-getelementsbyclassname">list of elements with class names <var>classNames</var></a> for the <a data-link-type="dfn" href="#context-object">context object</a>.</p>
    <div class="example" id="example-5ffcda00">
     <a class="self-link" href="#example-5ffcda00"></a> Given the following XHTML fragment: 
-<pre><code class="lang-html highlight"><span class="nt">&lt;div</span> <span class="na">id=</span><span class="s">"example"</span><span class="nt">></span>
-  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p1"</span> <span class="na">class=</span><span class="s">"aaa bbb"</span><span class="nt">/></span>
-  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p2"</span> <span class="na">class=</span><span class="s">"aaa ccc"</span><span class="nt">/></span>
-  <span class="nt">&lt;p</span> <span class="na">id=</span><span class="s">"p3"</span> <span class="na">class=</span><span class="s">"bbb ccc"</span><span class="nt">/></span>
-<span class="nt">&lt;/div></span>
+<pre><code class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">div</span> <span class="na">id</span><span class="o">=</span><span class="s">"example"</span><span class="p">></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p1"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa bbb"</span><span class="p">/></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p2"</span> <span class="na">class</span><span class="o">=</span><span class="s">"aaa ccc"</span><span class="p">/></span>
+  <span class="p">&lt;</span><span class="nt">p</span> <span class="na">id</span><span class="o">=</span><span class="s">"p3"</span> <span class="na">class</span><span class="o">=</span><span class="s">"bbb ccc"</span><span class="p">/></span>
+<span class="p">&lt;/</span><span class="nt">div</span><span class="p">></span>
 </code></pre>
-    <p>A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
-    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
-    <p>A call to <code class="lang-javascript highlight"><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
+    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa"</span><span class="p">)</span> </code> would return a <code class="idl"><a data-link-type="idl" href="#htmlcollection">HTMLCollection</a></code> with the two paragraphs <code>p1</code> and <code>p2</code> in it.</p>
+    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"ccc bbb"</span><span class="p">)</span> </code> would only return one node, however, namely <code>p3</code>. A call to <code class="lang-javascript highlight"><span></span><span class="nb">document</span><span class="p">.</span><span class="nx">getElementById</span><span class="p">(</span><span class="s2">"example"</span><span class="p">).</span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"bbb  ccc "</span><span class="p">)</span> </code> would return the same thing.</p>
+    <p>A call to <code class="lang-javascript highlight"><span></span><span class="nx">getElementsByClassName</span><span class="p">(</span><span class="s2">"aaa,bbb"</span><span class="p">)</span> </code> would return no nodes; none of the elements above are in the <code>aaa,bbb</code> class.</p>
    </div>
    <hr>
    <dl class="domintro">
@@ -3291,8 +3292,12 @@ object’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a da
    <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-shadow-including-inclusive-descendant">shadow-including inclusive descendant<a class="self-link" href="#concept-shadow-including-inclusive-descendant"></a></dfn> is an object or one of its <a data-link-type="dfn" href="#concept-shadow-including-descendant">shadow-including descendants</a>. </p>
    <p>An object <var>A</var> is a <dfn data-dfn-type="dfn" data-export="" id="concept-shadow-including-ancestor">shadow-including ancestor<a class="self-link" href="#concept-shadow-including-ancestor"></a></dfn> of an object <var>B</var>, if and only if <var>B</var> is a <a data-link-type="dfn" href="#concept-shadow-including-descendant">shadow-including descendant</a> of <var>A</var>. </p>
    <p>A <dfn data-dfn-type="dfn" data-export="" id="concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor<a class="self-link" href="#concept-shadow-including-inclusive-ancestor"></a></dfn> is an object or one of its <a data-link-type="dfn" href="#concept-shadow-including-ancestor">shadow-including ancestors</a>. </p>
-   <p>A <a data-link-type="dfn" href="#concept-node">node</a> <var>A</var> is an <dfn data-dfn-type="dfn" data-export="" id="concept-unclosed-node">unclosed node<a class="self-link" href="#concept-unclosed-node"></a></dfn> of a <a data-link-type="dfn" href="#concept-node">node</a> <var>B</var>, if <var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is not a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>, <var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</a> of <var>B</var>,
-or <var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> whose <a data-link-type="dfn" href="#shadowroot-mode">mode</a> is "<code>open</code>" and <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> is an <a data-link-type="dfn" href="#concept-unclosed-node">unclosed node</a> of <var>B</var>. </p>
+   <p>A <a data-link-type="dfn" href="#concept-node">node</a> <var>A</var> is a <dfn data-dfn-type="dfn" data-export="" id="concept-closed-shadow-hidden">closed-shadow-hidden<a class="self-link" href="#concept-closed-shadow-hidden"></a></dfn> <a data-link-type="dfn" href="#concept-node">node</a> of a <a data-link-type="dfn" href="#concept-node">node</a> <var>B</var> if all of the following conditions are true: </p>
+   <ul>
+    <li><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> 
+    <li><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is not a <a data-link-type="dfn" href="#concept-shadow-including-inclusive-ancestor">shadow-including inclusive ancestor</a> of <var>B</var>, 
+    <li><var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a> is a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a> whose <a data-link-type="dfn" href="#shadowroot-mode">mode</a> is "<code>closed</code>" or <var>A</var>’s <a data-link-type="dfn" href="#concept-tree-root">root</a>’s <a data-link-type="dfn" href="#concept-documentfragment-host">host</a> is a <a data-link-type="dfn" href="#concept-closed-shadow-hidden">closed-shadow-hidden</a> node of <var>B</var>. 
+   </ul>
    <p>To <dfn data-dfn-type="dfn" data-export="" data-lt="retarget|retargeting" id="retarget">retarget<a class="self-link" href="#retarget"></a></dfn> an object <var>A</var> against an object <var>B</var>, repeat these steps until they return an object:</p>
    <ol>
     <li>
@@ -3366,8 +3371,8 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
    <div class="example" id="example-c5b21302">
     <a class="self-link" href="#example-c5b21302"></a> 
     <p>The following code illustrates elements in each of these four states:</p>
-<pre><code class="lang-html highlight"><span class="cp">&lt;!DOCTYPE html></span>
-<span class="nt">&lt;script></span>
+<pre><code class="lang-html highlight"><span></span><span class="cp">&lt;!DOCTYPE html></span>
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-rey"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-finn"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{},</span> <span class="p">{</span> <span class="kr">extends</span><span class="o">:</span> <span class="s2">"p"</span> <span class="p">})</span>
   <span class="nb">window</span><span class="p">.</span><span class="nx">customElements</span><span class="p">.</span><span class="nx">define</span><span class="p">(</span><span class="s2">"sw-kylo"</span><span class="p">,</span> <span class="kr">class</span> <span class="kr">extends</span> <span class="nx">HTMLElement</span> <span class="p">{</span>
@@ -3375,23 +3380,23 @@ first time, it is not executed again by an <a data-link-type="dfn" href="https:/
       <span class="c1">// super() intentionally omitted for this example</span>
     <span class="p">}</span>
   <span class="p">})</span>
-<span class="nt">&lt;/script></span>
+<span class="p">&lt;/</span><span class="nt">script</span><span class="p">></span>
 
 <span class="c">&lt;!-- "undefined" (not defined, not custom) --></span>
-<span class="nt">&lt;sw-han>&lt;/sw-han></span>
-<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-luke"</span><span class="nt">>&lt;/p></span>
-<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"asdf"</span><span class="nt">>&lt;/p></span>
+<span class="p">&lt;</span><span class="nt">sw-han</span><span class="p">>&lt;/</span><span class="nt">sw-han</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-luke"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"asdf"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
 
 <span class="c">&lt;!-- "failed" (not defined, not custom) --></span>
-<span class="nt">&lt;sw-kylo>&lt;/sw-kylo></span>
+<span class="p">&lt;</span><span class="nt">sw-kylo</span><span class="p">>&lt;/</span><span class="nt">sw-kylo</span><span class="p">></span>
 
 <span class="c">&lt;!-- "uncustomized" (defined, not custom) --></span>
-<span class="nt">&lt;p>&lt;/p></span>
-<span class="nt">&lt;asdf>&lt;/asdf></span>
+<span class="p">&lt;</span><span class="nt">p</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">asdf</span><span class="p">>&lt;/</span><span class="nt">asdf</span><span class="p">></span>
 
 <span class="c">&lt;!-- "custom" (defined, custom) --></span>
-<span class="nt">&lt;sw-rey>&lt;/sw-rey></span>
-<span class="nt">&lt;p</span> <span class="na">is=</span><span class="s">"sw-finn"</span><span class="nt">>&lt;/p></span>
+<span class="p">&lt;</span><span class="nt">sw-rey</span><span class="p">>&lt;/</span><span class="nt">sw-rey</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">p</span> <span class="na">is</span><span class="o">=</span><span class="s">"sw-finn"</span><span class="p">>&lt;/</span><span class="nt">p</span><span class="p">></span>
 </code></pre>
    </div>
    <p><a data-link-type="dfn" href="#concept-element">Elements</a> also have an associated <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="concept-element-shadow-root">shadow root<a class="self-link" href="#concept-element-shadow-root"></a></dfn> (null or a <a data-link-type="dfn" href="#concept-shadow-root">shadow root</a>). It is null unless otherwise stated. An <a data-link-type="dfn" href="#concept-element">element</a> is a <dfn data-dfn-for="Element" data-dfn-type="dfn" data-export="" id="element-shadow-host">shadow host<a class="self-link" href="#element-shadow-host"></a></dfn> if its <a data-link-type="dfn" href="#concept-element-shadow-root">shadow root</a> is non-null. </p>
@@ -4120,10 +4125,10 @@ for selecting and copying content.</p>
     <li class="t1">
      <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code>p</code> 
      <ul>
-      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;img</span> <span class="na">src=</span><span class="s">"insanity-wolf"</span> <span class="na">alt=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="nt">></span> </code> 
+      <li class="t1"><code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">img</span> <span class="na">src</span><span class="o">=</span><span class="s">"insanity-wolf"</span> <span class="na">alt</span><span class="o">=</span><span class="s">"Little-endian BOM; decode as big-endian!"</span><span class="p">></span> </code> 
       <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span> CSS 2.1 syndata is </span> 
       <li class="t1">
-       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span class="nt">&lt;em></span> </code> 
+       <code class="idl"><a data-link-type="idl" href="#element">Element</a></code>: <code class="lang-markup highlight"><span></span><span class="p">&lt;</span><span class="nt">em</span><span class="p">></span> </code> 
        <ul>
         <li class="t3"><code class="idl"><a data-link-type="idl" href="#text">Text</a></code>: <span>awesome</span> 
        </ul>
@@ -5569,6 +5574,7 @@ neighboring rights to this work.</p>
    <li><a href="#concept-node-clone-ext">cloning steps</a><span>, in §4.4</span>
    <li><a href="#dom-shadowrootmode-closed">closed</a><span>, in §4.8</span>
    <li><a href="#dom-shadowrootmode-closed">"closed"</a><span>, in §4.8</span>
+   <li><a href="#concept-closed-shadow-hidden">closed-shadow-hidden</a><span>, in §4.8</span>
    <li><a href="#dom-element-closest">closest(selectors)</a><span>, in §4.9</span>
    <li><a href="#dom-range-collapse">collapse()</a><span>, in §5.2</span>
    <li><a href="#dom-range-collapsed">collapsed</a><span>, in §5.2</span>
@@ -6286,7 +6292,6 @@ neighboring rights to this work.</p>
      <li><a href="#concept-document-type">dfn for Document</a><span>, in §4.5</span>
     </ul>
    <li><a href="#typeinfo">TypeInfo</a><span>, in §8.2</span>
-   <li><a href="#concept-unclosed-node">unclosed node</a><span>, in §4.8</span>
    <li><a href="#concept-dtl-update">update steps</a><span>, in §7.1</span>
    <li>
     URL
@@ -6447,7 +6452,7 @@ neighboring rights to this work.</p>
    <dt id="biblio-css3-transitions">[CSS3-TRANSITIONS]
    <dd>Dean Jackson; et al. <a href="http://dev.w3.org/csswg/css-transitions/">CSS Transitions</a>. 19 November 2013. WD. URL: <a href="http://dev.w3.org/csswg/css-transitions/">http://dev.w3.org/csswg/css-transitions/</a>
    <dt id="biblio-device-orientation">[DEVICE-ORIENTATION]
-   <dd>Stephen Block; Andrei Popescu. <a href="https://www.w3.org/TR/orientation-event/">DeviceOrientation Event Specification</a>. 1 December 2011. LCWD. URL: <a href="https://www.w3.org/TR/orientation-event/">https://www.w3.org/TR/orientation-event/</a>
+   <dd>Rich Tibbett; et al. <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html">DeviceOrientation Event Specification</a>. 18 August 2016. CR. URL: <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html">https://w3c.github.io/deviceorientation/spec-source-orientation.html</a>
    <dt id="biblio-ecmascript">[ECMASCRIPT]
    <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
    <dt id="biblio-encoding">[ENCODING]


### PR DESCRIPTION
Now we use "closed-shadow-hidden" instead. Fixes #285.