### PR TITLE
Use the relevant realm of the event target when firing an event

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1478,7 +1478,7 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
  {{Event}}.
 
  <li><p>Let <var>event</var> be the result of <a>creating an event</a> given
- <var>eventConstructor</var>.
+ <var>eventConstructor</var>, in the <a>relevant Realm</a> of <var>target</var>.
 
  <li><p>Initialize <var>event</var>'s {{Event/type}} attribute to <var>e</var>.
 
@@ -1492,8 +1492,9 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
  <var>legacy target override flag</var> set if set.
 </ol>
 
-<p class="note no-backref">Fire in the context of DOM is short for creating, initializing, and
-<a>dispatching</a> an <a>event</a>. <a>Fire an event</a> makes that process easier to write down.
+<p class="note no-backref">Fire in the context of DOM is short for
+<a lt="create an event">creating</a>, initializing, and <a>dispatching</a> an <a>event</a>.
+<a>Fire an event</a> makes that process easier to write down.
 
 <div class="example no-backref" id=firing-events-example>
  <p>If the <a>event</a> needs its {{Event/bubbles}} or {{Event/cancelable}} attribute initialized,

--- a/dom.html
+++ b/dom.html
@@ -851,7 +851,7 @@ steps: </p>
    <p>The <dfn class="idl-code" data-dfn-for="EventTarget" data-dfn-type="method" data-export="" data-lt="addEventListener(type, callback, options)|addEventListener(type, callback)" id="dom-eventtarget-addeventlistener"><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code><a class="self-link" href="#dom-eventtarget-addeventlistener"></a></dfn> method, when invoked, must run these steps: </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a></code> object and its associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-script-resource">script resource</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</a> is set, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. <a data-link-type="biblio" href="#biblio-service-workers">[SERVICE-WORKERS]</a> </p>
+     <p>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a></code> object and its associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-script-resource">script resource</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</a> is set, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. <a data-link-type="biblio" href="#biblio-service-workers">[SERVICE-WORKERS]</a> </p>
      <p class="note no-backref" role="note">To optimize storing the event types allowed for the service worker and
   to avoid non-deterministic changes to the event listeners, invocation of the method is allowed
   only during the very first evaluation of the service worker script. </p>
@@ -866,7 +866,7 @@ steps: </p>
    <p>The <dfn class="idl-code" data-dfn-for="EventTarget" data-dfn-type="method" data-export="" data-lt="removeEventListener(type, callback, options)|removeEventListener(type, callback)" id="dom-eventtarget-removeeventlistener"><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code><a class="self-link" href="#dom-eventtarget-removeeventlistener"></a></dfn> method, when invoked, must, run these steps </p>
    <ol>
     <li>
-     <p>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a></code> object and its associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-script-resource">script resource</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</a> is set, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. <a data-link-type="biblio" href="#biblio-service-workers">[SERVICE-WORKERS]</a> </p>
+     <p>If <a data-link-type="dfn" href="#context-object">context object</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a> is a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a></code> object and its associated <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">service worker</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-script-resource">script resource</a>’s <a data-link-type="dfn" href="https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</a> is set, then <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a <code>TypeError</code>. <a data-link-type="biblio" href="#biblio-service-workers">[SERVICE-WORKERS]</a> </p>
     <li>
      <p>Let <var>capture</var> be the result of <a data-link-type="dfn" href="#concept-flatten-options">flattening</a> <var>options</var>. </p>
     <li>
@@ -1091,7 +1091,7 @@ initialized, and a <var>legacy target override flag</var>, run these steps: </p>
     <li>
      <p>If <var>eventConstructor</var> is not given, then let <var>eventConstructor</var> be <code class="idl"><a data-link-type="idl" href="#event">Event</a></code>. </p>
     <li>
-     <p>Let <var>event</var> be the result of <a data-link-type="dfn" href="#concept-event-create">creating an event</a> given <var>eventConstructor</var>. </p>
+     <p>Let <var>event</var> be the result of <a data-link-type="dfn" href="#concept-event-create">creating an event</a> given <var>eventConstructor</var>, in the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant Realm</a> of <var>target</var>. </p>
     <li>
      <p>Initialize <var>event</var>’s <code class="idl"><a data-link-type="idl" href="#dom-event-type">type</a></code> attribute to <var>e</var>. </p>
     <li>
@@ -1101,7 +1101,7 @@ initialized, and a <var>legacy target override flag</var>, run these steps: </p>
     <li>
      <p>Return the result of <a data-link-type="dfn" href="#concept-event-dispatch">dispatching</a> <var>event</var> at <var>target</var>, with <var>legacy target override flag</var> set if set. </p>
    </ol>
-   <p class="note no-backref" role="note">Fire in the context of DOM is short for creating, initializing, and <a data-link-type="dfn" href="#concept-event-dispatch">dispatching</a> an <a data-link-type="dfn" href="#concept-event">event</a>. <a data-link-type="dfn" href="#concept-event-fire">Fire an event</a> makes that process easier to write down. </p>
+   <p class="note no-backref" role="note">Fire in the context of DOM is short for <a data-link-type="dfn" href="#concept-event-create">creating</a>, initializing, and <a data-link-type="dfn" href="#concept-event-dispatch">dispatching</a> an <a data-link-type="dfn" href="#concept-event">event</a>. <a data-link-type="dfn" href="#concept-event-fire">Fire an event</a> makes that process easier to write down. </p>
    <div class="example no-backref" id="firing-events-example">
     <a class="self-link" href="#firing-events-example"></a> 
     <p>If the <a data-link-type="dfn" href="#concept-event">event</a> needs its <code class="idl"><a data-link-type="idl" href="#dom-event-bubbles">bubbles</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-event-cancelable">cancelable</a></code> attribute initialized,
@@ -6637,6 +6637,7 @@ neighboring rights to this work.</p>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">queue a microtask</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global object</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">relevant realm</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">report the exception</a>
      <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a>
      <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">slot</a>
@@ -6667,7 +6668,7 @@ neighboring rights to this work.</p>
    <li>
     <a data-link-type="biblio">[SERVICE-WORKERS]</a> defines the following terms:
     <ul>
-     <li><a href="https://w3c.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a>
+     <li><a href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a>
     </ul>
    <li>
     <a data-link-type="biblio">[SVG]</a> defines the following terms:


### PR DESCRIPTION
Closes #352.

Some tests at https://github.com/w3c/web-platform-tests/pull/4088, but they are not exhaustive. I don't feel up to the task of writing a test for every instance of "fire" in the spec.