### PR TITLE
Update width from 76 to 99 in vim modeline

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -10110,4 +10110,4 @@ if ("serviceWorker" in navigator) {
 }
 </script>
 
-<!-- vim: set expandtab shiftwidth=1 tabstop=1 textwidth=76 -->
+<!-- vim: set expandtab shiftwidth=1 tabstop=1 textwidth=100 -->


### PR DESCRIPTION
According to annevk on #488, text is supposed to be wrapped to 100
columns, but the modeline says 76.  I made it 99 instead of 100 so that
diffs will be 100 columns and won't overflow if your terminal has a
width of 100, but it could be actually 100 too if we want.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/ayg/dom/modeline.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/bcb0b3f...ayg:16da399.html)