### PR TITLE
Drop support for SVGZoomEvent in createEvent

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5213,8 +5213,6 @@ invoked, must run these steps:
     <tr><td>"<code>progressevent</code>"<td>{{ProgressEvent}}<td>[[!XHR]]
     <tr><td>"<code>storageevent</code>"<td>{{StorageEvent}}<td>[[!HTML]]
     <tr><td>"<code>svgevents</code>"<td>{{Event}}<td>
-    <tr><td>"<code>svgzoomevent</code>"<td rowspan=2>{{SVGZoomEvent}}<td rowspan=2>[[!SVG]]
-    <tr><td>"<code>svgzoomevents</code>"
     <tr><td>"<code>textevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]
     <tr><td>"<code>touchevent</code>"<td>{{TouchEvent}}<td>[[!TOUCH-EVENTS]]
     <tr><td>"<code>trackevent</code>"<td>{{TrackEvent}}<td>[[!HTML]]


### PR DESCRIPTION
SVGZoomEvent has been removed from SVG and from Chromium:
https://github.com/w3c/svgwg/issues/21
https://crbug.com/367890

Fixes #283.
