### PR TITLE
Following an abort signal

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1651,8 +1651,9 @@ them. For instance, if the operation has already completed.
  <li><p>[=Fire an event=] named <code>abort</code> at <var>signal</var>.
 </ol>
 
-<p>A <var>followingSignal</var> (an {{AbortSignal}}) <dfn export for=AbortSignal>follows</dfn> a
-<var>parentSignal</var> (an {{AbortSignal}}) by running these steps:
+<p>A <var>followingSignal</var> (an {{AbortSignal}}) is made to
+<dfn export for=AbortSignal>follow</dfn> a <var>parentSignal</var> (an {{AbortSignal}}) by running
+these steps:
 
 <ol>
  <li><p>If <var>followingSignal</var>'s [=AbortSignal/aborted flag=] is set, then return.

--- a/dom.bs
+++ b/dom.bs
@@ -1651,6 +1651,24 @@ them. For instance, if the operation has already completed.
  <li><p>[=Fire an event=] named <code>abort</code> at <var>signal</var>.
 </ol>
 
+<p>A <var>followingSignal</var> (an {{AbortSignal}}) <dfn export for=AbortSignal>follows</dfn> a
+<var>parentSignal</var> (an {{AbortSignal}}) by running these steps:
+
+<ol>
+ <li><p>If <var>followingSignal</var>'s [=AbortSignal/aborted flag=] is set, then return.
+
+ <li><p>If <var>parentSignal</var>'s [=AbortSignal/aborted flag=] is set, then
+ <a for=AbortSignal>signal abort</a> on <var>followingSignal</var>.
+
+ <li>
+  <p>Otherwise, <a for=AbortSignal lt=add>add the following abort steps</a> to
+  <var>parentSignal</var>:
+
+  <ol>
+   <li><p><a for=AbortSignal>Signal abort</a> on <var>followingSignal</var>.
+  </ol>
+</ol>
+
 
 <h3 id=abortcontroller-api-integration>Using {{AbortController}} and {{AbortSignal}} objects in
 APIs</h3>

--- a/dom.bs
+++ b/dom.bs
@@ -1698,7 +1698,7 @@ the following:
    <ol>
     <li><p>Let |amazingResult| be the result of doing some amazing things.
 
-    <li><p>[=Resolve=] |p| with |amazingResult|.
+    <li><p>[=/Resolve=] |p| with |amazingResult|.
    </ol>
 
   <li><p>Return |p|.


### PR DESCRIPTION
This PR makes it easier for one abort signal to follow another. This should avoid gotcha cases like https://github.com/whatwg/fetch/issues/668.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/569.html" title="Last updated on Feb 12, 2018, 8:34 AM GMT (9ddd54f)">Preview</a> | <a href="https://whatpr.org/dom/569/cebdfa1...9ddd54f.html" title="Last updated on Feb 12, 2018, 8:34 AM GMT (9ddd54f)">Diff</a>