### PR TITLE
No longer support ProgressEvent in createEvent()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5128,7 +5128,6 @@ invoked, must run these steps:
     <tr><td>"<code>mouseevents</code>"
     <tr><td>"<code>pagetransitionevent</code>"<td>{{PageTransitionEvent}}<td rowspan=2>[[!HTML]]
     <tr><td>"<code>popstateevent</code>"<td>{{PopStateEvent}}
-    <tr><td>"<code>progressevent</code>"<td>{{ProgressEvent}}<td>[[!XHR]]
     <tr><td>"<code>storageevent</code>"<td>{{StorageEvent}}<td>[[!HTML]]
     <tr><td>"<code>svgevents</code>"<td>{{Event}}<td>
     <tr><td>"<code>textevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]


### PR DESCRIPTION
Tests: https://github.com/w3c/web-platform-tests/pull/5158.

Fixes #289.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/annevk/progressevent/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/334428f...41eb09c.html)