### PR TITLE
Clarify insert-node's record's previousSibling

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1948,6 +1948,9 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   <p class="note no-backref">This step intentionally does not pay attention to the
   <i>suppress observers flag</i>.
 
+ <li><p>Let <var>previousSibling</var> be <var>child</var>'s <a>previous sibling</a> or
+ <var>parent</var>'s <a>last child</a> if <var>child</var> is null.
+
  <li>
   <p>For each <var>node</var> in <var>nodes</var>, in <a>tree order</a>:
 
@@ -2001,9 +2004,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  <li>If <i>suppress observers flag</i> is unset,
  <a>queue a mutation record</a> of "<code>childList</code>" for
  <var>parent</var> with addedNodes <var>nodes</var>, nextSibling
- <var>child</var>, and previousSibling <var>child</var>'s
- <a>previous sibling</a> or <var>parent</var>'s <a>last child</a> if
- <var>child</var> is null.
+ <var>child</var>, and previousSibling <var>previousSibling</var>.
 </ol>
 
 
@@ -9802,6 +9803,7 @@ Sergey G. Grekhov,
 Shiki Okasaka,
 Shinya Kawanaka,
 Simon Pieters,
+Stef Busking,
 Steve Byrne,
 Stig Halvorsen,
 Tab Atkins,


### PR DESCRIPTION
This adds a previousSibling variable to the insert node algorithm in order to clarify that the previousSibling property of the mutation record generated by the insert node algorithm should be determined before inserting nodes. 

If implemented as described in the original text, the property would be determined after insertion, and will therefore always be the last of nodes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/bwrrp/dom/insertNode-MutationRecord-previousSibling.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/93db340...bwrrp:3927500.html)