### PR TITLE
Fix 515: Expose Event, EventTarget to AudioWorklet

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -446,7 +446,7 @@ would have been {{Event/AT_TARGET}}.
 
 <pre class="idl">
 [Constructor(DOMString type, optional EventInit eventInitDict),
- Exposed=(Window,Worker)]
+ Exposed=(Window,Worker,AudioWorklet)]
 interface Event {
   readonly attribute DOMString type;
   readonly attribute EventTarget? target;
@@ -893,7 +893,7 @@ for historical reasons.
 
 <pre class=idl>
 [Constructor,
- Exposed=(Window,Worker)]
+ Exposed=(Window,Worker,AudioWorklet)]
 interface EventTarget {
   void addEventListener(DOMString type, EventListener? callback, optional (AddEventListenerOptions or boolean) options);
   void removeEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options);
@@ -10006,6 +10006,7 @@ Hajime Morrita,
 Harald Alvestrand,
 Hayato Ito,
 Henri Sivonen,
+Hongchan Choi,
 Hunan Rostomyan,
 Ian Hickson,
 Igor Bukanov,


### PR DESCRIPTION
@domenic @annevk PTAL.

- Fixes #515.
- The full context on this change can be found [here](https://github.com/WebAudio/web-audio-api/issues/1266).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/hoch/dom/515-expose-event-eventtarget-to-audioworklet.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/41db2a9...hoch:379e8e5.html)