### PR TITLE
Fix Web IDL extended attribute usage for recent changes

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6677,7 +6677,7 @@ string <var>value</var>, run these steps:
 <pre class=idl>
 [Exposed=Window]
 interface CharacterData : Node {
-  [TreatNullAs=EmptyString] attribute DOMString data;
+  attribute [TreatNullAs=EmptyString] DOMString data;
   readonly attribute unsigned long length;
   DOMString substringData(unsigned long offset, unsigned long count);
   void appendData(DOMString data);


### PR DESCRIPTION
In https://github.com/heycam/webidl/pull/286 we updated Web IDL so that
the extended attribute [TreatNullAs] now apply to types, not attributes.
This updates the spec's usage of [TreatNullAs] to conform to this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/treatnullas-update/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/26faf9a...899def2.html)