### PR TITLE
Reinstate active flag for iterators

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -8625,6 +8625,10 @@ and {{Range/getBoundingClientRect()}} methods are defined in other specification
 to filter and traverse <a>node</a>
 <a>trees</a>.
 
+Each {{NodeIterator}} and {{TreeWalker}} object has an associated <dfn export
+id=concept-traversal-active for=traversal>active flag</dfn> to avoid
+recursive invocations.  It is initially unset.
+
 Each {{NodeIterator}} and {{TreeWalker}} object also
 has an associated <dfn export id=concept-traversal-root for=traversal>root</dfn>
 <a>node</a>,
@@ -8635,6 +8639,7 @@ To <dfn export id=concept-node-filter for=Node>filter</dfn> <var>node</var> run
 these steps:
 
 <ol>
+ <li>If the <a for=traversal>active flag</a> is set, throw an {{InvalidStateError}}.
  <li>Let <var>n</var> be <var>node</var>'s
  {{Node/nodeType}} attribute value minus 1.
  <li>If the <var>n</var><sup>th</sup> bit (where 0 is the least
@@ -8644,9 +8649,11 @@ these steps:
  <!-- !((1 << (node.nodeType - 1)) & whatToShow) -->
  <li>If <a for=traversal>filter</a> is null,
  return {{NodeFilter/FILTER_ACCEPT}}.
+ <li>Set the <a for=traversal>active flag</a>.
  <li>Let <var>result</var> be the return value of <a>call a user object's operation</a> with
  <a for=traversal>filter</a>, "<code>acceptNode</code>", and a list of arguments consisting of
  <var>node</var>.
+ <li>Unset the <a for=traversal>active flag</a>.
  <!-- no need to pass callback this value; it's undefined which becomes the global object -->
  <li>Return <var>result</var>.
 </ol>
@@ -8680,7 +8687,7 @@ Each {{NodeIterator}} object has an associated
 <a>node</a>.
 
 <p class="note no-backref">As mentioned earlier, {{NodeIterator}} objects have an
-associated
+associated <a for=traversal>active flag</a>,
 <a for=traversal>root</a> <a>node</a>,
 <a for=traversal>whatToShow</a> bitmask, and
 <a for=traversal>filter</a> callback as well.


### PR DESCRIPTION
This reverts ccf51e85, and fixes
https://www.w3.org/Bugs/Public/show_bug.cgi?id=25412.  It brings the
spec back in line with Firefox instead of other browsers.  Boris argues
convincingly that the behavior without the active flag is much harder to
spec and test properly, and nobody has a use-case for allowing recursion
here, so it's easier all around to converge on Firefox behavior and just
ban recursion.  He doesn't want Firefox to allow recursion unless
someone writes good tests for it, which nobody wants to.  Other UAs were
asked for comment on the bug and didn't support or oppose.

@bzbarsky @travisleithead @domenic @cdumez


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ayg/dom/active-flag.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/61f40b0...ayg:2c0e1fe.html)