### PR TITLE
Copy the origin pointer when cloning a document

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3950,10 +3950,9 @@ dom-Range-extractContents, dom-Range-cloneContents -->
 
   <dl class=switch>
    <dt>{{Document}}
-   <dd>
-    <p>Set <var>copy</var>'s <a for=Document>encoding</a>,
-    <a for=Document>content type</a>, <a for=Document>URL</a>, <a for=Document>type</a>,
-    and <a for=Document>mode</a>, to those of <var>node</var>.
+   <dd><p>Set <var>copy</var>'s <a for=Document>encoding</a>, <a for=Document>content type</a>,
+   <a for=Document>URL</a>, <a for=Document>origin</a>, <a for=Document>type</a>, and
+   <a for=Document>mode</a>, to those of <var>node</var>.
 
    <dt>{{DocumentType}}
    <dd><p>Set <var>copy</var>'s <a for=DocumentType>name</a>, <a>public ID</a>, and


### PR DESCRIPTION
Fixes #378.

Tests: https://github.com/w3c/web-platform-tests/issues/4268.