### PR TITLE
Remove no-op range mutations from split a Text node

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -7053,27 +7053,6 @@ To <dfn export id=concept-text-split lt="split a Text node">split</dfn> a {{Text
  <var>node</var>, offset <var>offset</var>, count
  <var>count</var>, and data the empty string.
 
- <li>
-  If <var>parent</var> is null, run these substeps:
-
-  <ol>
-   <li>For each <a>range</a> whose
-   <a for=Range>start node</a> is
-   <var>node</var> and
-   <a>start offset</a> is greater
-   than <var>offset</var>, set its
-   <a>start offset</a> to
-   <var>offset</var>.
-
-   <li>For each <a>range</a> whose
-   <a for=Range>end node</a> is
-   <var>node</var> and
-   <a>end offset</a> is greater than
-   <var>offset</var>, set its
-   <a>end offset</a> to
-   <var>offset</var>.
-  </ol>
-
  <li>Return <var>new node</var>.
 </ol>
 


### PR DESCRIPTION
Per https://github.com/w3c/web-platform-tests/issues/2499#issuecomment-172901580 this step is redundant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/annevk/no-op-range-mutations/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/2358735...653fc60.html)