### PR TITLE
Update Event.timeStamp type to DOMHighResTimeStamp.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5177,7 +5177,7 @@ invoked, must run these steps:
 
  <li><p>Unset <var>event</var>'s <a>initialized flag</a>.
 
- <li><p>Return <var>event</var>.
+ <li><p>Return <var>event</var>.`
 </ol>
 
 <p class=note><a>Event</a> constructors ought to be used instead.
@@ -9850,6 +9850,7 @@ Kirill Topolyan,
 Koji Ishii,
 Lachlan Hunt,
 Lauren Wood,
+Majid Valipour,
 Malte Ubl,
 Manish Goregaokar,
 Manish Tripathi,

--- a/dom.bs
+++ b/dom.bs
@@ -633,8 +633,8 @@ algorithm below.
  false otherwise.
 
  <dt><code><var>event</var> . {{Event/timeStamp}}</code>
- <dd>Returns the <var>event</var>'s timestamp as the number of milliseconds measured relative
- from the <a>time origin</a>.
+ <dd>Returns the <var>event</var>'s timestamp as the number of milliseconds measured relative to
+ the <a>time origin</a>.
 </dl>
 
 The <dfn attribute for=Event><code>type</code></dfn> attribute must
@@ -767,12 +767,10 @@ the user agent to dispatch an <a>event</a> whose {{Event/isTrusted}} attribute i
 false.
 
 The <dfn attribute for=Event><code>timeStamp</code></dfn> attribute must return the value it was
-initialized to. When an <a>event</a> is created the attribute must be initialized with a
-{{DOMHighResTimeStamp}} representing the high resolution time in milliseconds that has passed
-since the <a>time origin</a>.
+initialized to.
 
 <p class=warning> User agents are strongly encouraged to set minimum resolution of the
-{{Event/timeStamp}} attribute to 5 microseconds following existing <a>clock resolution</a>
+{{Event/timeStamp}} attribute to 5 microseconds following the existing <a>clock resolution</a>
 recommendation. [[!HR-TIME]]
 
 <hr>
@@ -880,8 +878,8 @@ must be run, given the arguments <var>type</var> and <var>eventInitDict</var>:
  <li><p>Initialize <var>event</var>'s {{Event/type}} attribute to <var>type</var>.
 
  <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
- representing the <var>event</var>'s <dfn>construction time</dfn> which is the high resolution
- time from the <a>time origin</a> to the occurrence of the call to the <a>constructor</a>.
+ representing the high resolution time from the <a>time origin</a> to the occurrence of the call
+ to the <var>event</var>'s <a>constructor</a>.
 
  <li><p>For each <a>dictionary member</a> present in <var>eventInitDict</var>, find the attribute on
  <var>event</var> whose <a spec=webidl>identifier</a> matches the key of the
@@ -915,13 +913,15 @@ it, and optionally given a <a>Realm</a> <var>realm</var>, run these steps:</p>
  <a>dictionary member</a> and then set the attribute to the default value of that
  <a>dictionary member</a>.
 
- <li><p>If available, set <var>event</var>'s {{Event/timeStamp}} attribute to a
- {{DOMHighResTimeStamp}} representing the <var>event</var>'s <dfn>occurence time</dfn> which is
- the high resolution time from the <a>time origin</a> to the occurrence that the event is
- signaling, for example the moment when a particular user interaction occurred.
+ <li><p>Set <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
+ representing the high resolution time from the <a>time origin</a> to the occurrence that the
+ event is signaling.
 
- <p class=note>User agents are encouraged to make the high resolution occurrence time available
- for as many events as possible, in particular those related to user interaction.
+ <p class=note>For example, in macOs the occurrence time for input actions are available via the
+ timestamp property of corresponding <code>NSEvent</code> objects. So in this case, the
+ {{Event/timeStamp}} value should be equivalent to the <code>NSEvent</code>'s timestamp offset by
+ <a>time origin</a>, translated in milliseconds, and with its precision adjusted to meet the
+ recommended minimum <a>clock resolution</a>.
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to true.
 
@@ -5173,7 +5173,6 @@ invoked, must run these steps:
  <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
  which is the high resolution time from the <a>time origin</a> to the occurrence of the call to
  {{Document/createEvent()}}.
-
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to false.
 

--- a/dom.bs
+++ b/dom.bs
@@ -5177,7 +5177,7 @@ invoked, must run these steps:
 
  <li><p>Unset <var>event</var>'s <a>initialized flag</a>.
 
- <li><p>Return <var>event</var>.`
+ <li><p>Return <var>event</var>.
 </ol>
 
 <p class=note><a>Event</a> constructors ought to be used instead.

