### PR TITLE
Set event.target to null when dispatching finishes at ShadowRoot

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1253,9 +1253,8 @@ for discussion).
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
- <li><p>Set <var>event</var>'s {{Event/target}} attribute and <var>event</var>'s
- <a>relatedTarget</a> to null if {{Event/target}}'s <a for=tree>root</a> is a
- <a for=/>shadow root</a>.
+ <li><p>If {{Event/target}}'s <a for=tree>root</a> is a <a for=/>shadow root</a>, set
+ <var>event</var>'s {{Event/target}} attribute and <var>event</var>'s <a>relatedTarget</a> to null.
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1253,7 +1253,7 @@ for discussion).
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
- <li><p>If {{Event/target}}'s <a for=tree>root</a> is a <a for=/>shadow root</a>, set
+ <li><p>If {{Event/target}}'s <a for=tree>root</a> is a <a for=/>shadow root</a>, then set
  <var>event</var>'s {{Event/target}} attribute and <var>event</var>'s <a>relatedTarget</a> to null.
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.

--- a/dom.bs
+++ b/dom.bs
@@ -1256,6 +1256,9 @@ for discussion).
  <li><p>Set <var>event</var>'s {{Event/target}} attribute to null if {{Event/target}}'s root is a
  <a for=/>shadow root</a>.
 
+ <li><p>Set <var>event</var>'s <a>relatedTarget</a> to null if <a>relatedTarget</a>'s root is a
+ <a for=/>shadow root</a>.
+
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 
  <li><p>Set <var>event</var>'s <a for=Event>path</a> to the empty list.

--- a/dom.bs
+++ b/dom.bs
@@ -1254,8 +1254,8 @@ for discussion).
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
  <li><p>Set <var>event</var>'s {{Event/target}} attribute and <var>event</var>'s
- <a>relatedTarget</a> to null if either {{Event/target}}'s <a for=tree>root</a> or
- <a>relatedTarget</a>'s <a for=tree>root</a> is a <a for=/>shadow root</a>.
+ <a>relatedTarget</a> to null if {{Event/target}}'s <a for=tree>root</a> is a
+ <a for=/>shadow root</a>.
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1253,11 +1253,9 @@ for discussion).
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
- <li><p>Set <var>event</var>'s {{Event/target}} attribute to null if {{Event/target}}'s root is a
- <a for=/>shadow root</a>.
-
- <li><p>Set <var>event</var>'s <a>relatedTarget</a> to null if <a>relatedTarget</a>'s root is a
- <a for=/>shadow root</a>.
+ <li><p>Set <var>event</var>'s {{Event/target}} attribute and <var>event</var>'s
+ <a>relatedTarget</a> to null if either {{Event/target}}'s <a for=tree>root</a> or
+ <a>relatedTarget</a>'s <a for=tree>root</a> is a <a for=/>shadow root</a>.
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1253,6 +1253,9 @@ for discussion).
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
+ <li><p>Set <var>event</var>'s {{Event/target}} attribute to null if {{Event/target}}'s root is a
+ <a for=/>shadow root</a> and <var>event</var>'s <a>composed flag</a> is unset.
+
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 
  <li><p>Set <var>event</var>'s <a for=Event>path</a> to the empty list.

--- a/dom.bs
+++ b/dom.bs
@@ -1254,7 +1254,7 @@ for discussion).
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
  <li><p>Set <var>event</var>'s {{Event/target}} attribute to null if {{Event/target}}'s root is a
- <a for=/>shadow root</a> and <var>event</var>'s <a>composed flag</a> is unset.
+ <a for=/>shadow root</a>.
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 


### PR DESCRIPTION
Resolves whatwg/dom#511.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/TakayoshiKochi/dom/squashing_target.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/601655d...TakayoshiKochi:22d1fb6.html)