### PR TITLE
Specify [LegacyWindowAlias=HTMLDocument] on Document

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4715,7 +4715,8 @@ object may be returned as returned by an earlier call.
 
 <pre class=idl force="Document">
 [Constructor,
- Exposed=Window]
+ Exposed=Window,
+ LegacyWindowAlias=HTMLDocument]
 interface Document : Node {
   [SameObject] readonly attribute DOMImplementation implementation;
   readonly attribute USVString URL;


### PR DESCRIPTION
In https://html.spec.whatwg.org/multipage/window-object.html#the-window-object there is:

> For historical reasons, [`Window`](https://html.spec.whatwg.org/multipage/window-object.html#window) objects must also have a writable, configurable, non-enumerable property named **`HTMLDocument`** whose value is the [`Document`](https://html.spec.whatwg.org/multipage/dom.html#document) [interface object](https://heycam.github.io/webidl/#dfn-interface-object).

I'd like to get rid of that using the still relatively new [[`LegacyWindowAlias`](https://heycam.github.io/webidl/#LegacyWindowAlias)] extended attribute. However, Web IDL forbids that extended attribute from being used on partial interface definitions, and thus I had to open the PR here rather than as HTML. As much as I hate putting more HTML-specific things in DOM, I think this is minor enough to be okay.

As soon as this gets merged I'll open a PR to HTML removing that paragraph.

/cc @tobie


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/551.html" title="Last updated on Dec 25, 2017, 12:19 PM GMT (aab303c)">Preview</a> | <a href="https://whatpr.org/dom/551/5222eee...aab303c.html" title="Last updated on Dec 25, 2017, 12:19 PM GMT (aab303c)">Diff</a>