### PR TITLE
Allow removing event listeners by group

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -54,7 +54,6 @@ urlPrefix: https://w3c.github.io/ServiceWorker/#; spec: SERVICE-WORKERS
         text: has ever been evaluated flag; for: service worker
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
     text: Realm; url: realm; type: dfn
-    text: SameValueZero; url: sec-samevaluezero; type: abstract-op
 </pre>
 
 <pre class=link-defaults>
@@ -328,17 +327,17 @@ function imgFetched(ev) {
 <a>Event listeners</a> can be removed by utilizing the
 {{EventTarget/removeEventListener(type, callback, options)}} method, passing the same arguments.
 
-Once can also provide a <em>group</em> when adding an <a>event listener</a>. This can be any value,
-including a simple string. Then later, the same group value can be provided to
+Once can also provide a <em>group</em> when adding an <a>event listener</a>. This can be either a
+string or a JavaScript symbol value. Then later, the same group value can be provided to
 {{EventTarget/removeEventListener(type, options)}} or {{EventTarget/removeEventListener(options)}},
 to remove all event listeners in that group:
 
 <pre class=lang-javascript>
-oven.addEventListener("turnon", () => { &hellip; }, { group: "cookies" })
-oven.addEventListener("heat", () => { &hellip; }, { group: "cookies" })
-oven.addEventListener("turnoff", () => { &hellip; }, { group: "cookies" })
+oven.addEventListener("turnon", () => { &hellip; }, { group: "brownies" })
+oven.addEventListener("heat", () => { &hellip; }, { group: "brownies" })
+oven.addEventListener("turnoff", () => { &hellip; }, { group: "brownies" })
 
-oven.removeEventListener({ group: "cookies" })
+oven.removeEventListener({ group: "brownies" })
 </pre>
 
 <hr>
@@ -900,6 +899,8 @@ interface EventTarget {
   boolean dispatchEvent(Event event);
 };
 
+typedef (DOMString or symbol) EventGroup;
+
 callback interface EventListener {
   void handleEvent(Event event);
 };
@@ -909,13 +910,13 @@ dictionary EventListenerOptions {
 };
 
 dictionary RemoveEventListenerGroupOptions {
- required any group;
+ required EventGroup group;
 };
 
 dictionary AddEventListenerOptions : EventListenerOptions {
   boolean passive = false;
   boolean once = false;
-  any group;
+  EventGroup group;
 };
 </pre>
 
@@ -935,8 +936,7 @@ when something has occurred.
  <li><b>capture</b> (a boolean, initially false)
  <li><b>passive</b> (a boolean, initially false)
  <li><b>once</b> (a boolean, initially false)
- <li><b>is grouped</b> (a boolean, initially false)
- <li><b>group</b> (any Web IDL value, initially null)
+ <li><b>group</b> (an {{EventGroup}} or null)
  <li><b>removed</b> (a boolean for bookkeeping purposes, initially false)
 </ul>
 
@@ -995,7 +995,7 @@ are not to be used for anything else. [[!HTML]]
   When provided, <var>options</var>'s {{AddEventListenerOptions/group}} member is stored so that
   later calls to {{EventTarget/removeEventListener(type, options)}} or
   {{EventTarget/removeEventListener(options)}} can remove all event listeners that provided the same
-  group value.
+  group value. It can be either a string or a symbol.
 
   The <a>event listener</a> is appended to <var>target</var>'s list of <a>event listeners</a> and is
   not appended if it is a duplicate, i.e., having the same <b>type</b>, <b>callback</b>, and
@@ -1039,7 +1039,7 @@ steps:
 <ol>
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 
- <li><p>Let <var>once</var>, <var>passive</var>, and <var>is grouped</var> be false, and let <var>group</var> be null.
+ <li><p>Let <var>once</var> and <var>passive</var>, and let <var>group</var> be null.
 
  <li>
   <p>If <var>options</var> is a dictionary, then:
@@ -1048,11 +1048,10 @@ steps:
    <var>once</var> to <var>options</var>["{{AddEventListenerOptions/once}}"].
 
    <li><p>If {{AddEventListenerOptions/group}} is <a>present</a> in <var>options</var>, set
-   <var>is grouped</var> to true and set <var>group</var> to
-   <var>options</var>["{{AddEventListenerOptions/group}}"].
+   <var>group</var> to <var>options</var>["{{AddEventListenerOptions/group}}"].
   </ol>
 
- <li><p>Return the <a>tuple</a> (<var>capture</var>, <var>passive</var>, <var>once</var>, <var>is grouped</var>,
+ <li><p>Return the <a>tuple</a> (<var>capture</var>, <var>passive</var>, <var>once</var>,
  <var>group</var>).
 </ol>
 
@@ -1066,10 +1065,6 @@ steps:
 avoid non-deterministic changes to the event listeners, invocation of certain {{EventTarget}}
 methods is allowed only during the very first evaluation of the service worker script.
 
-<p>Two Web IDL values are <dfn for="event listener">equal for grouping purposes</dfn> if, when
-<a>converted to ECMAScript values</a>, the results are equivalent according to
-<a abstract-op>SameValueZero</a>. [[!ECMASCRIPT]]
-
 <p>The
 <dfn method for=EventTarget><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
@@ -1079,21 +1074,20 @@ method, when invoked, must run these steps:
 
  <li><p>If <var>callback</var> is null, then return.
 
- <li><p>Let (<var>capture</var>, <var>passive</var>, <var>once</var>, <var>is grouped</var>,
- <var>group</var>) be the result of <a lt="flatten more">flattening more</a> <var>options</var>.
+ <li><p>Let (<var>capture</var>, <var>passive</var>, <var>once</var>, <var>group</var>) be the
+ result of <a lt="flatten more">flattening more</a> <var>options</var>.
 
  <li><p>If <a>context object</a>'s associated list of <a>event listener</a> does not contain an
  <a>event listener</a> whose <b>type</b> is <var>type</var>, <b>callback</b> is <var>callback</var>,
- <b>capture</b> is <var>capture</var>, <b>is grouped</b> is <var>is grouped</var>, and <b>group</b>
- is equal to <var>group</var>, then append a new <a>event listener</a> to it, whose
+ and <b>capture</b> is <var>capture</var>, then append a new <a>event listener</a> to it, whose
  <b>type</b> is <var>type</var>, <b>callback</b> is <var>callback</var>, <b>capture</b> is
- <var>capture</var>, <b>passive</b> is <var>passive</var>, <b>once</b> is <var>once</var>,
- <b>is grouped</b> is <var>is grouped</var>, and <b>group</b> is <var>group</var>.
+ <var>capture</var>, <b>passive</b> is <var>passive</var>, <b>once</b> is <var>once</var>, and
+ <b>group</b> is <var>group</var>.
 </ol>
 
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
-method overload, when invoked, must run these steps
+method overload, when invoked, must run these steps:
 
 <ol>
  <li><p><a>Perform a service worker check</a> on <a>context object</a>.
@@ -1108,27 +1102,25 @@ method overload, when invoked, must run these steps
 
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>options</var>)</code></dfn>
-method overload, when invoked, must run these steps
+method overload, when invoked, must run these steps:
 
 <ol>
  <li><p><a>Perform a service worker check</a> on <a>context object</a>.
 
  <li><p>Remove all <a>event listeners</a> in the associated list of event listeners whose
- <b>type</b> is <var>type</var>, <b>is grouped</b> is true, and <b>group</b> is
- <a>equal for grouping purposes</a> to
+ <b>type</b> is <var>type</var> and <b>group</b> is
  <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
 </ol>
 
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>options</var>)</code></dfn>
-method overload, when invoked, must run these steps
+method overload, when invoked, must run these steps:
 
 <ol>
  <li><p><a>Perform a service worker check</a> on <a>context object</a>.
 
  <li><p>Remove all <a>event listeners</a> in the associated list of event listeners whose
