### PR TITLE
Make all parameters to initEvent() / initCustomEvent() optional excep…

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -524,7 +524,7 @@ interface Event {
   [Unforgeable] readonly attribute boolean isTrusted;
   readonly attribute DOMTimeStamp timeStamp;
 
-  void initEvent(DOMString type, boolean bubbles, boolean cancelable); // historical
+  void initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false); // historical
 };
 
 dictionary EventInit {
@@ -817,7 +817,7 @@ incapable of setting {{Event/composed}}. It has to be supported for legacy conte
 interface CustomEvent : Event {
   readonly attribute any detail;
 
-  void initCustomEvent(DOMString type, boolean bubbles, boolean cancelable, any detail);
+  void initCustomEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null);
 };
 
 dictionary CustomEventInit : EventInit {


### PR DESCRIPTION
…t the first

Make all parameters to initEvent() / initCustomEvent() optional except the first.
This aligns the specification with WebKit and gets it closer to Blink.

This closes issue #387.