### PR TITLE
Reset dispatching flags when retargeting to a different target than event's

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1175,7 +1175,8 @@ for discussion).
  non-null, and null otherwise.
 
  <li><p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not
- <var>event</var>'s <a>relatedTarget</a>, then return true.
+ <var>event</var>'s <a>relatedTarget</a>, then unset <var>event</var>'s <a>dispatch flag</a>,
+ <a>stop propagation flag</a>, and <a>stop immediate propagation flag</a> and return true.
 
  <li><p>Append (<var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>) to
  <var>event</var>'s <a for=Event>path</a>.


### PR DESCRIPTION
This repeats step 14 in step 4's shortcut of dispatching an event.