### PR TITLE
Drop "invoking" from "invoking retargeting"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1187,7 +1187,7 @@ for discussion).
   <!-- We should consider refactoring it to make it have less of a scope, since we don't really want
        folks to start using it for non-legacy scenarios. -->
 
- <li>Let <var>relatedTarget</var> be the result of invoking <a>retargeting</a> <var>event</var>'s
+ <li>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
  <a>relatedTarget</a> against <var>target</var> if <var>event</var>'s <a>relatedTarget</a> is
  non-null, and null otherwise.
 
@@ -1201,7 +1201,7 @@ for discussion).
   <p>While <var>parent</var> is non-null:</p>
 
   <ol>
-   <li><p>Let <var>relatedTarget</var> be the result of invoking <a>retargeting</a>
+   <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a>
    <var>event</var>'s <a>relatedTarget</a> against <var>parent</var> if <var>event</var>'s
    <a>relatedTarget</a> is non-null, and null otherwise.
 


### PR DESCRIPTION
This was pointed out during pointerLock spec change review:
https://github.com/w3c/pointerlock/pull/8

I'd like to get this reviewed by a native speaker whether it looks less
unnatural.