--- a/dom.bs
+++ b/dom.bs
@@ -917,7 +917,7 @@ it, and optionally given a <a>Realm</a> <var>realm</var>, run these steps:</p>
  representing the high resolution time from the <a>time origin</a> to the occurrence that the
  event is signaling.
 
- <p class=note>For example, in macOs the occurrence time for input actions are available via the
+ <p class=note>For example, in macOS the occurrence time for input actions are available via the
  timestamp property of corresponding <code>NSEvent</code> objects. So in this case, the
  {{Event/timeStamp}} value should be equivalent to the <code>NSEvent</code>'s timestamp offset by
  <a>time origin</a>, translated in milliseconds, and with its precision adjusted to meet the
@@ -5171,8 +5171,7 @@ invoked, must run these steps:
  <li><p>Initialize <var>event</var>'s {{Event/type}} attribute to the empty string.
 
  <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
- which is the high resolution time from the <a>time origin</a> to the occurrence of the call to
- {{Document/createEvent()}}.
+ representing the high resolution time from the <a>time origin</a> to now.
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to false.
 

--- a/dom.bs
+++ b/dom.bs
@@ -70,6 +70,9 @@ urlPrefix: https://w3c.github.io/ServiceWorker/#; spec: SERVICE-WORKERS
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: Construct; url: sec-construct; type: abstract-op
     text: Realm; url: realm; type: dfn
+urlPrefix: https://w3c.github.io/hr-time/#
+    type:typedef; urlPrefix: dom-; text: DOMHighResTimeStamp
+    type:dfn; text: time origin
 </pre>
 
 <pre class='link-defaults'>
@@ -522,7 +525,7 @@ interface Event {
   readonly attribute boolean composed;
 
   [Unforgeable] readonly attribute boolean isTrusted;
-  readonly attribute DOMTimeStamp timeStamp;
+  readonly attribute DOMHighResTimeStamp timeStamp;
 
   void initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false); // historical
 };
@@ -628,8 +631,8 @@ algorithm below.
  false otherwise.
 
  <dt><code><var>event</var> . {{Event/timeStamp}}</code>
- <dd>Returns the creation time of <var>event</var> as the number of milliseconds that
- passed since 00:00:00 UTC on 1 January 1970.
+ <dd>Returns the <var>event</var>'s timestamp as the number of milliseconds measured relative
+ from the <a>time origin</a>.
 </dl>
 
 The <dfn attribute for=Event><code>type</code></dfn> attribute must
@@ -761,15 +764,14 @@ initialized to false.
 the user agent to dispatch an <a>event</a> whose {{Event/isTrusted}} attribute is initialized to
 false.
 
-The <dfn attribute for=Event><code>timeStamp</code></dfn> attribute
-must return the value it was initialized to. When an
-<a>event</a> is created the attribute must be
-initialized to the number of milliseconds that have passed since
-00:00:00 UTC on 1 January 1970, ignoring leap seconds.
-<!-- leap seconds are ignored by JavaScript too -->
+The <dfn attribute for=Event><code>timeStamp</code></dfn> attribute must return the value it was
+initialized to. If available, the attribute should be initialized with the high resolution time of
+the occurrence that the event is signaling, for example the moment when a particular user
+interaction occurred. Otherwise it should be initialized with the time representing the creation
+time of the <var>event</var>.
 
-<p class=XXX>This is highly likely to change and already does not reflect implementations well.
-Please see <a href=https://github.com/whatwg/dom/issues/23>dom #23</a> for more details.
+<p class=note>User agents are encouraged to make the high resolution time occurrence time
+available for as many events as possible in particular those related to user interaction.
 
 <hr>
 
@@ -9569,6 +9571,9 @@ other chapters are defined by the <cite>UI Events</cite> specification.
  <li>The propagation and canceled flags are unset when invoking
  {{Event/initEvent()}} rather than after
  dispatch.
+ <li>{{Event/timeStamp}} is no longer a {{DOMTimeStamp}} representing creation time of event as
+ the number of milliseconds that passed since 00:00:00 UTC on 1 January 1970, but instead a
+ {{DOMHighResTimeStamp}}.
 </ul>
 
 

--- a/dom.bs
+++ b/dom.bs
@@ -70,9 +70,11 @@ urlPrefix: https://w3c.github.io/ServiceWorker/#; spec: SERVICE-WORKERS
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: Construct; url: sec-construct; type: abstract-op
     text: Realm; url: realm; type: dfn
