### PR TITLE
Use Web IDL to construct custom element constructors

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5666,7 +5666,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <li><p>Let <var>C</var> be <var>definition</var>'s
      <a for="custom element definition">constructor</a>.
 
-     <li><p>Set <var>result</var> to <a abstract-op>Construct</a>(<var>C</var>).
+     <li><p>Set <var>result</var> to the result of <a>constructing</a> <var>C</var>, with no
+     arguments.
 
      <li>
       <p>If <var>result</var> does not implement the {{HTMLElement}} interface, then <a>throw</a> a
@@ -9728,6 +9729,7 @@ Dominic Cooney,
 Dominique Hazaël-Massieux,
 Don Jordan,
 Doug Schepers,
+Edgar Chen,
 Elisée Maurer,
 Elliott Sprehn,
 Eric Bidelman,
@@ -9794,6 +9796,7 @@ Robbert Broersma,
 Robin Berjon,
 Roland Steiner,
 Rune <span title=Fabulous>F.</span> Halvorsen,
+Russell Bicknell,
 Ruud Steltenpool,
 Ryosuke Niwa,
 Sam Dutton,


### PR DESCRIPTION
Fixes part of https://github.com/whatwg/html/issues/2381. The other
part is covered by https://github.com/whatwg/html/pull/2457.

Cannot be merged until https://github.com/heycam/webidl/pull/328 is also merged and the cross-spec linking database has been populated.

Tests: https://github.com/w3c/web-platform-tests/pull/5208


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/custom-element-construct/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/6253e53...ddeaa7f.html)