### PR TITLE
Export aborted flag

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1560,8 +1560,8 @@ interface AbortSignal : EventTarget {
  otherwise.
 </dl>
 
-<p>An {{AbortSignal}} object has an associated <dfn for=AbortSignal>aborted flag</dfn>. It is unset
-unless specified otherwise.
+<p>An {{AbortSignal}} object has an associated <dfn export for=AbortSignal>aborted flag</dfn>. It is
+unset unless specified otherwise.
 
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>abort algorithms</dfn>, which is a
 <a for=/>set</a> of algorithms which are to be executed when its [=AbortSignal/aborted flag=] is


### PR DESCRIPTION
This is needed in the fetch spec to determine if a signal has already been aborted.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/jakearchibald/dom/export-abort-flag.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/b8d9f4e...jakearchibald:fe36f19.html)