### PR TITLE
Change DOMTokenList's replace() to return boolean

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9527,7 +9527,7 @@ interface DOMTokenList {
   [CEReactions] void add(DOMString... tokens);
   [CEReactions] void remove(DOMString... tokens);
   [CEReactions] boolean toggle(DOMString token, optional boolean force);
-  [CEReactions] void replace(DOMString token, DOMString newToken);
+  [CEReactions] boolean replace(DOMString token, DOMString newToken);
   boolean supports(DOMString token);
   [CEReactions] stringifier attribute DOMString value;
   iterable&lt;DOMString>;
@@ -9646,6 +9646,7 @@ are to return the result of running <a>get an attribute value</a> given the asso
  <dt><code><var>tokenlist</var> . <a method for=DOMTokenList lt=replace()>replace(<var>token</var>, <var>newToken</var>)</a></code>
  <dd>
   <p>Replaces <var>token</var> with <var>newToken</var>.
+  <p>Returns true if <var>token</var> was replaced with <var>newToken</var>, and false otherwise.
   <p>Throws a "{{SyntaxError!!exception}}" {{DOMException}} if one of the arguments is the empty
   string.
   <p>Throws an "{{InvalidCharacterError!!exception}}" {{DOMException}} if one of the arguments
@@ -9771,12 +9772,14 @@ method, when invoked, must run these steps:
  <a>throw</a> an "{{InvalidCharacterError!!exception}}" {{DOMException}}.
 
  <li><p>If <a>context object</a>'s <a>token set</a> does not <a for=set>contain</a>
- <var>token</var>, then return.</p>
+ <var>token</var>, then return false.</p>
 
  <li><p><a for=set>Replace</a> <var>token</var> in <a>context object</a>'s <a>token set</a> with
  <var>newToken</var>.
 
  <li><p>Run the <a>update steps</a>.
+
+ <li><p>Return true.
 </ol>
 
 <p class="note no-backref">The <a>update steps</a> are not always run for {{DOMTokenList/replace()}}
@@ -10092,6 +10095,7 @@ Kirill Topolyan,
 Koji Ishii,
 Lachlan Hunt,
 Lauren Wood,
+Magne Andersson,
 Majid Valipour,
 Malte Ubl,
 Manish Goregaokar,


### PR DESCRIPTION
This specifies a return value for DOMTokenList's `replace(token, newToken)` method, making it return true if token was replaced by newToken and false otherwise. This is useful for code which takes different paths depending on whether a replacement occurred, avoiding the need for an extra condition using `contains()`.

I have modified the [Element-classlist.html](https://github.com/w3c/web-platform-tests/blob/master/dom/nodes/Element-classlist.html) test to include [testing](https://gist.github.com/Zirro/b0fb873ccb86eb3bb6596833558abca4#file-element-classlist-html-L406) of this change, and will submit a pull request to the WPT repository if it is approved here.

Fixes #577.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/582.html" title="Last updated on Mar 7, 2018, 6:10 PM GMT (fd0157c)">Preview</a> | <a href="https://whatpr.org/dom/582/c05ca60...fd0157c.html" title="Last updated on Mar 7, 2018, 6:10 PM GMT (fd0157c)">Diff</a>