### PR TITLE
Meta: add a service worker to make the spec viewable offline

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -10101,4 +10101,11 @@ Per <a rel="license" href="//creativecommons.org/publicdomain/zero/1.0/">CC0</a>
 the extent possible under law, the editors have waived all copyright and related or
 neighboring rights to this work.
 
+<script>
+"use strict";
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/service-worker.js");
+}
+</script>
+
 <!-- vim: set expandtab shiftwidth=1 tabstop=1 textwidth=76 -->


### PR DESCRIPTION
Uses https://github.com/whatwg/resources.whatwg.org/pull/53.

@annevk, if you could look over this and ideally https://github.com/whatwg/resources.whatwg.org/pull/53 as well, I'll merge them together once approved, and keep my finger hovering on the revert button in case anything goes wrong.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/service-worker/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/fba2caf...22611c0.html)