### PR TITLE
DOMTokernList's toggle() cannot always update the attribute

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9664,25 +9664,25 @@ method, when invoked, must run these steps:
  <li><p>If <var>token</var> contains any <a>ASCII whitespace</a>, then <a>throw</a> an
  {{InvalidCharacterError}}.
 
- <li><p>Let <var>result</var> be false.
-
  <li>
   <p>If <a>context object</a>'s <a>token set</a>[<var>token</var>] <a for=set>exists</a>, then:
 
   <ol>
    <li><p>If <var>force</var> is either not given or is false, then <a for=set>remove</a>
-   <var>token</var> from <a>context object</a>'s <a>token set</a>.
+   <var>token</var> from <a>context object</a>'s <a>token set</a>, run the <a>update steps</a> and
+   return false.
 
-   <li><p>Otherwise, set <var>result</var> to true.
+   <li><p>Otherwise, return true.
   </ol>
 
  <li><p>Otherwise, if <var>force</var> not given or is true, <a for=set>append</a> <var>token</var>
- to <a>context object</a>'s <a>token set</a> and set <var>result</var> to true.
+ to <a>context object</a>'s <a>token set</a>, run the <a>update steps</a>, and return true.
 
- <li><p>Run the <a>update steps</a>.
-
- <li><p>Return <var>result</var>.
+ <li><p>Return false.
 </ol>
+
+<p class="note no-backref">The <a>update steps</a> are not always run for {{DOMTokenList/toggle()}}
+for web compatibility.
 
 <p>The
 <dfn method for=DOMTokenList><code>replace(<var>token</var>, <var>newToken</var>)</code></dfn>

--- a/dom.bs
+++ b/dom.bs
@@ -5299,13 +5299,13 @@ invoked, must run these steps:
    <thead>
     <tr><th>String<th>Interface<td>Notes
    <tbody>
-    <tr><td>"<code>beforeunloadevent</code>"<td>{{BeforeUnloadEvent}}<td rowspan=2>[[!HTML]]
+    <tr><td>"<code>beforeunloadevent</code>"<td>{{BeforeUnloadEvent}}<td>[[!HTML]]
     <tr><td>"<code>compositionevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]
     <!-- textevent also maps to CompositionEvent -->
     <tr><td>"<code>customevent</code>"<td>{{CustomEvent}}<td>
     <tr><td>"<code>devicemotionevent</code>"<td>{{DeviceMotionEvent}}<td rowspan=2>[[!DEVICE-ORIENTATION]]
     <tr><td>"<code>deviceorientationevent</code>"<td>{{DeviceOrientationEvent}}
-    <tr><td>"<code>dragevent</code>"<td>{{DragEvent}}<td rowspan=2>[[!HTML]]
+    <tr><td>"<code>dragevent</code>"<td>{{DragEvent}}<td>[[!HTML]]
     <tr><td>"<code>event</code>"<td rowspan=2>{{Event}}<td rowspan=2>
     <tr><td>"<code>events</code>"
     <!-- htmlevents and svgevents also map to Event -->

--- a/dom.bs
+++ b/dom.bs
@@ -9696,6 +9696,9 @@ method, when invoked, must run these steps:
  <li><p>If either <var>token</var> or <var>newToken</var> contains any <a>ASCII whitespace</a>, then
  <a>throw</a> an {{InvalidCharacterError}}.
 
+ <li><p>If <a>context object</a>'s <a>token set</a> does not <a for=set>contain</a>
+ <var>token</var>, then return.</p>
+
  <li><p><a for=set>Replace</a> <var>token</var> in <a>context object</a>'s <a>token set</a> with
  <var>newToken</var>.
 


### PR DESCRIPTION
The consistency change made in d396872f847d63b803393092eb81843e80d566b7
turned out to not be compatible with the web.

Fixes #451.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/annevk/toggle/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/5a532da...160d551.html)