- <b>is grouped</b> is true and <b>group</b> is <a>equal for grouping purposes</a> to
- <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
+ <b>group</b> is <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
 </ol>
 
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when

--- a/dom.bs
+++ b/dom.bs
@@ -53,8 +53,8 @@ urlPrefix: https://w3c.github.io/ServiceWorker/#; spec: SERVICE-WORKERS
         text: script resource; for: service worker
         text: has ever been evaluated flag; for: service worker
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
-    text: Construct; url: sec-construct; type: abstract-op
     text: Realm; url: realm; type: dfn
+    text: SameValueZero; url: sec-samevaluezero; type: abstract-op
 </pre>
 
 <pre class=link-defaults>
@@ -314,7 +314,7 @@ run these steps:
 Throughout the web platform <a>events</a> are <a>dispatched</a> to objects to signal an
 occurrence, such as network activity or user interaction. These objects implement the
 {{EventTarget}} interface and can therefore add <a>event listeners</a> to observe
-<a>events</a> by calling {{EventTarget/addEventListener()}}:
+<a>events</a> by calling {{EventTarget/addEventListener(type, callback, options)}}:
 
 <pre class=lang-javascript>
 obj.addEventListener("load", imgFetched)
@@ -325,10 +325,23 @@ function imgFetched(ev) {
 }
 </pre>
 
