### PR TITLE
Define a 'CancelationController' and 'CancelationSignal' interface.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1478,7 +1478,8 @@ steps:
 <ol>
  <li>Let <var>signal</var> be this object's {{PromiseController/signal}}.
  <li>Set <var>signal</var>'s [=PromiseSignal/aborted flag=].
- <li>[=Fire an event=] named <code>abort</code> at <var>signal</var>.</li>
+ <li>[=Fire an event=] named <code>abort</code> at <var>signal</var>.
+ <li>Run <var>signal</var>'s [=PromiseSignal/abort steps=].
 </ol>
 
 <h4 id=interface-cancellationcontroller>Interface {{PromiseSignal}}</h4>
@@ -1498,6 +1499,15 @@ interface PromiseSignal : EventTarget {
 
 Each {{PromiseSignal}} has an <dfn for=PromiseSignal>aborted flag</dfn> which is unset unless
 otherwise specified.
+
+Each {{PromiseSignal}} has an <dfn for=PromiseSignal>abort steps</dfn> algorithm which is
+executed when its [=PromiseSignal/aborted flag=] is set. Unless otherwise specified, this
+algorithm is a no-op.
+
+<p class="note no-backref">The [=PromiseSignal/abort steps=] algorithm enables APIs with more
+complex requirements to react in a reasonable way to {{PromiseController/abort()}}. For example,
+a given API's [=PromiseSignal/aborted flag=] may need to be propagated to a cross-thread
+environment (like a Service Worker).
 
 The <dfn attribute for=PromiseSignal>aborted</dfn> attribute's getter must return true if the
 object's [=PromiseSignal/aborted flag=] is set, and false otherwise.

--- a/dom.bs
+++ b/dom.bs
@@ -55,6 +55,10 @@ urlPrefix: https://w3c.github.io/ServiceWorker/#; spec: SERVICE-WORKERS
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: Construct; url: sec-construct; type: abstract-op
     text: Realm; url: realm; type: dfn
+
+<!-- Remove this once WebIDL takes https://github.com/heycam/webidl/pull/339 -->
+urlPrefix: https://heycam.github.io/webidl/; spec: WEBIDL
+    text: CancelationError; url: cancelationerror; type: exception
 </pre>
 
 <pre class=link-defaults>
@@ -1428,8 +1432,8 @@ corresponding {{CancelationSignal}} object. The API which wishes to support canc
 such a {{CancelationSignal}}, and use its state to determine how (not) to proceed.
 
 APIs that rely upon {{CancelationController}} are encouraged to respond to
-{{CancelationController/cancel()}} by rejecting any unsettled {{Promise}} with a
-<dfn exception>CancelationError</dfn> exception.
+{{CancelationController/cancel()}} by rejecting any unsettled {{Promise}} with a new
+{{DOMException}} with [=error name=] "{{CancelationError}}".
 
 <div class=note>
  For example, a hypothetical <code>doAmazingness({ ... })</code> method could accept a

--- a/dom.bs
+++ b/dom.bs
@@ -564,7 +564,7 @@ algorithm below.
  the operation that caused <var>event</var> to be <a>dispatched</a> that it needs to be canceled.
 
  <dt><code><var>event</var> . {{Event/defaultPrevented}}</code>
- <dd>Returns true if {{Event/preventDefault()}} was invoked successfully to indicate cancellation,
+ <dd>Returns true if {{Event/preventDefault()}} was invoked successfully to indicate cancelation,
  and false otherwise.
 
  <dt><code><var>event</var> . {{Event/composed}}</code>
@@ -1421,22 +1421,22 @@ can only be used to influence an ongoing one.
 
 <h2 id=canceling-ongoing-activities>Canceling Ongoing Activities</h3>
 
-Though {{Promise}} objects don't have any built-in cancellation mechanism, many APIs using these
-concepts require cancellation semantics. {{CancellationController}} is meant to support these
-requirements by providing an {{CancellationController/cancel()}} method that toggles the state of a
-corresponding {{CancellationSignal}} object. The API which wishes to support cancellation can accept
-such a {{CancellationSignal}}, and use its state to determine how (not) to proceed.
+Though {{Promise}} objects don't have any built-in cancelation mechanism, many APIs using these
+concepts require cancelation semantics. {{CancelationController}} is meant to support these
+requirements by providing an {{CancelationController/cancel()}} method that toggles the state of a
+corresponding {{CancelationSignal}} object. The API which wishes to support cancelation can accept
+such a {{CancelationSignal}}, and use its state to determine how (not) to proceed.
 
-APIs that rely upon {{CancellationController}} are encouraged to respond to
-{{CancellationController/cancel()}} by rejecting any unsettled {{Promise}} with a
-<dfn exception>CancellationError</dfn> exception.
+APIs that rely upon {{CancelationController}} are encouraged to respond to
+{{CancelationController/cancel()}} by rejecting any unsettled {{Promise}} with a
+<dfn exception>CancelationError</dfn> exception.
 
 <div class=note>
  For example, a hypothetical <code>doAmazingness({ ... })</code> method could accept a
- {{CancellationSignal}} object in order to support cancellation as follows:
+ {{CancelationSignal}} object in order to support cancelation as follows:
 
  <pre class=lang-javascript>
-  const controller = new CancellationController();
+  const controller = new CancelationController();
   const signal = controller.signal;
   doAmazingness({ ..., signal })
     .then(result => ...)
@@ -1447,77 +1447,77 @@ APIs that rely upon {{CancellationController}} are encouraged to respond to
   controller.cancel();
   </pre>
 
- APIs that require more granular control could extend both {{CancellationController}} and
- {{CancellationSignal}} according to their needs.
+ APIs that require more granular control could extend both {{CancelationController}} and
+ {{CancelationSignal}} according to their needs.
 </div>
 
-<h3 id=interface-cancellationcontroller>Interface {{CancellationController}}</h3>
+<h3 id=interface-cancelationcontroller>Interface {{CancelationController}}</h3>
 
 <pre class="idl">
 [Constructor(), Exposed=(Window,Worker)]
-interface CancellationController {
-  readonly attribute CancellationSignal signal;
+interface CancelationController {
+  readonly attribute CancelationSignal signal;
 
   void cancel();
 };
 </pre>
 <dl class=domintro>
- <dt><code><var>controller</var> = new <a constructor lt="CancellationController()">CancellationController</a>()</code>
- <dd>Returns a new <var>controller</var> whose {{CancellationController/signal}} is set to a newly
- created {{CancellationSignal}} object.
+ <dt><code><var>controller</var> = new <a constructor lt="CancelationController()">CancelationController</a>()</code>
+ <dd>Returns a new <var>controller</var> whose {{CancelationController/signal}} is set to a newly
+ created {{CancelationSignal}} object.
 
- <dt><code><var>controller</var> . </code>{{CancellationController/signal}}
- <dd>Returns the {{CancellationSignal}} object associated with this object.
+ <dt><code><var>controller</var> . </code>{{CancelationController/signal}}
+ <dd>Returns the {{CancelationSignal}} object associated with this object.
 
- <dt><code><var>controller</var> . </code>{{CancellationController/cancel()}}
- <dd>Invoking this method will set this object's {{CancellationSignal}}'s
- [=CancellationSignal/cancelled flag=], thereby signaling to any observers that the associated
- activity should be cancelled.
+ <dt><code><var>controller</var> . </code>{{CancelationController/cancel()}}
+ <dd>Invoking this method will set this object's {{CancelationSignal}}'s
+ [=CancelationSignal/canceled flag=], thereby signaling to any observers that the associated
+ activity should be canceled.
 </dl>
 
-The <dfn attribute for=CancellationController><code>signal</code></dfn> attribute must return the value
-to which it was initialized. When a {{CancellationController}} is created, the attribute must be
-initialized to a newly created {{CancellationSignal}} object.
+The <dfn attribute for=CancelationController><code>signal</code></dfn> attribute must return the value
+to which it was initialized. When a {{CancelationController}} is created, the attribute must be
+initialized to a newly created {{CancelationSignal}} object.
 
-The <dfn method for=CancellationController><code>cancel()</code></dfn> method, when invoked, must run
+The <dfn method for=CancelationController><code>cancel()</code></dfn> method, when invoked, must run
 these steps:
 
 <ol>
- <li>Let <var>signal</var> be this object's {{CancellationController/signal}}.
- <li>Set <var>signal</var>'s [=CancellationSignal/cancelled flag=].
- <li>Run <var>signal</var>'s [=CancellationSignal/cancellation steps=].
+ <li>Let <var>signal</var> be this object's {{CancelationController/signal}}.
+ <li>Set <var>signal</var>'s [=CancelationSignal/canceled flag=].
+ <li>Run <var>signal</var>'s [=CancelationSignal/cancelation steps=].
  <li>[=Fire an event=] named <code>cancel</code> at <var>signal</var>.
 </ol>
 
-<h4 id=interface-cancellationsignal>Interface {{CancellationSignal}}</h4>
+<h4 id=interface-cancelationsignal>Interface {{CancelationSignal}}</h4>
 
 <pre class="idl">
 [Exposed=(Window,Worker)]
-interface CancellationSignal : EventTarget {
-  readonly attribute boolean cancelled;
+interface CancelationSignal : EventTarget {
+  readonly attribute boolean canceled;
 
   attribute EventHandler oncancel;
 };
 </pre>
 <dl class=domintro>
- <dt><code><var>signal</var> . </code>{{CancellationSignal/cancelled}}
- <dd>Returns true if this {{CancellationSignal}} has been cancelled, and false otherwise.
+ <dt><code><var>signal</var> . </code>{{CancelationSignal/canceled}}
+ <dd>Returns true if this {{CancelationSignal}} has been canceled, and false otherwise.
 </dl>
 
-Each {{CancellationSignal}} has an <dfn for=CancellationSignal>cancelled flag</dfn> which is
+Each {{CancelationSignal}} has an <dfn for=CancelationSignal>canceled flag</dfn> which is
 unset unless otherwise specified.
 
-Each {{CancellationSignal}} has an <dfn for=CancellationSignal>cancellation steps</dfn> algorithm
-which is executed when its [=CancellationSignal/cancelled flag=] is set. Unless otherwise
+Each {{CancelationSignal}} has an <dfn for=CancelationSignal>cancelation steps</dfn> algorithm
+which is executed when its [=CancelationSignal/canceled flag=] is set. Unless otherwise
 specified, this algorithm is a no-op.
 
-<p class="note no-backref">The [=CancellationSignal/cancellation steps=] algorithm enables APIs with
-more complex requirements to react in a reasonable way to {{CancellationController/cancel()}}. For
-example, a given API's [=CancellationSignal/cancelled flag=] may need to be propagated to a
+<p class="note no-backref">The [=CancelationSignal/cancelation steps=] algorithm enables APIs with
+more complex requirements to react in a reasonable way to {{CancelationController/cancel()}}. For
+example, a given API's [=CancelationSignal/canceled flag=] may need to be propagated to a
 cross-thread environment (like a Service Worker).
 
-The <dfn attribute for=CancellationSignal>cancelled</dfn> attribute's getter must return true if the
-object's [=CancellationSignal/cancelled flag=] is set, and false otherwise.
+The <dfn attribute for=CancelationSignal>canceled</dfn> attribute's getter must return true if the
+object's [=CancelationSignal/canceled flag=] is set, and false otherwise.
 
 
 

--- a/dom.bs
+++ b/dom.bs
@@ -1419,6 +1419,88 @@ that gave folks all the wrong ideas. <a>Events</a> do not represent or cause act
 can only be used to influence an ongoing one.
 
 
+<h3 id=controlling-promises>Controlling {{Promise}}s</h3>
+
+<p>Though {{Promise}} objects don't have any built-in cancellation mechanism, many
+{{Promise}}-vending APIs require cancellation semantics. {{PromiseController}} is meant to support
+these requirements by providing an {{PromiseController/abort()}} method that toggles the state of
+a corresponding {{PromiseSignal}} object. The API which wishes to support cancelation can accept
+such a {{PromiseSignal}}, and use its state to determine how (not) to proceed.
+
+<div class=note>
+  For example, a hypothetical <code>DoAmazingness({ ... })</code> method could accept a
+  {{PromiseSignal}} object in order to support cancellation as follows:
+
+  <pre class=lang-javascript>
+    const controller = new PromiseController();
+    const signal = controller.signal;
+    DoAmazingness({ ..., signal }).then(result => ...);
+
+    ...
+
+    controller.abort();
+  </pre>
+
+  APIs that require more granular control could extend both {{PromiseController}} and
+  {{PromiseSignal}} according to their needs.
+</div>
+
+<h4 id=interface-promisecontroller>Interface {{PromiseController}}</h3>
+
+<pre class="idl">
+[Constructor(), Exposed=(Window,Worker)]
+interface PromiseController {
+  readonly attribute PromiseSignal signal;
+
+  void abort();
+};
+</pre>
+<dl class=domintro>
+ <dt><code><var>controller</var> = new <a constructor lt="PromiseController()">PromiseController</a>()</code>
+ <dd>Returns a new <var>controller</var> whose {{PromiseController/signal}} attribute value is set
+ to a newly created {{PromiseSignal}} object.
+
+ <dt><code><var>controller</var> . </code>{{PromiseController/signal}}
+ <dd>Returns the {{PromiseSignal}} object associated with this object.
+
+ <dt><code><var>controller</var> . </code>{{PromiseController/abort()}}
+ <dd>Invoking this method will set this object's {{PromiseSignal}}'s [=PromiseSignal/aborted flag=],
+ thereby signaling to any observers that the associated activity should be aborted.
+</dl>
+
+The <dfn attribute for=PromiseController>signal</dfn> attribute must return the value to which it
+was initialized. When a {{PromiseController}} is created, the attribute must be initialized to a
+newly created {{PromiseSignal}} object.
+
+The <dfn method for=PromiseController><code>abort()</code></dfn>, when invoked, must run these
+steps:
+
+<ol>
+ <li>Let <var>signal</var> be this object's {{PromiseController/signal}}.
+ <li>Set <var>signal</var>'s [=PromiseSignal/aborted flag=].
+ <li>[=Fire an event=] named <code>abort</code> at <var>signal</var>.</li>
+</ol>
+
+<h4 id=interface-cancellationcontroller>Interface {{PromiseSignal}}</h4>
+
+<pre class="idl">
+[Exposed=(Window,Worker)]
+interface PromiseSignal : EventTarget {
+  readonly attribute boolean aborted;
+
+  attribute EventHandler onabort;
+};
+</pre>
+<dl class=domintro>
+ <dt><code><var>signal</var> . </code>{{PromiseSignal/aborted}}
+ <dd>Returns true if this {{PromiseSignal}} has been aborted, and false otherwise.
+</dl>
+
+Each {{PromiseSignal}} has an <dfn for=PromiseSignal>aborted flag</dfn> which is unset unless
+otherwise specified.
+
+The <dfn attribute for=PromiseSignal>aborted</dfn> attribute's getter must return true if the
+object's [=PromiseSignal/aborted flag=] is set, and false otherwise.
 
 <h2 id=nodes>Nodes</h2>
 

--- a/dom.bs
+++ b/dom.bs
@@ -1483,8 +1483,8 @@ steps:
 <ol>
  <li>Let <var>signal</var> be this object's {{PromiseController/signal}}.
  <li>Set <var>signal</var>'s [=PromiseSignal/aborted flag=].
- <li>[=Fire an event=] named <code>abort</code> at <var>signal</var>.
  <li>Run <var>signal</var>'s [=PromiseSignal/abort steps=].
+ <li>[=Fire an event=] named <code>abort</code> at <var>signal</var>.
 </ol>
 
 <h4 id=interface-cancellationcontroller>Interface {{PromiseSignal}}</h4>

--- a/dom.bs
+++ b/dom.bs
@@ -1485,7 +1485,14 @@ these steps:
 <ol>
  <li>Let <var>signal</var> be this object's {{CancelationController/signal}}.
  <li>Set <var>signal</var>'s [=CancelationSignal/canceled flag=].
- <li>Run <var>signal</var>'s [=CancelationSignal/cancelation steps=].
+ <li>
+  <p>For each <var>algorithm</var> in <var>signal</var>'s
+  [=CancelationSignal/cancelation callbacks=]:</p>
+
+  <ol>
+   <li>Run <var>algorithm</var>.
+  </ol>
+ </li>
  <li>[=Fire an event=] named <code>cancel</code> at <var>signal</var>.
 </ol>
 
@@ -1507,14 +1514,14 @@ interface CancelationSignal : EventTarget {
 Each {{CancelationSignal}} has an <dfn for=CancelationSignal>canceled flag</dfn> which is
 unset unless otherwise specified.
 
-Each {{CancelationSignal}} has an <dfn for=CancelationSignal>cancelation steps</dfn> algorithm
-which is executed when its [=CancelationSignal/canceled flag=] is set. Unless otherwise
-specified, this algorithm is a no-op.
+Each {{CancelationSignal}} has a <dfn for=CancelationSignal>cancelation callbacks</dfn>, which is
+an [=ordered set=] of algorithms which are to be executed when its
+[=CancelationSignal/canceled flag=] is set. Unless otherwise specified, its value is the empty set.
 
-<p class="note no-backref">The [=CancelationSignal/cancelation steps=] algorithm enables APIs with
-more complex requirements to react in a reasonable way to {{CancelationController/cancel()}}. For
-example, a given API's [=CancelationSignal/canceled flag=] may need to be propagated to a
-cross-thread environment (like a Service Worker).
+<p class="note no-backref">The [=CancelationSignal/cancelation callbacks=] enable APIs with complex
+requirements to react in a reasonable way to {{CancelationController/cancel()}}. For example, a
+given API's [=CancelationSignal/canceled flag=] may need to be propagated to a cross-thread
+environment (like a Service Worker).
 
 The <dfn attribute for=CancelationSignal>canceled</dfn> attribute's getter must return true if the
 object's [=CancelationSignal/canceled flag=] is set, and false otherwise.

--- a/dom.bs
+++ b/dom.bs
@@ -685,7 +685,7 @@ The <dfn attribute for=Event><code>bubbles</code></dfn> and
 must return the values they were initialized to.
 
 The <dfn method for=Event><code>preventDefault()</code></dfn> method, when invoked, must set the
-<a>canceled flag</a> if the {{Event/cancelable}} attribute value is true and the
+[=Event/canceled flag=] if the {{Event/cancelable}} attribute value is true and the
 <a>in passive listener flag</a> is unset.
 
 <p class="note no-backref">This means there are scenarios where invoking {{Event/preventDefault()}}
@@ -693,7 +693,7 @@ has no effect. User agents are encouraged to log the precise cause in a develope
 debugging.
 
 <p>The <dfn attribute for=Event><code>defaultPrevented</code></dfn> attribute's getter must return
-true if <a>context object</a>'s <a>canceled flag</a> is set, and false otherwise.</p>
+true if <a>context object</a>'s [=Event/canceled flag=] is set, and false otherwise.</p>
 
 <p>The <dfn attribute for=Event><code>composed</code></dfn> attribute's getter must return true if
 <a>context object</a>'s <a>composed flag</a> is set, and false otherwise.</p>
@@ -731,7 +731,7 @@ To <dfn export for=Event id=concept-event-initialize>initialize</dfn> an
  <li>Set the <a>initialized flag</a>.
  <li>Unset the <a>stop propagation flag</a>,
  <a>stop immediate propagation flag</a>, and
- <a>canceled flag</a>.
+ [=Event/canceled flag=].
  <li>Set the {{Event/isTrusted}} attribute
  to false.
  <li>Set the {{Event/target}} attribute to
@@ -1240,7 +1240,7 @@ for discussion).
   <p>If <var>activationTarget</var> is non-null, then:
 
   <ol>
-   <li><p>If <var>event</var>'s <a>canceled flag</a> is unset, then run
+   <li><p>If <var>event</var>'s [=Event/canceled flag=] is unset, then run
    <var>activationTarget</var>'s <a for=EventTarget>activation behavior</a> with <var>event</var>.
 
    <li><p>Otherwise, if <var>activationTarget</var> has
@@ -1248,7 +1248,7 @@ for discussion).
    <var>activationTarget</var>'s <a for=EventTarget>legacy-canceled-activation behavior</a>.
   </ol>
 
- <li><p>Return false if <var>event</var>'s <a>canceled flag</a> is set, and true otherwise.
+ <li><p>Return false if <var>event</var>'s [=Event/canceled flag=] is set, and true otherwise.
 </ol>
 
 <p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn> an <var>object</var> with

--- a/dom.bs
+++ b/dom.bs
@@ -1456,7 +1456,7 @@ APIs that rely upon {{CancelationController}} are encouraged to respond to
 <pre class="idl">
 [Constructor(), Exposed=(Window,Worker)]
 interface CancelationController {
-  readonly attribute CancelationSignal signal;
+  [SameObject] readonly attribute CancelationSignal signal;
 
   void cancel();
 };

--- a/dom.bs
+++ b/dom.bs
@@ -1421,28 +1421,33 @@ can only be used to influence an ongoing one.
 
 <h3 id=controlling-promises>Controlling {{Promise}}s</h3>
 
-<p>Though {{Promise}} objects don't have any built-in cancellation mechanism, many
-{{Promise}}-vending APIs require cancellation semantics. {{PromiseController}} is meant to support
-these requirements by providing an {{PromiseController/abort()}} method that toggles the state of
-a corresponding {{PromiseSignal}} object. The API which wishes to support cancelation can accept
-such a {{PromiseSignal}}, and use its state to determine how (not) to proceed.
+Though {{Promise}} objects don't have any built-in cancellation mechanism, many {{Promise}}-vending
+APIs require cancellation semantics. {{PromiseController}} is meant to support these requirements by
+providing an {{PromiseController/abort()}} method that toggles the state of a corresponding
+{{PromiseSignal}} object. The API which wishes to support cancellation can accept such a
+{{PromiseSignal}}, and use its state to determine how (not) to proceed.
+
+Upon {{PromiseController/abort()}}, the relevant {{Promise}} will reject with an
+<dfn exception>AbortError</dfn> [=simple exception=].
 
 <div class=note>
-  For example, a hypothetical <code>DoAmazingness({ ... })</code> method could accept a
-  {{PromiseSignal}} object in order to support cancellation as follows:
+ For example, a hypothetical <code>DoAmazingness({ ... })</code> method could accept a
+ {{PromiseSignal}} object in order to support cancellation as follows:
 
   <pre class=lang-javascript>
-    const controller = new PromiseController();
-    const signal = controller.signal;
-    DoAmazingness({ ..., signal }).then(result => ...);
+   const controller = new PromiseController();
+   const signal = controller.signal;
+   DoAmazingness({ ..., signal })
+     .then(result => ...)
+     .catch(e => ...);
 
-    ...
+   ...
 
-    controller.abort();
+   controller.abort();
   </pre>
 
-  APIs that require more granular control could extend both {{PromiseController}} and
-  {{PromiseSignal}} according to their needs.
+ APIs that require more granular control could extend both {{PromiseController}} and
+ {{PromiseSignal}} according to their needs.
 </div>
 
 <h4 id=interface-promisecontroller>Interface {{PromiseController}}</h3>

--- a/dom.bs
+++ b/dom.bs
@@ -1419,103 +1419,107 @@ that gave folks all the wrong ideas. <a>Events</a> do not represent or cause act
 can only be used to influence an ongoing one.
 
 
-<h3 id=controlling-promises>Controlling {{Promise}}s</h3>
+<h2 id=canceling-ongoing-activities>Canceling Ongoing Activities</h3>
 
-Though {{Promise}} objects don't have any built-in cancellation mechanism, many {{Promise}}-vending
-APIs require cancellation semantics. {{PromiseController}} is meant to support these requirements by
-providing an {{PromiseController/abort()}} method that toggles the state of a corresponding
-{{PromiseSignal}} object. The API which wishes to support cancellation can accept such a
-{{PromiseSignal}}, and use its state to determine how (not) to proceed.
+Though {{Promise}} objects don't have any built-in cancellation mechanism, many APIs using these
+concepts require cancellation semantics. {{CancellationController}} is meant to support these
+requirements by providing an {{CancellationController/cancel()}} method that toggles the state of a
+corresponding {{CancellationSignal}} object. The API which wishes to support cancellation can accept
+such a {{CancellationSignal}}, and use its state to determine how (not) to proceed.
 
-Upon {{PromiseController/abort()}}, the relevant {{Promise}} will reject with an
-<dfn exception>AbortError</dfn> [=simple exception=].
+APIs that rely upon {{CancellationController}} are encouraged to respond to
+{{CancellationController/cancel()}} by rejecting any unsettled {{Promise}} with a
+<dfn exception>CancellationError</dfn> exception.
 
 <div class=note>
- For example, a hypothetical <code>DoAmazingness({ ... })</code> method could accept a
- {{PromiseSignal}} object in order to support cancellation as follows:
+ For example, a hypothetical <code>doAmazingness({ ... })</code> method could accept a
+ {{CancellationSignal}} object in order to support cancellation as follows:
 
-  <pre class=lang-javascript>
-   const controller = new PromiseController();
-   const signal = controller.signal;
-   DoAmazingness({ ..., signal })
-     .then(result => ...)
-     .catch(e => ...);
+ <pre class=lang-javascript>
+  const controller = new CancellationController();
+  const signal = controller.signal;
+  doAmazingness({ ..., signal })
+    .then(result => ...)
+    .catch(e => ...);
 
-   ...
+  ...
 
-   controller.abort();
+  controller.cancel();
   </pre>
 
- APIs that require more granular control could extend both {{PromiseController}} and
- {{PromiseSignal}} according to their needs.
+ APIs that require more granular control could extend both {{CancellationController}} and
+ {{CancellationSignal}} according to their needs.
 </div>
 
-<h4 id=interface-promisecontroller>Interface {{PromiseController}}</h3>
+<h3 id=interface-cancellationcontroller>Interface {{CancellationController}}</h3>
 
 <pre class="idl">
 [Constructor(), Exposed=(Window,Worker)]
-interface PromiseController {
-  readonly attribute PromiseSignal signal;
+interface CancellationController {
+  readonly attribute CancellationSignal signal;
 
-  void abort();
+  void cancel();
 };
 </pre>
 <dl class=domintro>
- <dt><code><var>controller</var> = new <a constructor lt="PromiseController()">PromiseController</a>()</code>
- <dd>Returns a new <var>controller</var> whose {{PromiseController/signal}} attribute value is set
- to a newly created {{PromiseSignal}} object.
+ <dt><code><var>controller</var> = new <a constructor lt="CancellationController()">CancellationController</a>()</code>
+ <dd>Returns a new <var>controller</var> whose {{CancellationController/signal}} is set to a newly
+ created {{CancellationSignal}} object.
 
- <dt><code><var>controller</var> . </code>{{PromiseController/signal}}
- <dd>Returns the {{PromiseSignal}} object associated with this object.
+ <dt><code><var>controller</var> . </code>{{CancellationController/signal}}
+ <dd>Returns the {{CancellationSignal}} object associated with this object.
 
- <dt><code><var>controller</var> . </code>{{PromiseController/abort()}}
- <dd>Invoking this method will set this object's {{PromiseSignal}}'s [=PromiseSignal/aborted flag=],
- thereby signaling to any observers that the associated activity should be aborted.
+ <dt><code><var>controller</var> . </code>{{CancellationController/cancel()}}
+ <dd>Invoking this method will set this object's {{CancellationSignal}}'s
+ [=CancellationSignal/cancelled flag=], thereby signaling to any observers that the associated
+ activity should be cancelled.
 </dl>
 
-The <dfn attribute for=PromiseController>signal</dfn> attribute must return the value to which it
-was initialized. When a {{PromiseController}} is created, the attribute must be initialized to a
-newly created {{PromiseSignal}} object.
+The <dfn attribute for=CancellationController><code>signal</code></dfn> attribute must return the value
+to which it was initialized. When a {{CancellationController}} is created, the attribute must be
+initialized to a newly created {{CancellationSignal}} object.
 
-The <dfn method for=PromiseController><code>abort()</code></dfn>, when invoked, must run these
-steps:
+The <dfn method for=CancellationController><code>cancel()</code></dfn> method, when invoked, must run
+these steps:
 
 <ol>
- <li>Let <var>signal</var> be this object's {{PromiseController/signal}}.
- <li>Set <var>signal</var>'s [=PromiseSignal/aborted flag=].
- <li>Run <var>signal</var>'s [=PromiseSignal/abort steps=].
- <li>[=Fire an event=] named <code>abort</code> at <var>signal</var>.
+ <li>Let <var>signal</var> be this object's {{CancellationController/signal}}.
+ <li>Set <var>signal</var>'s [=CancellationSignal/cancelled flag=].
+ <li>Run <var>signal</var>'s [=CancellationSignal/cancellation steps=].
+ <li>[=Fire an event=] named <code>cancel</code> at <var>signal</var>.
 </ol>
 
-<h4 id=interface-cancellationcontroller>Interface {{PromiseSignal}}</h4>
+<h4 id=interface-cancellationsignal>Interface {{CancellationSignal}}</h4>
 
 <pre class="idl">
 [Exposed=(Window,Worker)]
-interface PromiseSignal : EventTarget {
-  readonly attribute boolean aborted;
+interface CancellationSignal : EventTarget {
+  readonly attribute boolean cancelled;
 
-  attribute EventHandler onabort;
+  attribute EventHandler oncancel;
 };
 </pre>
 <dl class=domintro>
- <dt><code><var>signal</var> . </code>{{PromiseSignal/aborted}}
- <dd>Returns true if this {{PromiseSignal}} has been aborted, and false otherwise.
+ <dt><code><var>signal</var> . </code>{{CancellationSignal/cancelled}}
+ <dd>Returns true if this {{CancellationSignal}} has been cancelled, and false otherwise.
 </dl>
 
-Each {{PromiseSignal}} has an <dfn for=PromiseSignal>aborted flag</dfn> which is unset unless
-otherwise specified.
+Each {{CancellationSignal}} has an <dfn for=CancellationSignal>cancelled flag</dfn> which is
+unset unless otherwise specified.
 
-Each {{PromiseSignal}} has an <dfn for=PromiseSignal>abort steps</dfn> algorithm which is
-executed when its [=PromiseSignal/aborted flag=] is set. Unless otherwise specified, this
-algorithm is a no-op.
+Each {{CancellationSignal}} has an <dfn for=CancellationSignal>cancellation steps</dfn> algorithm
+which is executed when its [=CancellationSignal/cancelled flag=] is set. Unless otherwise
+specified, this algorithm is a no-op.
 
-<p class="note no-backref">The [=PromiseSignal/abort steps=] algorithm enables APIs with more
-complex requirements to react in a reasonable way to {{PromiseController/abort()}}. For example,
-a given API's [=PromiseSignal/aborted flag=] may need to be propagated to a cross-thread
-environment (like a Service Worker).
+<p class="note no-backref">The [=CancellationSignal/cancellation steps=] algorithm enables APIs with
+more complex requirements to react in a reasonable way to {{CancellationController/cancel()}}. For
+example, a given API's [=CancellationSignal/cancelled flag=] may need to be propagated to a
+cross-thread environment (like a Service Worker).
 
-The <dfn attribute for=PromiseSignal>aborted</dfn> attribute's getter must return true if the
-object's [=PromiseSignal/aborted flag=] is set, and false otherwise.
+The <dfn attribute for=CancellationSignal>cancelled</dfn> attribute's getter must return true if the
+object's [=CancellationSignal/cancelled flag=] is set, and false otherwise.
+
+
 
 <h2 id=nodes>Nodes</h2>
 


### PR DESCRIPTION
Fetch is sketching out a cancellation mechanism in whatwg/fetch#447, and
other specifications are interested in cargo-culting their way to similar
behaviors.

To that end, this patch defines a simple interface that provides enough
control for the simple case of cancellation, while paving the way for
more complex consumers like Fetch to tack on arbitrary complexity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mikewest/dom/promisecontroller.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/6ba16e7...mikewest:4273de9.html)