### PR TITLE
Add [Exposed=Window] to MutationObserver

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3209,7 +3209,8 @@ removed so they do not get lost when <code>subtree</code> is set to true on <a>n
 <h4 id=interface-mutationobserver>Interface {{MutationObserver}}</h4>
 
 <pre class="idl">
-[Constructor(MutationCallback callback)]
+[Constructor(MutationCallback callback),
+ Exposed=Window]
 interface MutationObserver {
   void observe(Node target, optional MutationObserverInit options);
   void disconnect();


### PR DESCRIPTION
Helps with https://github.com/heycam/webidl/issues/365.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/annevk/exposed-window/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/da7b3ec...281db00.html)