### PR TITLE
Change handling of is="" in element creation and cloning

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4180,9 +4180,9 @@ dom-Range-extractContents, dom-Range-cloneContents -->
   <ol>
    <li><p>Let <var>copy</var> be the result of <a>creating an element</a>, given
    <var>document</var>, <var>node</var>'s <a for=Element>local name</a>, <var>node</var>'s
-   <a for=Element>namespace</a>, <var>node</var>'s <a for=Element>namespace prefix</a>, and the
-   value of <var>node</var>'s <code>is</code> attribute if present (or null if not). The
-   <var>synchronous custom elements flag</var> should be unset.
+   <a for=Element>namespace</a>, <var>node</var>'s <a for=Element>namespace prefix</a>, and
+   <var>node</var>'s <a><code>is</code> value</a>, with the <var>synchronous custom elements
+   flag</var> unset.
 
    <li>
     <p><a for=list>For each</a> <var>attribute</var> in <var>node</var>'s
@@ -5089,21 +5089,15 @@ invoked, must run these steps:
  <var>localName</var> in <a>ASCII lowercase</a>.
  <!-- XXX why restrict this to HTML documents? -->
 
- <li>Let <var>is</var> be the value of <code>is</code> member of <var>options</var>, or null if no
+ <li>Let <var>is</var> be the value of the {{ElementCreationOptions/is}} member of <var>options</var>, or null if no
  such member exists.
 
  <li><p>Let <var>namespace</var> be the <a>HTML namespace</a>, if the <a>context object</a> is an
  <a>HTML document</a> or <a>context object</a>'s <a for=Document>content type</a> is
  "<code>application/xhtml+xml</code>", and null otherwise.
 
- <li>Let <var>element</var> be the result of <a>creating an element</a> given the
- <a>context object</a>, <var>localName</var>, <var>namespace</var>, null, <var>is</var>, and with
- the <var>synchronous custom elements</var> flag set.
-
- <li>If <var>is</var> is non-null, then <a>set an attribute value</a> for <var>element</var> using
- "<code>is</code>" and <var>is</var>.
-
- <li>Return <var>element</var>.
+ <li>Return the result of <a>creating an element</a> given the <a>context object</a>, <var>localName</var>,
+ <var>namespace</var>, null, <var>is</var>, and with the <var>synchronous custom elements</var> flag set.
 </ol>
 
 <p>The <dfn noexport>internal <code>createElementNS</code> steps</dfn>, given <var>document</var>,
@@ -5113,17 +5107,11 @@ invoked, must run these steps:
  <li>Let <var>namespace</var>, <var>prefix</var>, and <var>localName</var> be the result of passing
  <var>namespace</var> and <var>qualifiedName</var> to <a>validate and extract</a>.
 
- <li>Let <var>is</var> be the value of <code>is</code> member of <var>options</var>, or null if no
+ <li>Let <var>is</var> be the value of the {{ElementCreationOptions/is}} member of <var>options</var>, or null if no
  such member exists.
 
- <li><p>Let <var>element</var> be the result of <a>creating an element</a> given
- <var>document</var>, <var>localName</var>, <var>namespace</var>, <var>prefix</var>, <var>is</var>,
- and with the <var>synchronous custom elements</var> flag set.
-
- <li>If <var>is</var> is non-null, then <a>set an attribute value</a> for <var>element</var> using
- "<code>is</code>" and <var>is</var>.
-
- <li>Return <var>element</var>.
+ <li><p>Return the result of <a>creating an element</a> given <var>document</var>, <var>localName</var>,
+ <var>namespace</var>, <var>prefix</var>, <var>is</var>, and with the <var>synchronous custom elements</var> flag set.
 </ol>
 
 <p>The


### PR DESCRIPTION
Part of fixing https://github.com/whatwg/html/issues/3402. This changes two things:

* It fixes the cloning steps to consult the internal is value, instead of the is="" content attribute.
* It removes the step from createElement()/createElementNS() that would insert an is="" attribute in the created element, as we've now decided that is="" is a way of communicating to the parser, and not a general-purpose indicator of customized built-in-ness.

---

This is coupled with a HTML change I will be submitting shortly, to the serializer (and to several examples).

@tkent-google, will you be able to help with tests for this? I am happy to review.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/566.html" title="Last updated on Feb 2, 2018, 5:56 PM GMT (d510371)">Preview</a> | <a href="https://whatpr.org/dom/566/676fcbe...d510371.html" title="Last updated on Feb 2, 2018, 5:56 PM GMT (d510371)">Diff</a>