### PR TITLE
Add [CEReactions] to createElement()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4687,8 +4687,8 @@ interface Document : Node {
   HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
   HTMLCollection getElementsByClassName(DOMString classNames);
 
-  [NewObject] Element createElement(DOMString localName, optional ElementCreationOptions options);
-  [NewObject] Element createElementNS(DOMString? namespace, DOMString qualifiedName, optional ElementCreationOptions options);
+  [CEReactions, NewObject] Element createElement(DOMString localName, optional ElementCreationOptions options);
+  [CEReactions, NewObject] Element createElementNS(DOMString? namespace, DOMString qualifiedName, optional ElementCreationOptions options);
   [NewObject] DocumentFragment createDocumentFragment();
   [NewObject] Text createTextNode(DOMString data);
   [NewObject] CDATASection createCDATASection(DOMString data);


### PR DESCRIPTION
Fixes https://github.com/w3c/webcomponents/issues/570.

I'm somewhat surprised implementers haven't called this out meanwhile. Is this broken in implementations or does it end up working due to something else?

Anyone willing to write tests?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/annevk/cereactions/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/da7b3ec...0606e9f.html)