-<a>Event listeners</a> can be removed
-by utilizing the
-{{EventTarget/removeEventListener()}}
-method, passing the same arguments.
+<a>Event listeners</a> can be removed by utilizing the
+{{EventTarget/removeEventListener(type, callback, options)}} method, passing the same arguments.
+
+Once can also provide a <em>group</em> when adding an <a>event listener</a>. This can be any value,
+including a simple string. Then later, the same group value can be provided to
+{{EventTarget/removeEventListener(type, options)}} or {{EventTarget/removeEventListener(options)}},
+to remove all event listeners in that group:
+
+<pre class=lang-javascript>
+oven.addEventListener("turnon", () => { &hellip; }, { group: "cookies" })
+oven.addEventListener("heat", () => { &hellip; }, { group: "cookies" })
+oven.addEventListener("turnoff", () => { &hellip; }, { group: "cookies" })
+
+oven.removeEventListener({ group: "cookies" })
+</pre>
+
+<hr>
 
 <a>Events</a> are objects too and implement the
 {{Event}} interface (or a derived interface). In the example above
@@ -879,7 +892,11 @@ for historical reasons.
 [Exposed=(Window,Worker)]
 interface EventTarget {
   void addEventListener(DOMString type, EventListener? callback, optional (AddEventListenerOptions or boolean) options);
+
   void removeEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options);
+  void removeEventListener(DOMString type, RemoveEventListenerGroupOptions options);
+  void removeEventListener(RemoveEventListenerGroupOptions options);
+
   boolean dispatchEvent(Event event);
 };
 
@@ -891,9 +908,14 @@ dictionary EventListenerOptions {
   boolean capture = false;
 };
 
+dictionary RemoveEventListenerGroupOptions {
+ required any group;
+};
+
 dictionary AddEventListenerOptions : EventListenerOptions {
   boolean passive = false;
   boolean once = false;
+  any group;
 };
 </pre>
 
@@ -913,6 +935,8 @@ when something has occurred.
  <li><b>capture</b> (a boolean, initially false)
  <li><b>passive</b> (a boolean, initially false)
  <li><b>once</b> (a boolean, initially false)
+ <li><b>is grouped</b> (a boolean, initially false)
+ <li><b>group</b> (any Web IDL value, initially null)
  <li><b>removed</b> (a boolean for bookkeeping purposes, initially false)
 </ul>
 
@@ -952,32 +976,42 @@ are not to be used for anything else. [[!HTML]]
 
   The <var>options</var> argument sets listener-specific options. For compatibility this can be just
   a boolean, in which case the method behaves exactly as if the value was specified as
