### PR TITLE
Remove more types from document.createEvent()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5299,39 +5299,29 @@ invoked, must run these steps:
    <thead>
     <tr><th>String<th>Interface<td>Notes
    <tbody>
-    <tr><td>"<code>animationevent</code>"<td>{{AnimationEvent}}<td>[[!CSS3-ANIMATIONS]]
     <tr><td>"<code>beforeunloadevent</code>"<td>{{BeforeUnloadEvent}}<td rowspan=2>[[!HTML]]
-    <tr><td>"<code>closeevent</code>"<td>{{CloseEvent}}
     <tr><td>"<code>compositionevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]
     <!-- textevent also maps to CompositionEvent -->
     <tr><td>"<code>customevent</code>"<td>{{CustomEvent}}<td>
     <tr><td>"<code>devicemotionevent</code>"<td>{{DeviceMotionEvent}}<td rowspan=2>[[!DEVICE-ORIENTATION]]
     <tr><td>"<code>deviceorientationevent</code>"<td>{{DeviceOrientationEvent}}
     <tr><td>"<code>dragevent</code>"<td>{{DragEvent}}<td rowspan=2>[[!HTML]]
-    <tr><td>"<code>errorevent</code>"<td>{{ErrorEvent}}
     <tr><td>"<code>event</code>"<td rowspan=2>{{Event}}<td rowspan=2>
     <tr><td>"<code>events</code>"
     <!-- htmlevents and svgevents also map to Event -->
     <tr><td>"<code>focusevent</code>"<td>{{FocusEvent}}<td>[[!UIEVENTS]]
     <tr><td>"<code>hashchangeevent</code>"<td>{{HashChangeEvent}}<td>[[!HTML]]
     <tr><td>"<code>htmlevents</code>"<td>{{Event}}<td>
-    <tr><td>"<code>idbversionchangeevent</code>"<td>{{IDBVersionChangeEvent}}<td>[[INDEXEDDB]]
     <tr><td>"<code>keyboardevent</code>"<td>{{KeyboardEvent}}<td>[[!UIEVENTS]]
     <tr><td>"<code>messageevent</code>"<td>{{MessageEvent}}<td>[[!HTML]]
     <tr><td>"<code>mouseevent</code>"<td rowspan=2>{{MouseEvent}}<td rowspan=2>[[!UIEVENTS]]
     <tr><td>"<code>mouseevents</code>"
-    <tr><td>"<code>pagetransitionevent</code>"<td>{{PageTransitionEvent}}<td rowspan=2>[[!HTML]]
-    <tr><td>"<code>popstateevent</code>"<td>{{PopStateEvent}}
     <tr><td>"<code>storageevent</code>"<td>{{StorageEvent}}<td>[[!HTML]]
     <tr><td>"<code>svgevents</code>"<td>{{Event}}<td>
     <tr><td>"<code>textevent</code>"<td>{{CompositionEvent}}<td>[[!UIEVENTS]]
     <tr><td>"<code>touchevent</code>"<td>{{TouchEvent}}<td>[[!TOUCH-EVENTS]]
-    <tr><td>"<code>trackevent</code>"<td>{{TrackEvent}}<td>[[!HTML]]
-    <tr><td>"<code>transitionevent</code>"<td>{{TransitionEvent}}<td>[[!CSS3-TRANSITIONS]]
     <tr><td>"<code>uievent</code>"<td rowspan=2>{{UIEvent}}<td rowspan=2>[[!UIEVENTS]]
     <tr><td>"<code>uievents</code>"
-    <tr><td>"<code>webglcontextevent</code>"<td>{{WebGLContextEvent}}<td>[[!WEBGL]]
-    <tr><td>"<code>wheelevent</code>"<td>{{WheelEvent}}<td>[[!UIEVENTS]]
   </table>
 
  <li><p>If <var>constructor</var> is null, then <a>throw</a> a {{NotSupportedError}}.


### PR DESCRIPTION
Fixes #362.  All of the removed event types except WheelEvent are
unsupported or are supported but cannot be properly initialized in
Blink, Gecko, and WebKit.  WheelEvent is supported in WebKit with a
vendor-prefixed initializer, but WebKit is willing to try dropping it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ayg/dom/createEvent.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/4a58d67...ayg:cf75365.html)