### PR TITLE
Do not dispatch a trusted event when target and reletedTarget are identical

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1201,8 +1201,8 @@ for discussion).
  <a>relatedTarget</a> against <var>target</var> if <var>event</var>'s <a>relatedTarget</a> is
  non-null, and null otherwise.
 
- <li><p>If <var>event</var>'s {{Event/isTrusted}} attribute is true and <var>target</var> and
- <var>relatedTarget</var> are identical, terminate these steps.
+ <li><p>If <var>event</var>'s {{Event/isTrusted}} attribute is true and <var>target</var> is
+ <var>relatedTarget</var>, then terminate these steps.
 
  <li><p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>'s
  <a for=Event>path</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -1201,9 +1201,8 @@ for discussion).
  <a>relatedTarget</a> against <var>target</var> if <var>event</var>'s <a>relatedTarget</a> is
  non-null, and null otherwise.
 
- <li><p>If <var>event</var>'s {{Event/isTrusted}} attribute is true, <var>target</var> is
- <var>relatedTarget</var>, and <var>target</var> is not <var>event</var>'s <a>relatedTarget</a>,
- then return true.
+ <li><p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not
+ <var>event</var>'s <a>relatedTarget</a>, then return true.
 
  <li><p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>'s
  <a for=Event>path</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -1201,8 +1201,9 @@ for discussion).
  <a>relatedTarget</a> against <var>target</var> if <var>event</var>'s <a>relatedTarget</a> is
  non-null, and null otherwise.
 
- <li><p>If <var>event</var>'s {{Event/isTrusted}} attribute is true and <var>target</var> is
- <var>relatedTarget</var>, then terminate these steps.
+ <li><p>If <var>event</var>'s {{Event/isTrusted}} attribute is true, <var>target</var> is
+ <var>relatedTarget</var>, and <var>target</var> is not <var>event</var>'s <a>relatedTarget</a>,
+ then terminate these steps.
 
  <li><p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>'s
  <a for=Event>path</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -1203,7 +1203,7 @@ for discussion).
 
  <li><p>If <var>event</var>'s {{Event/isTrusted}} attribute is true, <var>target</var> is
  <var>relatedTarget</var>, and <var>target</var> is not <var>event</var>'s <a>relatedTarget</a>,
- then terminate these steps.
+ then return true.
 
  <li><p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>'s
  <a for=Event>path</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -1201,6 +1201,9 @@ for discussion).
  <a>relatedTarget</a> against <var>target</var> if <var>event</var>'s <a>relatedTarget</a> is
  non-null, and null otherwise.
 
+ <li><p>If <var>event</var>'s {{Event/isTrusted}} attribute is true and <var>target</var> and
+ <var>relatedTarget</var> are identical, terminate these steps.
+
  <li><p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>'s
  <a for=Event>path</a>.
 

--- a/dom.html
+++ b/dom.html
@@ -882,7 +882,7 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneropti
  non-null, and null otherwise. 
     <li>
      <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute is true, <var>target</var> is <var>relatedTarget</var>, and <var>target</var> is not <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a>,
- then terminate these steps. </p>
+ then return true. </p>
     <li>
      <p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
     <li>

--- a/dom.html
+++ b/dom.html
@@ -881,7 +881,7 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneropti
     <li>Let <var>relatedTarget</var> be the result of <a data-link-type="dfn" href="#retarget">retargeting</a> <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> against <var>target</var> if <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> is
  non-null, and null otherwise. 
     <li>
-     <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute is true and <var>target</var> and <var>relatedTarget</var> are identical, terminate these steps. </p>
+     <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute is true and <var>target</var> is <var>relatedTarget</var>, then terminate these steps. </p>
     <li>
      <p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
     <li>

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-10-14">14 October 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-10-17">17 October 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -880,6 +880,8 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneropti
      <p class="note" role="note"><var>legacy target override flag</var> is only used by HTML and only when <var>target</var> is a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a></code> object. </p>
     <li>Let <var>relatedTarget</var> be the result of <a data-link-type="dfn" href="#retarget">retargeting</a> <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> against <var>target</var> if <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> is
  non-null, and null otherwise. 
+    <li>
+     <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute is true and <var>target</var> and <var>relatedTarget</var> are identical, terminate these steps. </p>
     <li>
      <p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
     <li>

--- a/dom.html
+++ b/dom.html
@@ -71,7 +71,7 @@ pre.idl.highlight { color: #708090; }
    <p data-fill-with="logo"><a class="logo" href="https://whatwg.org/"> <img alt="WHATWG" height="100" src="https://resources.whatwg.org/logo-dom.svg"> </a> </p>
    <hgroup>
     <h1 class="p-name no-ref allcaps" id="title">DOM</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-10-17">17 October 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Living Standard — Last Updated <time class="dt-updated" datetime="2016-10-18">18 October 2016</time></span></h2>
    </hgroup>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -881,8 +881,7 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneropti
     <li>Let <var>relatedTarget</var> be the result of <a data-link-type="dfn" href="#retarget">retargeting</a> <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> against <var>target</var> if <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> is
  non-null, and null otherwise. 
     <li>
-     <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute is true, <var>target</var> is <var>relatedTarget</var>, and <var>target</var> is not <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a>,
- then return true. </p>
+     <p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a>, then return true. </p>
     <li>
      <p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
     <li>

--- a/dom.html
+++ b/dom.html
@@ -881,7 +881,8 @@ of non-<code class="idl"><a data-link-type="idl" href="#dom-addeventlisteneropti
     <li>Let <var>relatedTarget</var> be the result of <a data-link-type="dfn" href="#retarget">retargeting</a> <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> against <var>target</var> if <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a> is
  non-null, and null otherwise. 
     <li>
-     <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute is true and <var>target</var> is <var>relatedTarget</var>, then terminate these steps. </p>
+     <p>If <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-istrusted">isTrusted</a></code> attribute is true, <var>target</var> is <var>relatedTarget</var>, and <var>target</var> is not <var>event</var>’s <a data-link-type="dfn" href="#event-relatedtarget">relatedTarget</a>,
+ then terminate these steps. </p>
     <li>
      <p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to <var>event</var>’s <a data-link-type="dfn" href="#event-path">path</a>. </p>
     <li>


### PR DESCRIPTION
…Target are identical

Change the behavior of event dispatch as follows:

1. Make an event dispatch happen until the root of the tree when target
and relatedTarget are identical in synthetic events.

2. Do not dispatch an event when retargeted-target and
retargeted-reletedTarget are identical, but target and relatedTarget are
not identical.

(2) is a bug fix. This sitution happens in UA events. For example,
if a mouse pointer moves from an element in a shadow tree to
its shadow host, a "mouseover" event should not be dispatched on the
shadow host. The current spec allows a non-empty event path in this case.

Fixes https://github.com/w3c/webcomponents/issues/577