### PR TITLE
Remove incorrect customized built-in element checks

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4933,13 +4933,6 @@ invoked, must run these steps:
  <li>Let <var>is</var> be the value of <code>is</code> member of <var>options</var>, or null if no
  such member exists.
 
- <li>Let <var>definition</var> be the result of
- <a lt="look up a custom element definition">looking up a custom element definition</a>, given the
- <a>context object</a>, the <a>HTML namespace</a>, <var>localName</var>, and <var>is</var>.
-
- <li>If <var>is</var> is non-null and <var>definition</var> is null, then <a>throw</a> a
- {{NotFoundError}}.
-
  <li><p>Let <var>namespace</var> be the <a>HTML namespace</a>, if the <a>context object</a> is an
  <a>HTML document</a> or <a>context object</a>'s <a for=Document>content type</a> is
  "<code>application/xhtml+xml</code>", and null otherwise.
@@ -4964,13 +4957,6 @@ invoked, must run these steps:
 
  <li>Let <var>is</var> be the value of <code>is</code> member of <var>options</var>, or null if no
  such member exists.
-
- <li>Let <var>definition</var> be the result of
- <a lt="look up a custom element definition">looking up a custom element definition</a>, given the
- <a>context object</a>, <var>namespace</var>, <var>localName</var>, and <var>is</var>.
-
- <li>If <var>is</var> is non-null and <var>definition</var> is null, then <a>throw</a> a
- {{NotFoundError}}.
 
  <li><p>Let <var>element</var> be the result of <a>creating an element</a> given
  <var>document</var>, <var>localName</var>, <var>namespace</var>, <var>prefix</var>, <var>is</var>,


### PR DESCRIPTION
createElement/createElementNS disallowed upgrading of customized
built-in elements, incorrectly. Instead we should allow { is } to be
supplied and even if there is no corresponding definition now, it will
be upgraded later.

Fixes https://github.com/w3c/webcomponents/issues/608.