### PR TITLE
Align with Selectors

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -251,8 +251,8 @@ against a <var>set</var>, run these steps:
  <li><p>If <var>s</var> is failure, then <a>throw</a> a "{{SyntaxError!!exception}}"
  {{DOMException}}.
 
- <li><p>Return the result of <a>evaluate a selector</a> <var>s</var> against <var>node</var>'s
- <a for=tree>root</a> using <a>scoping root</a> <var>node</var>. [[!SELECTORS4]].
+ <li><p>Return the result of <a>match a selector against a tree</a> with <var>s</var> and
+ <var>node</var>'s <a for=tree>root</a> using <a>scoping root</a> <var>node</var>. [[!SELECTORS4]].
 </ol>
 
 <p class=note>Support for namespaces within selectors is not planned and will not be
@@ -3102,7 +3102,7 @@ interface HTMLCollection {
 
 <p>An {{HTMLCollection}} object is a <a>collection</a> of <a for="/">elements</a>.
 
-<p class="note no-backref">{{HTMLCollection}} is an historical artifact we cannot rid the web of.
+<p class="note no-backref">{{HTMLCollection}} is a historical artifact we cannot rid the web of.
 While developers are of course welcome to keep using it, new API standard designers ought not to use
 it (use <code>sequence&lt;T></code> in IDL instead).
 
@@ -3323,7 +3323,7 @@ Each {{MutationObserver}} object has these associated concepts:
    <dt>{{MutationObserverInit/attributes}}
    <dd>Set to true if mutations to <var>target</var>'s
    <a>attributes</a> are to be observed. Can be omitted if
-   {{MutationObserverInit/attributeOldValue}} and/or
+   {{MutationObserverInit/attributeOldValue}} or
    {{MutationObserverInit/attributeFilter}} is
    specified.
 


### PR DESCRIPTION
They renamed "evaluate a selector" to "match a selector against a tree".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/573.html" title="Last updated on Feb 19, 2018, 1:25 PM GMT (fa3a425)">Preview</a> | <a href="https://whatpr.org/dom/573/fc601be...fa3a425.html" title="Last updated on Feb 19, 2018, 1:25 PM GMT (fa3a425)">Diff</a>