### PR TITLE
Stop using unit of related similar-origin browsing contexts

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2078,16 +2078,16 @@ steps:
 
 <h5 id=signaling-slot-change>Signaling slot change</h5>
 
-<p>Each <a>unit of related similar-origin browsing contexts</a> has a
-<dfn export>signal slot list</dfn> (a list of <a>slots</a>). Unless stated otherwise it is empty.
+<p>Each <a>similar-origin window agent</a> has a <dfn export>signal slot list</dfn> (a
+<a for=/>list</a> of <a>slots</a>). Unless stated otherwise it is empty.
 [[!HTML]]
 
 <p>To <dfn noexport>signal a slot change</dfn>, for a <a>slot</a> <var>slot</var>, run these steps:
 
 <ol>
- <li><p>If <var>slot</var> is not in <a>unit of related similar-origin browsing contexts</a>'
- <a>signal slot list</a>, append <var>slot</var> to
- <a>unit of related similar-origin browsing contexts</a>' <a>signal slot list</a>.
+ <li><p>If <var>slot</var> is not in <a>similar-origin window agent</a>'s <a>signal slot list</a>,
+ then <a for=list>append</a> <var>slot</var> to <a>similar-origin window agent</a>'s
+ <a>signal slot list</a>.
 
  <li><p><a>Queue a mutation observer compound microtask</a>.
 </ol>
@@ -3190,8 +3190,7 @@ invoked, must run these steps:
 
 <h3 id=mutation-observers>Mutation observers</h3>
 
-Each
-<a>unit of related similar-origin browsing contexts</a> has a
+<p>Each <a>similar-origin window agent</a> has a
 <dfn export>mutation observer compound microtask queued flag</dfn>, which is initially unset, and an
 associated list of {{MutationObserver}} objects, which is initially empty.
 [[!HTML]]
@@ -3213,14 +3212,13 @@ To <dfn export>notify mutation observers</dfn>, run these steps:
 <ol>
  <li>Unset <a>mutation observer compound microtask queued flag</a>.
 
- <li>Let <var>notify list</var> be a copy of
- <a>unit of related similar-origin browsing contexts</a>'
+ <li>Let <var>notify list</var> be a copy of <a>similar-origin window agent</a>'s
  list of {{MutationObserver}} objects.
 
- <li><p>Let <var>signalList</var> be a copy of
- <a>unit of related similar-origin browsing contexts</a>' <a>signal slot list</a>.
+ <li><p>Let <var>signalList</var> be a copy of <a>similar-origin window agent</a>'s
+ <a>signal slot list</a>.
 
- <li><p>Empty <a>unit of related similar-origin browsing contexts</a>' <a>signal slot list</a>.
+ <li><p>Empty <a>similar-origin window agent</a>'s <a>signal slot list</a>.
 
  <li>
   For each {{MutationObserver}} object <var>mo</var> in <var>notify list</var>,
@@ -3380,7 +3378,7 @@ Each {{MutationObserver}} object has these associated concepts:
 <p>The
 <dfn constructor for=MutationObserver><code>MutationObserver(<var>callback</var>)</code></dfn>
 constructor, when invoked, must create a new {{MutationObserver}} object with <a>callback</a> set to
-<var>callback</var>, append it to the <a>unit of related similar-origin browsing contexts</a>' list
+<var>callback</var>, append it to the <a>similar-origin window agent</a>'s list
 of {{MutationObserver}} objects, and then return it.
 
 <p>The


### PR DESCRIPTION
Use similar-origin window agent instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://dom.spec.whatwg.org/branch-snapshots/annevk/agents/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/dom/56ca18c...4709d45.html)