### PR TITLE
DOMTokenList shouldn't add empty attributes

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9506,10 +9506,17 @@ associated <a>attribute</a>'s <a for=Attr>local name</a>.
  <li><p>Return false.
 </ol>
 
-<p>A {{DOMTokenList}} object's <dfn id=concept-dtl-update for="DOMTokenList">update steps</dfn> are
-to <a>set an attribute value</a> for the associated <a for="/">element</a> using associated
-<a>attribute</a>'s <a for=Attr>local name</a> and the result of running the
-<a>ordered set serializer</a> for <a>token set</a>.
+<p>A {{DOMTokenList}} object's <dfn id=concept-dtl-update for="DOMTokenList">update steps</dfn> are:
+
+<ol>
+ <li><p>If the associated <a for="/">element</a> does not have an associated
+ <a>attribute</a>, and <a>token set</a> is empty, do nothing.
+
+ <li><p>Otherwise, <a>set an attribute value</a> for the associated
+ <a for="/">element</a> using associated <a>attribute</a>'s
+ <a for=Attr>local name</a> and the result of running the
+ <a>ordered set serializer</a> for <a>token set</a>.
+</ol>
 
 <p>A {{DOMTokenList}} object's <dfn id=concept-dtl-serialize for=DOMTokenList>serialize steps</dfn>
 are to return the result of running <a>get an attribute value</a> given the associated

--- a/dom.bs
+++ b/dom.bs
@@ -9509,13 +9509,12 @@ associated <a>attribute</a>'s <a for=Attr>local name</a>.
 <p>A {{DOMTokenList}} object's <dfn id=concept-dtl-update for="DOMTokenList">update steps</dfn> are:
 
 <ol>
- <li><p>If the associated <a for="/">element</a> does not have an associated
- <a>attribute</a>, and <a>token set</a> is empty, do nothing.
+ <li><p>If the associated <a for="/">element</a> does not have an associated <a>attribute</a> and
+ <a>token set</a> is empty, then return.
 
- <li><p>Otherwise, <a>set an attribute value</a> for the associated
- <a for="/">element</a> using associated <a>attribute</a>'s
- <a for=Attr>local name</a> and the result of running the
- <a>ordered set serializer</a> for <a>token set</a>.
+ <li><p><a>Set an attribute value</a> for the associated <a for="/">element</a> using associated
+ <a>attribute</a>'s <a for=Attr>local name</a> and the result of running the <a>ordered set
+ serializer</a> for <a>token set</a>.
 </ol>
 
 <p>A {{DOMTokenList}} object's <dfn id=concept-dtl-serialize for=DOMTokenList>serialize steps</dfn>


### PR DESCRIPTION
Fixes #462.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ayg/dom/DOMTokenList-remove-noop.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/bcb0b3f...ayg:a06ca93.html)