### PR TITLE
Origins serialize to ASCII these days

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4567,7 +4567,7 @@ The <dfn attribute for=Document><code>URL</code></dfn> attribute's getter and
 <a for=Document>URL</a>, <a lt="URL serializer" spec=url>serialized</a>.
 
 The <dfn attribute for=Document><code>origin</code></dfn> attribute's getter must return the
-<a lt="Unicode serialization of an origin">Unicode serialization</a> of <a>context object</a>'s
+<a lt="serialization of an origin">serialization</a> of <a>context object</a>'s
 <a for=Document>origin</a>.
 
 The <dfn attribute for=Document><code>compatMode</code></dfn> attribute's getter must


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/annevk/origin-ascii/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/8f8c1c3...308dac6.html)