-urlPrefix: https://w3c.github.io/hr-time/#
+urlPrefix: https://w3c.github.io/hr-time/#; spec: HR-TIME
     type:typedef; urlPrefix: dom-; text: DOMHighResTimeStamp
     type:dfn; text: time origin
+    type:dfn; text: clock resolution
+
 </pre>
 
 <pre class='link-defaults'>
@@ -765,13 +767,13 @@ the user agent to dispatch an <a>event</a> whose {{Event/isTrusted}} attribute i
 false.
 
 The <dfn attribute for=Event><code>timeStamp</code></dfn> attribute must return the value it was
-initialized to. If available, the attribute should be initialized with the high resolution time of
-the occurrence that the event is signaling, for example the moment when a particular user
-interaction occurred. Otherwise it should be initialized with the creation time of the
-<var>event</var>.
+initialized to. When an <a>event</a> is created the attribute must be initialized with a
+{{DOMHighResTimeStamp}} representing the high resolution time in milliseconds that has passed
+since the <a>time origin</a>.
 
-<p class=note>User agents are encouraged to make the high resolution occurrence time available
-for as many events as possible, in particular those related to user interaction.
+<p class=warning> User agents are strongly encouraged to set minimum resolution of the
+{{Event/timeStamp}} attribute to 5 microseconds following existing <a>clock resolution</a>
+recommendation. [[!HR-TIME]]
 
 <hr>
 
@@ -877,6 +879,10 @@ must be run, given the arguments <var>type</var> and <var>eventInitDict</var>:
 
  <li><p>Initialize <var>event</var>'s {{Event/type}} attribute to <var>type</var>.
 
+ <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
+ representing the <var>event</var>'s <dfn>construction time</dfn> which is the high resolution
+ time from the <a>time origin</a> to the occurrence of the call to the <a>constructor</a>.
+
  <li><p>For each <a>dictionary member</a> present in <var>eventInitDict</var>, find the attribute on
  <var>event</var> whose <a spec=webidl>identifier</a> matches the key of the
  <a>dictionary member</a> and then set the attribute to the value of that <a>dictionary member</a>.
@@ -908,6 +914,14 @@ it, and optionally given a <a>Realm</a> <var>realm</var>, run these steps:</p>
  attribute on <var>event</var> whose <a spec=webidl>identifier</a> matches the key of the
  <a>dictionary member</a> and then set the attribute to the default value of that
  <a>dictionary member</a>.
+
+ <li><p>If available, set <var>event</var>'s {{Event/timeStamp}} attribute to a
+ {{DOMHighResTimeStamp}} representing the <var>event</var>'s <dfn>occurence time</dfn> which is
+ the high resolution time from the <a>time origin</a> to the occurrence that the event is
+ signaling, for example the moment when a particular user interaction occurred.
+
+ <p class=note>User agents are encouraged to make the high resolution occurrence time available
+ for as many events as possible, in particular those related to user interaction.
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to true.
 
@@ -5155,6 +5169,11 @@ invoked, must run these steps:
  <li><p>Let <var>event</var> be the result of <a>creating an event</a> given <var>constructor</var>.
 
  <li><p>Initialize <var>event</var>'s {{Event/type}} attribute to the empty string.
+
+ <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
+ which is the high resolution time from the <a>time origin</a> to the occurrence of the call to
+ {{Document/createEvent()}}.
+
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to false.
 

--- a/dom.bs
+++ b/dom.bs
@@ -767,11 +767,11 @@ false.
 The <dfn attribute for=Event><code>timeStamp</code></dfn> attribute must return the value it was
 initialized to. If available, the attribute should be initialized with the high resolution time of
 the occurrence that the event is signaling, for example the moment when a particular user
-interaction occurred. Otherwise it should be initialized with the time representing the creation
-time of the <var>event</var>.
+interaction occurred. Otherwise it should be initialized with the creation time of the
+<var>event</var>.
 
-<p class=note>User agents are encouraged to make the high resolution time occurrence time
-available for as many events as possible in particular those related to user interaction.
+<p class=note>User agents are encouraged to make the high resolution occurrence time available
+for as many events as possible, in particular those related to user interaction.
 
 <hr>
 


### PR DESCRIPTION
Update Event.timeStamp type to DOMHighResTimeStamp.

This fixes #23 and the commit contains the following changes:
- The text asks for the high resolution time of the event occurrence time to be used when
available and otherwise event object creation time.
- Add note in legacy section describing the change in semantic.
- Add note encouraging user agents to make high res time available for UI Events.
- Add necessary spec reference for Bikeshed to pick up new definitions in hr-time spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/majido/dom/high-res-timestamp.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/334428f...majido:3f9f333.html)