-  <var>options</var>' <code>capture</code> member.
+  <var>options</var>'s {{EventListenerOptions/capture}} member.
 
-  When set to true, <var>options</var>' <code>capture</code> member prevents <b>callback</b> from
-  being invoked when the <a>event</a>'s {{Event/eventPhase}} attribute value is
+  When set to true, <var>options</var>'s {{EventListenerOptions/capture}} member prevents
+  <b>callback</b> from being invoked when the <a>event</a>'s {{Event/eventPhase}} attribute value is
   {{Event/BUBBLING_PHASE}}. When false (or not present), <b>callback</b> will not be invoked when
   <a>event</a>'s {{Event/eventPhase}} attribute value is {{Event/CAPTURING_PHASE}}. Either way,
   <b>callback</b> will be invoked if <a>event</a>'s {{Event/eventPhase}} attribute value is
   {{Event/AT_TARGET}}.
 
-  When set to true, <var>options</var>' <code>passive</code> member indicates that the
-  <b>callback</b> will not cancel the event by invoking {{Event/preventDefault()}}. This is used to
-  enable performance optimizations described in [[#observing-event-listeners]].
+  When set to true, <var>options</var>' {{AddEventListenerOptions/passive}} member indicates that
+  the <b>callback</b> will not cancel the event by invoking {{Event/preventDefault()}}. This is used
+  to enable performance optimizations described in [[#observing-event-listeners]].
 
-  When set to true, <var>options</var>'s <code>once</code> member indicates that the <b>callback</b>
-  will only be invoked once after which the event listener will be removed.
+  When set to true, <var>options</var>'s {{AddEventListenerOptions/once}} member indicates that the
+  <b>callback</b> will only be invoked once after which the event listener will be removed.
+
+  When provided, <var>options</var>'s {{AddEventListenerOptions/group}} member is stored so that
+  later calls to {{EventTarget/removeEventListener(type, options)}} or
+  {{EventTarget/removeEventListener(options)}} can remove all event listeners that provided the same
+  group value.
 
   The <a>event listener</a> is appended to <var>target</var>'s list of <a>event listeners</a> and is
   not appended if it is a duplicate, i.e., having the same <b>type</b>, <b>callback</b>, and
   <b>capture</b> values.
 
- <dt><code><var>target</var> . <a method for=EventTarget lt=removeEventListener()>removeEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code>
- <dd>Remove the <a>event listener</a>
- in <var>target</var>'s list of
- <a>event listeners</a> with the same
- <var>type</var>, <var>callback</var>, and
- <var>options</var>.
+ <dt><code><var>target</var> . <a method for=EventTarget lt="removeEventListener(type, callback, options)">removeEventListener</a>(<var>type</var>, <var>callback</var> [, <var>options</var>])</code>
+ <dd>Remove the <a>event listener</a> in <var>target</var>'s list of <a>event listeners</a> with the
+ same <var>type</var>, <var>callback</var>, and <var>options</var>.
+
+ <dt><code><var>target</var> . <a method for=EventTarget lt="removeEventListener(type, options)">removeEventListener</a>(<var>type</var>, { <var>group</var> })</code>
+ <dd>Remove all <a>event listeners</a> in <var>target</var>'s list of <a>event listeners</a> with
+ the same <var>type</var> and <var>group</var>.
+
+ <dt><code><var>target</var> . <a method for=EventTarget lt=removeEventListener(options)>removeEventListener</a>({ <var>group</var> })</code>
+ <dd>Remove all <a>event listeners</a> in <var>target</var>'s list of <a>event listeners</a> with
+ the same <var>group</var> (regardless of their type).
 
  <dt><code><var>target</var> . <a method for=EventTarget lt=dispatchEvent()>dispatchEvent</a>(<var>event</var>)</code>
  <dd><a>Dispatches</a> a synthetic event <var>event</var> to <var>target</var> and returns
@@ -993,8 +1027,8 @@ steps:
 
  <li><p>If <var>options</var> is a boolean, set <var>capture</var> to <var>options</var>.
 
- <li><p>If <var>options</var> is a dictionary, then set <var>capture</var> to <var>options</var>'s
- <code>{{EventListenerOptions/capture}}</code>.
+ <li><p>If <var>options</var> is a dictionary, then set <var>capture</var> to
+ <var>options</var>["{{EventListenerOptions/capture}}"].
 
  <li><p>Return <var>capture</var>.
 </ol>
@@ -1005,52 +1039,64 @@ steps:
 <ol>
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 
- <li><p>Let <var>once</var> and <var>passive</var> be false.
+ <li><p>Let <var>once</var>, <var>passive</var>, and <var>is grouped</var> be false, and let <var>group</var> be null.
 
- <li><p>If <var>options</var> is a dictionary, then set <var>passive</var> to <var>options</var>'s
- <code>{{AddEventListenerOptions/passive}}</code> and <var>once</var> to <var>options</var>'s
- <code>{{AddEventListenerOptions/once}}</code>.
+ <li>
+  <p>If <var>options</var> is a dictionary, then:
+  <ol>
+   <li><p>Set <var>passive</var> to <var>options</var>["{{AddEventListenerOptions/passive}}"] and
+   <var>once</var> to <var>options</var>["{{AddEventListenerOptions/once}}"].
 
- <li><p>Return <var>capture</var>, <var>passive</var>, and <var>once</var>.
+   <li><p>If {{AddEventListenerOptions/group}} is <a>present</a> in <var>options</var>, set
+   <var>is grouped</var> to true and set <var>group</var> to
+   <var>options</var>["{{AddEventListenerOptions/group}}"].
+  </ol>
+
+ <li><p>Return the <a>tuple</a> (<var>capture</var>, <var>passive</var>, <var>once</var>, <var>is grouped</var>,
+ <var>group</var>).
 </ol>
+
+<p>To <dfn export for=EventTarget>perform a service worker check</dfn> on <var>eventTarget</var>,
+<a>throw</a> a {{TypeError}} if <var>eventTarget</var>'s <a>relevant global object</a> is a
+{{ServiceWorkerGlobalScope}} object and its associated <a>service worker</a>'s
+<a for="service worker">script resource</a>'s
+<a for="service worker">has ever been evaluated flag</a> is set. [[!SERVICE-WORKERS]]
+
+<p class="note no-backref">To optimize storing the event types allowed for the service worker and to
+avoid non-deterministic changes to the event listeners, invocation of certain {{EventTarget}}
+methods is allowed only during the very first evaluation of the service worker script.
+
+<p>Two Web IDL values are <dfn for="event listener">equal for grouping purposes</dfn> if, when
+<a>converted to ECMAScript values</a>, the results are equivalent according to
+<a abstract-op>SameValueZero</a>. [[!ECMASCRIPT]]
 
 <p>The
 <dfn method for=EventTarget><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
- <li>
-  <p>If <a>context object</a>'s <a>relevant global object</a> is a {{ServiceWorkerGlobalScope}}
-  object and its associated <a>service worker</a>'s <a for="service worker">script resource</a>'s
-  <a for="service worker">has ever been evaluated flag</a> is set, then <a>throw</a> a
-  <code>TypeError</code>.
-  [[!SERVICE-WORKERS]]
-
-  <p class="note no-backref">To optimize storing the event types allowed for the service worker and
-  to avoid non-deterministic changes to the event listeners, invocation of the method is allowed
-  only during the very first evaluation of the service worker script.
+ <li><p><a>Perform a service worker check</a> on <a>context object</a>.
 
  <li><p>If <var>callback</var> is null, then return.
 
- <li><p>Let <var>capture</var>, <var>passive</var>, and <var>once</var> be the result of
- <a lt="flatten more">flattening more</a> <var>options</var>.
+ <li><p>Let (<var>capture</var>, <var>passive</var>, <var>once</var>, <var>is grouped</var>,
+ <var>group</var>) be the result of <a lt="flatten more">flattening more</a> <var>options</var>.
 
  <li><p>If <a>context object</a>'s associated list of <a>event listener</a> does not contain an
  <a>event listener</a> whose <b>type</b> is <var>type</var>, <b>callback</b> is <var>callback</var>,
- and <b>capture</b> is <var>capture</var>, then append a new <a>event listener</a> to it, whose
+ <b>capture</b> is <var>capture</var>, <b>is grouped</b> is <var>is grouped</var>, and <b>group</b>
+ is equal to <var>group</var>, then append a new <a>event listener</a> to it, whose
  <b>type</b> is <var>type</var>, <b>callback</b> is <var>callback</var>, <b>capture</b> is
- <var>capture</var>, <b>passive</b> is <var>passive</var>, and <b>once</b> is <var>once</var>.
+ <var>capture</var>, <b>passive</b> is <var>passive</var>, <b>once</b> is <var>once</var>,
+ <b>is grouped</b> is <var>is grouped</var>, and <b>group</b> is <var>group</var>.
 </ol>
 
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
-method, when invoked, must, run these steps
+method overload, when invoked, must run these steps
 
 <ol>
- <li><p>If <a>context object</a>'s <a>relevant global object</a> is a {{ServiceWorkerGlobalScope}}
- object and its associated <a>service worker</a>'s <a for="service worker">script resource</a>'s
- <a for="service worker">has ever been evaluated flag</a> is set, then <a>throw</a> a
- <code>TypeError</code>. [[!SERVICE-WORKERS]]
+ <li><p><a>Perform a service worker check</a> on <a>context object</a>.
 
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 
@@ -1058,6 +1104,31 @@ method, when invoked, must, run these steps
  <b>type</b> is <var>type</var>, <b>callback</b> is <var>callback</var>, and <b>capture</b> is
  <var>capture</var>, then set that <a>event listener</a>'s <b>removed</b> to true and remove it from
  the associated list of <a>event listeners</a>.
+</ol>
+
+<p>The
+<dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>options</var>)</code></dfn>
+method overload, when invoked, must run these steps
+
+<ol>
+ <li><p><a>Perform a service worker check</a> on <a>context object</a>.
+
+ <li><p>Remove all <a>event listeners</a> in the associated list of event listeners whose
+ <b>type</b> is <var>type</var>, <b>is grouped</b> is true, and <b>group</b> is
+ <a>equal for grouping purposes</a> to
+ <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
+</ol>
+
+<p>The
+<dfn method for=EventTarget><code>removeEventListener(<var>options</var>)</code></dfn>
+method overload, when invoked, must run these steps
+
+<ol>
+ <li><p><a>Perform a service worker check</a> on <a>context object</a>.
+
+ <li><p>Remove all <a>event listeners</a> in the associated list of event listeners whose
+ <b>is grouped</b> is true and <b>group</b> is <a>equal for grouping purposes</a> to
+ <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
 </ol>
 
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when

--- a/dom.bs
+++ b/dom.bs
@@ -334,7 +334,7 @@ to remove all event listeners in that group:
 
 <pre class=lang-javascript>
 oven.addEventListener("turnon", () => { &hellip; }, { group: "brownies" })
-oven.addEventListener("heat", () => { &hellip; }, { group: "brownies" })
+oven.addEventListener("heat", () => { &hellip; }, { group: ["brownies", "adjustments"] })
 oven.addEventListener("turnoff", () => { &hellip; }, { group: "brownies" })
 
 oven.removeEventListener({ group: "brownies" })
@@ -916,7 +916,7 @@ dictionary RemoveEventListenerGroupOptions {
 dictionary AddEventListenerOptions : EventListenerOptions {
   boolean passive = false;
   boolean once = false;
-  EventGroup group;
+  (EventGroup or sequence&lt;EventGroup>) group;
 };
 </pre>
 
@@ -936,7 +936,7 @@ when something has occurred.
  <li><b>capture</b> (a boolean, initially false)
  <li><b>passive</b> (a boolean, initially false)
  <li><b>once</b> (a boolean, initially false)
- <li><b>group</b> (an {{EventGroup}} or null)
+ <li><b>groups</b> (a <a>list</a> of {{EventGroup}}s, initially empty)
  <li><b>removed</b> (a boolean for bookkeeping purposes, initially false)
 </ul>
 
@@ -995,7 +995,9 @@ are not to be used for anything else. [[!HTML]]
   When provided, <var>options</var>'s {{AddEventListenerOptions/group}} member is stored so that
   later calls to {{EventTarget/removeEventListener(type, options)}} or
   {{EventTarget/removeEventListener(options)}} can remove all event listeners that provided the same
-  group value. It can be either a string or a symbol.
+  group value. It can be either a string or a symbol. It can also be an iterable containing strings
+  or symbols, to attach multiple group values to the listener, any one of which can be used for
+  later removal.
 
   The <a>event listener</a> is appended to <var>target</var>'s list of <a>event listeners</a> and is
   not appended if it is a duplicate, i.e., having the same <b>type</b>, <b>callback</b>, and
@@ -1039,7 +1041,8 @@ steps:
 <ol>
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 
- <li><p>Let <var>once</var> and <var>passive</var>, and let <var>group</var> be null.
+ <li><p>Let <var>once</var> and <var>passive</var>, and let <var>groups</var> be an empty
+ <a>list</a>.
 
  <li>
   <p>If <var>options</var> is a dictionary, then:
@@ -1047,23 +1050,32 @@ steps:
    <li><p>Set <var>passive</var> to <var>options</var>["{{AddEventListenerOptions/passive}}"] and
    <var>once</var> to <var>options</var>["{{AddEventListenerOptions/once}}"].
 
-   <li><p>If {{AddEventListenerOptions/group}} is <a>present</a> in <var>options</var>, set
-   <var>group</var> to <var>options</var>["{{AddEventListenerOptions/group}}"].
+   <li><p>If {{AddEventListenerOptions/group}} is <a>present</a> in <var>options</var> and is an
+   {{EventGroup}}, set <var>groups</var> to a <a>list</a> containing the single item given by
+   <var>options</var>["{{AddEventListenerOptions/group}}"].
+
+   <li><p>Otherwise, if {{AddEventListenerOptions/group}} is <a>present</a> in <var>options</var>,
+   set <var>groups</var> to <var>options</var>["{{AddEventListenerOptions/group}}"].
   </ol>
 
  <li><p>Return the <a>tuple</a> (<var>capture</var>, <var>passive</var>, <var>once</var>,
- <var>group</var>).
+ <var>groups</var>).
 </ol>
 
-<p>To <dfn export for=EventTarget>perform a service worker check</dfn> on <var>eventTarget</var>,
-<a>throw</a> a {{TypeError}} if <var>eventTarget</var>'s <a>relevant global object</a> is a
-{{ServiceWorkerGlobalScope}} object and its associated <a>service worker</a>'s
-<a for="service worker">script resource</a>'s
+<p>To <dfn for=EventTarget>perform a service worker check</dfn> on an {{EventTarget}}
+<var>eventTarget</var>, <a>throw</a> a {{TypeError}} if <var>eventTarget</var>'s
+<a>relevant global object</a> is a {{ServiceWorkerGlobalScope}} object and its associated
+<a>service worker</a>'s <a for="service worker">script resource</a>'s
 <a for="service worker">has ever been evaluated flag</a> is set. [[!SERVICE-WORKERS]]
 
 <p class="note no-backref">To optimize storing the event types allowed for the service worker and to
 avoid non-deterministic changes to the event listeners, invocation of certain {{EventTarget}}
 methods is allowed only during the very first evaluation of the service worker script.
+
+<p>To <dfn for=EventTarget lt="remove an event listener">remove</dfn> an <a>event listener</a>
+<var>listener</var> from an {{EventTarget}} <var>eventTarget</var>, set <var>listener</var>'s
+<b>removed</b> to true and <a for=list>remove</a> it from <var>eventTarget</var>'s associated list
+of <a>event listeners</a>.
 
 <p>The
 <dfn method for=EventTarget><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
@@ -1074,7 +1086,7 @@ method, when invoked, must run these steps:
 
  <li><p>If <var>callback</var> is null, then return.
 
- <li><p>Let (<var>capture</var>, <var>passive</var>, <var>once</var>, <var>group</var>) be the
+ <li><p>Let (<var>capture</var>, <var>passive</var>, <var>once</var>, <var>groups</var>) be the
  result of <a lt="flatten more">flattening more</a> <var>options</var>.
 
  <li><p>If <a>context object</a>'s associated list of <a>event listener</a> does not contain an
@@ -1082,7 +1094,7 @@ method, when invoked, must run these steps:
  and <b>capture</b> is <var>capture</var>, then append a new <a>event listener</a> to it, whose
  <b>type</b> is <var>type</var>, <b>callback</b> is <var>callback</var>, <b>capture</b> is
  <var>capture</var>, <b>passive</b> is <var>passive</var>, <b>once</b> is <var>once</var>, and
- <b>group</b> is <var>group</var>.
+ <b>groups</b> is <var>groups</var>.
 </ol>
 
 <p>The
@@ -1096,8 +1108,7 @@ method overload, when invoked, must run these steps:
 
  <li><p>If there is an <a>event listener</a> in the associated list of <a>event listeners</a> whose
  <b>type</b> is <var>type</var>, <b>callback</b> is <var>callback</var>, and <b>capture</b> is
- <var>capture</var>, then set that <a>event listener</a>'s <b>removed</b> to true and remove it from
- the associated list of <a>event listeners</a>.
+ <var>capture</var>, then <a lt="remove an event listener">remove</a> it.
 </ol>
 
 <p>The
@@ -1107,8 +1118,8 @@ method overload, when invoked, must run these steps:
 <ol>
  <li><p><a>Perform a service worker check</a> on <a>context object</a>.
 
- <li><p>Remove all <a>event listeners</a> in the associated list of event listeners whose
- <b>type</b> is <var>type</var> and <b>group</b> is
+ <li><p><a lt="remove an event listener">Remove</a> all <a>event listeners</a> whose <b>type</b> is
+ <var>type</var> and <b>groups</b> <a for=list>contains</a>
  <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
 </ol>
 
@@ -1119,8 +1130,8 @@ method overload, when invoked, must run these steps:
 <ol>
  <li><p><a>Perform a service worker check</a> on <a>context object</a>.
 
- <li><p>Remove all <a>event listeners</a> in the associated list of event listeners whose
- <b>group</b> is <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
+ <li><p><a lt="remove an event listener">Remove</a> all <a>event listeners</a> whose <b>groups</b>
+ <a for=list>contains</a> <var>options</var>["{{RemoveEventListenerGroupOptions/group}}"].
 </ol>
 
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when


### PR DESCRIPTION
Closes #208.

Tests: https://github.com/w3c/web-platform-tests/pull/6331

Chrome is tentatively interested in this, although the first step is getting a spec and tests up for review. Would love to hear if other implementers are interested--- @smaug----, @cdumez, @travisleithead?

I decided to go with an overload instead of a new method, so we can leave new method names for something potentially nicer like `on`/`off`. Overloading for this pattern is pretty common, e.g. it is what jQuery does. And introducing two similar-but-different method names like `removeEventListener` + `deleteEventListener` seemed like a bad idea.

I also added an overload `removeEventListener(type, { group })` which is not really necessary. We could get rid of that if we don't like it. But it fell out naturally.

This also preserves what I'm pretty sure is a bug, per #468, but at least it centralizes the probably-buggy check.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/event-namespaces/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/d9cd30d...9400bac.html)