### PR TITLE
Correct setting of target and relatedTargets post-dispatch

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1330,8 +1330,8 @@ for discussion).
 </ol>
 
 <p>To <dfn noexport id=concept-event-path-append>append to an event path</dfn>, given an
-<var>event</var>, <var>target</var>, <var>targetOverride</var>, <var>relatedTargets</var>, and a
-<var>slot-in-closed-tree</var>, run these steps:</p>
+<var>event</var>, <var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>,
+<var>touchTargets</var>, and a <var>slot-in-closed-tree</var>, run these steps:</p>
 
 <ol>
  <li><p>Let <var>root-of-closed-tree</var> be false.
@@ -1341,7 +1341,8 @@ for discussion).
 
  <li><p><a for=list>Append</a> a new <a for=/>struct</a> to <var>event</var>'s <a for=Event>path</a>
  whose <a for=Event/path>item</a> is <var>target</var>, <a for=Event/path>target</a> is
- <var>targetOverride</var>, <a for=Event/path>relatedTargets</a> is <var>relatedTargets</var>,
+ <var>targetOverride</var>, <a for=Event/path>relatedTarget</a> is <var>relatedTarget</var>,
+ <a for=Event/path>touch target list</a> is <var>touchTargets</var>,
  <a for=Event/path>root-of-closed-tree</a> is <var>root-of-closed-tree</var>, and
  <a for=Event/path>slot-in-closed-tree</a> is <var>slot-in-closed-tree</var>.
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -1173,140 +1173,148 @@ for discussion).
  <a for=Event>relatedTarget</a> against <var>target</var>.
 
  <li>
-  <p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not
-  <var>event</var>'s <a for=Event>relatedTarget</a>, then:
+  <p>If <var>target</var> is not <var>relatedTarget</var> or <var>target</var> is <var>event</var>'s
+  <a for=Event>relatedTarget</a>, then:
 
   <ol>
-   <li><p><a>Clear an event</a> with <var>event</var> and <var>clearTargets</var>.
-
-   <li><p>Return true.
-  </ol>
-
- <li><p>Let <var>touchTargets</var> be a new <a for=/>list</a>.
-
- <li><p><a for=list>For each</a> <var>touchTarget</var> of <var>event</var>'s
- <a for=Event>touch target list</a>, <a for=list>append</a> the result of <a>retargeting</a>
- <var>touchTarget</var> against <var>target</var> to <var>touchTargets</var>.
-
- <li><p><a>Append to an event path</a> with <var>event</var>, <var>target</var>,
- <var>targetOverride</var>, <var>relatedTarget</var>, <var>touchTargets</var>, and false.
-
- <li><p>Let <var>isActivationEvent</var> be true, if <var>event</var> is a {{MouseEvent}} object and
- <var>event</var>'s {{Event/type}} attribute is "<code>click</code>", and false otherwise.
-
- <li><p>Let <var>activationTarget</var> be <var>target</var>, if <var>isActivationEvent</var> is
- true and <var>target</var> has <a for=EventTarget>activation behavior</a>, and null otherwise.
-
- <li><p>Let <var>slotable</var> be <var>target</var>, if <var>target</var> is
- <a for=slotable>assigned</a>, and null otherwise.
-
- <li><p>Let <var>slot-in-closed-tree</var> be false.
-
- <li><p>Let <var>parent</var> be the result of invoking <var>target</var>'s <a>get the parent</a>
- with <var>event</var>.
-
- <li>
-  <p>While <var>parent</var> is non-null:</p>
-
-  <ol>
-   <li>
-    <p>If <var>slotable</var> is non-null:
-
-    <ol>
-     <li><p>Assert: <var>parent</var> is a <a for=/>slot</a>.
-
-     <li><p>Set <var>slotable</var> to null.
-
-     <li><p>If <var>parent</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a> whose
-     <a for=ShadowRoot>mode</a> is "<code>closed</code>", then set <var>slot-in-closed-tree</var> to
-     true.
-    </ol>
-
-   <li><p>If <var>parent</var> is a <a>slotable</a> and is <a for=slotable>assigned</a>, then set
-   <var>slotable</var> to <var>parent</var>.
-
-   <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
-   <a for=Event>relatedTarget</a> against <var>parent</var>.
-
    <li><p>Let <var>touchTargets</var> be a new <a for=/>list</a>.
 
    <li><p><a for=list>For each</a> <var>touchTarget</var> of <var>event</var>'s
-   <a for=Event>touchTargets</a>, <a for=list>append</a> the result of <a>retargeting</a>
+   <a for=Event>touch target list</a>, <a for=list>append</a> the result of <a>retargeting</a>
    <var>touchTarget</var> against <var>target</var> to <var>touchTargets</var>.
 
+   <li><p><a>Append to an event path</a> with <var>event</var>, <var>target</var>,
+   <var>targetOverride</var>, <var>relatedTarget</var>, <var>touchTargets</var>, and false.
+
+   <li><p>Let <var>isActivationEvent</var> be true, if <var>event</var> is a {{MouseEvent}} object
+   and <var>event</var>'s {{Event/type}} attribute is "<code>click</code>", and false otherwise.
+
+   <li><p>Let <var>activationTarget</var> be <var>target</var>, if <var>isActivationEvent</var> is
+   true and <var>target</var> has <a for=EventTarget>activation behavior</a>, and null otherwise.
+
+   <li><p>Let <var>slotable</var> be <var>target</var>, if <var>target</var> is
+   <a for=slotable>assigned</a>, and null otherwise.
+
+   <li><p>Let <var>slot-in-closed-tree</var> be false.
+
+   <li><p>Let <var>parent</var> be the result of invoking <var>target</var>'s <a>get the parent</a>
+   with <var>event</var>.
+
    <li>
-    <p>If <var>parent</var> is a <a>node</a> and <var>target</var>'s <a for=tree>root</a> is a
-    <a>shadow-including inclusive ancestor</a> of <var>parent</var>, then:
+    <p>While <var>parent</var> is non-null:</p>
 
     <ol>
-     <li><p>If <var>isActivationEvent</var> is true, <var>event</var>'s {{Event/bubbles}} attribute
-     is true, <var>activationTarget</var> is null, and <var>parent</var> has
-     <a for=EventTarget>activation behavior</a>, then set <var>activationTarget</var> to
-     <var>parent</var>.
+     <li>
+      <p>If <var>slotable</var> is non-null:
 
-     <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>, null,
-     <var>relatedTarget</var>, <var>touchTargets</var>, and <var>slot-in-closed-tree</var>.
+      <ol>
+       <li><p>Assert: <var>parent</var> is a <a for=/>slot</a>.
+
+       <li><p>Set <var>slotable</var> to null.
+
+       <li><p>If <var>parent</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a> whose
+       <a for=ShadowRoot>mode</a> is "<code>closed</code>", then set <var>slot-in-closed-tree</var>
+       to true.
+      </ol>
+
+     <li><p>If <var>parent</var> is a <a>slotable</a> and is <a for=slotable>assigned</a>, then set
+     <var>slotable</var> to <var>parent</var>.
+
+     <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
+     <a for=Event>relatedTarget</a> against <var>parent</var>.
+
+     <li><p>Let <var>touchTargets</var> be a new <a for=/>list</a>.
+
+     <li><p><a for=list>For each</a> <var>touchTarget</var> of <var>event</var>'s
+     <a for=Event>touch target list</a>, <a for=list>append</a> the result of <a>retargeting</a>
+     <var>touchTarget</var> against <var>target</var> to <var>touchTargets</var>.
+
+     <li>
+      <p>If <var>parent</var> is a <a>node</a> and <var>target</var>'s <a for=tree>root</a> is a
+      <a>shadow-including inclusive ancestor</a> of <var>parent</var>, then:
+
+      <ol>
+       <li><p>If <var>isActivationEvent</var> is true, <var>event</var>'s {{Event/bubbles}}
+       attribute is true, <var>activationTarget</var> is null, and <var>parent</var> has
+       <a for=EventTarget>activation behavior</a>, then set <var>activationTarget</var> to
+       <var>parent</var>.
+
+       <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>, null,
+       <var>relatedTarget</var>, <var>touchTargets</var>, and <var>slot-in-closed-tree</var>.
+      </ol>
+
+     <li><p>Otherwise, if <var>parent</var> is <var>relatedTarget</var>, then set <var>parent</var>
+     to null.
+
+     <li>
+      <p>Otherwise, set <var>target</var> to <var>parent</var> and then:
+
+      <ol>
+       <li><p>If <var>isActivationEvent</var> is true, <var>activationTarget</var> is null, and
+       <var>target</var> has <a for=EventTarget>activation behavior</a>, then set
+       <var>activationTarget</var> to <var>target</var>.
+
+       <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>,
+       <var>target</var>, <var>relatedTarget</var>, <var>touchTargets</var>, and
+       <var>slot-in-closed-tree</var>.
+      </ol>
+
+     <li><p>If <var>parent</var> is non-null, then set <var>parent</var> to the result of invoking
+     <var>parent</var>'s <a>get the parent</a> with <var>event</var>.
+
+     <li><p>Set <var>slot-in-closed-tree</var> to false.
     </ol>
 
-   <li><p>Otherwise, if <var>parent</var> is <var>relatedTarget</var>, then set <var>parent</var> to
-   null.
+   <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/CAPTURING_PHASE}}.
+
+   <li><p>If <var>activationTarget</var> is non-null and <var>activationTarget</var> has
+   <a for=EventTarget>legacy-pre-activation behavior</a>, then run <var>activationTarget</var>'s
+   <a for=EventTarget>legacy-pre-activation behavior</a>.
 
    <li>
-    <p>Otherwise, set <var>target</var> to <var>parent</var> and then:
+    <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
 
     <ol>
-     <li><p>If <var>isActivationEvent</var> is true, <var>activationTarget</var> is null, and
-     <var>target</var> has <a for=EventTarget>activation behavior</a>, then set
-     <var>activationTarget</var> to <var>target</var>.
-
-     <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>,
-     <var>target</var>, <var>relatedTarget</var>, <var>touchTargets</var>, and
-     <var>slot-in-closed-tree</var>.
+     <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a> with
+     <var>tuple</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
     </ol>
 
-   <li><p>If <var>parent</var> is non-null, then set <var>parent</var> to the result of invoking
-   <var>parent</var>'s <a>get the parent</a> with <var>event</var>.
+   <li>
+    <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in order:
 
-   <li><p>Set <var>slot-in-closed-tree</var> to false.
+    <ol>
+     <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is non-null, then set
+     <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
+
+     <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
+     {{Event/BUBBLING_PHASE}}.
+
+     <li><p>If either <var>event</var>'s {{Event/eventPhase}} attribute is {{Event/BUBBLING_PHASE}}
+     and <var>event</var>'s {{Event/bubbles}} attribute is true or <var>event</var>'s
+     {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> with
+     <var>tuple</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
+    </ol>
   </ol>
-
- <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/CAPTURING_PHASE}}.
-
- <li><p>If <var>activationTarget</var> is non-null and <var>activationTarget</var> has
- <a for=EventTarget>legacy-pre-activation behavior</a>, then run <var>activationTarget</var>'s
- <a for=EventTarget>legacy-pre-activation behavior</a>.
-
- <li>
-  <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
-
-  <ol>
-   <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a> with
-   <var>tuple</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
-  </ol>
-
- <li>
-  <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in order:
-
-  <ol>
-   <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is non-null, then set
-   <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
-
-   <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
-   {{Event/BUBBLING_PHASE}}.
-
-   <li><p>If either <var>event</var>'s {{Event/eventPhase}} attribute is {{Event/BUBBLING_PHASE}}
-   and <var>event</var>'s {{Event/bubbles}} attribute is true or <var>event</var>'s
-   {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> with <var>tuple</var>,
-   <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
-  </ol>
-
- <li><p><a>Clear an event</a> with <var>event</var> and <var>clearTargets</var>.
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 
  <li><p>Set <var>event</var>'s <a for=Event>path</a> to the empty list.
+
+ <li><p>Unset <var>event</var>'s <a>dispatch flag</a>, <a>stop propagation flag</a>, and
+ <a>stop immediate propagation flag</a>.
+
+ <li>
+  <p>If <var>clearTargets</var>, then:
+
+  <ol>
+   <li><p>Set <var>event</var>'s {{Event/target}} attribute to null.
+
+   <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to null.
+
+   <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to the empty list.
+  </ol>
 
  <li>
   <p>If <var>activationTarget</var> is non-null, then:
@@ -1339,25 +1347,6 @@ for discussion).
  <a for=Event/path>touch target list</a> is <var>touchTargets</var>,
  <a for=Event/path>root-of-closed-tree</a> is <var>root-of-closed-tree</var>, and
  <a for=Event/path>slot-in-closed-tree</a> is <var>slot-in-closed-tree</var>.
-</ol>
-
-<p>To <dfn noexport>clear an event</dfn>, given an <a for=/>event</a> <var>event</var> and a boolean
-<var>clearTargets</var>, run these steps:
-
-<ol>
- <li><p>Unset <var>event</var>'s <a>dispatch flag</a>, <a>stop propagation flag</a>, and
- <a>stop immediate propagation flag</a>.
-
- <li>
-  <p>If <var>clearTargets</var>, then:
-
-  <ol>
-   <li><p>Set <var>event</var>'s {{Event/target}} attribute to null.
-
-   <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to null.
-
-   <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to the empty list.
-  </ol>
 </ol>
 
 <p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn> an <var>object</var> with

--- a/dom.bs
+++ b/dom.bs
@@ -1164,7 +1164,7 @@ for discussion).
   <p class="note"><var>legacy target override flag</var> is only used by HTML and only when
   <var>target</var> is a {{Window}} object.
 
- <li><p>Let <var>clearTargetsPostDispatch</var> be true if <var>target</var>, <var>event</var>'s
+ <li><p>Let <var>clearTargets</var> be true if <var>target</var>, <var>event</var>'s
  <a for=Event>relatedTarget</a>, or an {{EventTarget}} object in <var>event</var>'s
  <a for=Event>touch target list</a> is a <a>node</a> and its <a for=tree>root</a> is a
  <a for=/>shadow root</a>, and false otherwise.
@@ -1172,9 +1172,15 @@ for discussion).
  <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
  <a for=Event>relatedTarget</a> against <var>target</var>.
 
- <li><p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not
- <var>event</var>'s <a for=Event>relatedTarget</a>, then return true.
- <!-- XXX Since we return early, we might want to unset more flags here. See #402. -->
+ <li>
+  <p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not
+  <var>event</var>'s <a for=Event>relatedTarget</a>, then:
+
+  <ol>
+   <li><p><a>Clear an event</a> with <var>event</var> and <var>clearTargets</var>.
+
+   <li><p>Return true.
+  </ol>
 
  <li><p>Let <var>touchTargets</var> be a new <a for=/>list</a>.
 
@@ -1294,21 +1300,9 @@ for discussion).
    <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
   </ol>
 
- <li><p>Unset <var>event</var>'s <a>dispatch flag</a>, <a>stop propagation flag</a>, and
- <a>stop immediate propagation flag</a>.
+ <li><p><a>Clear an event</a> with <var>event</var> and <var>clearTargets</var>.
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
-
- <li>
-  <p>If <var>clearTargetsPostDispatch</var>, then:
-
-  <ol>
-   <li><p>Set <var>event</var>'s {{Event/target}} attribute to null.
-
-   <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to null.
-
-   <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to the empty list.
-  </ol>
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 
@@ -1345,6 +1339,25 @@ for discussion).
  <a for=Event/path>touch target list</a> is <var>touchTargets</var>,
  <a for=Event/path>root-of-closed-tree</a> is <var>root-of-closed-tree</var>, and
  <a for=Event/path>slot-in-closed-tree</a> is <var>slot-in-closed-tree</var>.
+</ol>
+
+<p>To <dfn noexport>clear an event</dfn>, given an <a for=/>event</a> <var>event</var> and a boolean
+<var>clearTargets</var>, run these steps:
+
+<ol>
+ <li><p>Unset <var>event</var>'s <a>dispatch flag</a>, <a>stop propagation flag</a>, and
+ <a>stop immediate propagation flag</a>.
+
+ <li>
+  <p>If <var>clearTargets</var>, then:
+
+  <ol>
+   <li><p>Set <var>event</var>'s {{Event/target}} attribute to null.
+
+   <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to null.
+
+   <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to the empty list.
+  </ol>
 </ol>
 
 <p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn> an <var>object</var> with

--- a/dom.bs
+++ b/dom.bs
@@ -1153,9 +1153,9 @@ for discussion).
   <p class="note"><var>legacy target override flag</var> is only used by HTML and only when
   <var>target</var> is a {{Window}} object.
 
- <li><p>Let <var>clearTargetsPostDispatch</var> be true if <var>target</var>'s or one of
- <var>event</var>'s <a for=Event>relatedTargets</a>' <a for=tree>root</a> is a
- <a for=/>shadow root</a>, and false otherwise.
+ <li><p>Let <var>clearTargetsPostDispatch</var> be true if either <var>target</var> or one of
+ <var>event</var>'s <a for=Event>relatedTargets</a> is a <a>node</a> and its <a for=tree>root</a> is
+ a <a for=/>shadow root</a>, and false otherwise.
 
  <li><p>Let <var>relatedTargets</var> be a new <a for=/>list</a>.
 
@@ -1201,8 +1201,8 @@ for discussion).
      true.
     </ol>
 
-   <li><p>If <var>parent</var> is <a for=slotable>assigned</a>, then set <var>slotable</var> to
-   <var>parent</var>.
+   <li><p>If <var>parent</var> is a <a>slotable</a> and is <a for=slotable>assigned</a>, then set
+   <var>slotable</var> to <var>parent</var>.
 
    <li><p>Let <var>relatedTargets</var> be a new <a for=/>list</a>.
 
@@ -1211,7 +1211,7 @@ for discussion).
    <var>relatedTarget</var> against <var>target</var> to <var>relatedTargets</var>.
 
    <li>
-    <p>If <var>target</var>'s <a for=tree>root</a> is a
+    <p>If <var>parent</var> is a <a>node</a> and <var>target</var>'s <a for=tree>root</a> is a
     <a>shadow-including inclusive ancestor</a> of <var>parent</var>, then:
 
     <ol>
@@ -5627,11 +5627,21 @@ is an object or one of its <a>shadow-including ancestors</a>.
 <var>B</var>, repeat these steps until they return an object:</p>
 
 <ol>
- <li><p>If <var>A</var> is null, then return null.
+ <li><p>If <var>A</var> is a {{Window}} object, then set <var>A</var> to <var>A</var>'s
+ <a>associated <code>Document</code></a>.
 
- <li><p>If <var>A</var>'s <a for=tree>root</a> is not a <a for=/>shadow root</a>, or <var>A</var>'s
- <a for=tree>root</a> is a <a>shadow-including inclusive ancestor</a> of <var>B</var>, then return
- <var>A</var>.
+ <li>
+  <p>If one of the following is true
+
+  <ul class=brief>
+   <li><var>A</var> is not a <a>node</a>
+   <li><var>B</var> is not a <a>node</a>
+   <li><var>A</var>'s <a for=tree>root</a> is not a <a for=/>shadow root</a>
+   <li><var>A</var>'s <a for=tree>root</a> is a <a>shadow-including inclusive ancestor</a> of
+   <var>B</var>
+  </ul>
+
+  <p>then return <var>A</var>.
 
  <li><p>Set <var>A</var> to <var>A</var>'s <a for=tree>root</a>'s <a for=DocumentFragment>host</a>.
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -1169,6 +1169,8 @@ for discussion).
  <a for=Event>touch target list</a> is a <a>node</a> and its <a for=tree>root</a> is a
  <a for=/>shadow root</a>, and false otherwise.
 
+ <li><p>Let <var>activationTarget</var> be null.
+
  <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
  <a for=Event>relatedTarget</a> against <var>target</var>.
 
@@ -1189,8 +1191,9 @@ for discussion).
    <li><p>Let <var>isActivationEvent</var> be true, if <var>event</var> is a {{MouseEvent}} object
    and <var>event</var>'s {{Event/type}} attribute is "<code>click</code>", and false otherwise.
 
-   <li><p>Let <var>activationTarget</var> be <var>target</var>, if <var>isActivationEvent</var> is
-   true and <var>target</var> has <a for=EventTarget>activation behavior</a>, and null otherwise.
+   <li><p>If <var>isActivationEvent</var> is true and <var>target</var> has
+   <a for=EventTarget>activation behavior</a>, then set <var>activationTarget</var> to
+   <var>target</var>.
 
    <li><p>Let <var>slotable</var> be <var>target</var>, if <var>target</var> is
    <a for=slotable>assigned</a>, and null otherwise.

--- a/dom.bs
+++ b/dom.bs
@@ -5627,18 +5627,14 @@ is an object or one of its <a>shadow-including ancestors</a>.
 <var>B</var>, repeat these steps until they return an object:</p>
 
 <ol>
- <li><p>If <var>A</var> is a {{Window}} object, then set <var>A</var> to <var>A</var>'s
- <a>associated <code>Document</code></a>.
-
  <li>
   <p>If one of the following is true
 
   <ul class=brief>
    <li><var>A</var> is not a <a>node</a>
-   <li><var>B</var> is not a <a>node</a>
    <li><var>A</var>'s <a for=tree>root</a> is not a <a for=/>shadow root</a>
-   <li><var>A</var>'s <a for=tree>root</a> is a <a>shadow-including inclusive ancestor</a> of
-   <var>B</var>
+   <li><var>B</var> is a <a>node</a> and <var>A</var>'s <a for=tree>root</a> is a
+   <a>shadow-including inclusive ancestor</a> of <var>B</var>
   </ul>
 
   <p>then return <var>A</var>.
@@ -9838,6 +9834,7 @@ Tab Atkins,
 Takashi Sakamoto,
 Takayoshi Kochi,
 Theresa O'Connor,
+Theodore Dubois,
 <i>timeless</i>,
 Timo Tijhof,
 Tobie Langel,

--- a/dom.bs
+++ b/dom.bs
@@ -1164,11 +1164,6 @@ for discussion).
   <p class="note"><var>legacy target override flag</var> is only used by HTML and only when
   <var>target</var> is a {{Window}} object.
 
- <li><p>Let <var>clearTargets</var> be true if <var>target</var>, <var>event</var>'s
- <a for=Event>relatedTarget</a>, or an {{EventTarget}} object in <var>event</var>'s
- <a for=Event>touch target list</a> is a <a>node</a> and its <a for=tree>root</a> is a
- <a for=/>shadow root</a>, and false otherwise.
-
  <li><p>Let <var>activationTarget</var> be null.
 
  <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
@@ -1268,6 +1263,15 @@ for discussion).
      <li><p>Set <var>slot-in-closed-tree</var> to false.
     </ol>
 
+   <li><p>Let <var>clearTargetsTuple</var> be the last tuple in <var>event</var>'s
+   <a for=Event>path</a> whose <a for=Event/path>target</a> is non-null.
+
+   <li><p>Let <var>clearTargets</var> be true if <var>clearTargetsTuple</var>'s
+   <a for=Event/path>target</a>, <var>clearTargetsTuple</var>'s <a for=Event/path>relatedTarget</a>,
+   or an {{EventTarget}} object in <var>clearTargetsTuple</var>'s
+   <a for=Event/path>touch target list</a> is a <a for=/>node</a> and its <a for=tree>root</a> is a
+   <a for=/>shadow root</a>, and false otherwise.
+
    <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/CAPTURING_PHASE}}.
 
    <li><p>If <var>activationTarget</var> is non-null and <var>activationTarget</var> has
@@ -1352,12 +1356,10 @@ for discussion).
  <a for=Event/path>slot-in-closed-tree</a> is <var>slot-in-closed-tree</var>.
 </ol>
 
-<p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn> an <var>object</var> with
-<var>event</var> and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
+<p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn>, given a <var>tuple</var>,
+<var>event</var>, and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
 
 <ol>
- <li><p>If <var>event</var>'s <a>stop propagation flag</a> is set, then return.
-
  <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <a for=Event/path>target</a> of the
  last tuple in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or
  preceding <var>tuple</var>, whose <a for=Event/path>target</a> is non-null.
@@ -1368,14 +1370,13 @@ for discussion).
  <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to <var>tuple</var>'s
  <a for=Event/path>touch target list</a>.
 
+ <li><p>If <var>event</var>'s <a>stop propagation flag</a> is set, then return.
+
  <li><p>Let <var>object</var> be <var>tuple</var>'s <a for=Event/path>item</a>.
 
- <li><p>Let <var>listeners</var> be a new <a for=/>list</a>.
-
  <li>
-  <p><a for=list>For each</a> <var>listener</var> of <var>object</var>'s
-  <a for=EventTarget>event listener list</a>, <a for=list>append</a> <var>listener</var> to
-  <var>listeners</var>.
+  <p>Let <var>listeners</var> be a <a for=list>clone</a> of <var>object</var>'s
+  <a for=EventTarget>event listener list</a>.
 
   <p class="note no-backref">This avoids <a>event listeners</a> added after this point from being
   run. Note that removal still has an effect due to the <a for="event listener">removed</a> field.

--- a/dom.bs
+++ b/dom.bs
@@ -466,24 +466,23 @@ dictionary EventInit {
 <p>An {{Event}} object is simply named an <dfn export id=concept-event>event</dfn>. It allows for
 signaling that something has occurred, e.g., that an image has completed downloading.</p>
 
-<p>An <a>event</a> has an associated <dfn export for=Event>relatedTarget</dfn> (null or an
-{{EventTarget}} object). Unless stated otherwise it is null.</p>
+<p>A <dfn export>potential event target</dfn> is null or an {{EventTarget}} object.
 
-<p class="note">Other specifications use <a for=Event>relatedTarget</a> to define a
-<code>relatedTarget</code> attribute. [[UIEVENTS]]
+<p>An <a>event</a> has associated <dfn id=event-relatedtarget export for=Event>relatedTargets</dfn>
+(a <a for=/>list</a> of <a>potential event targets</a>). Unless stated otherwise it is the empty
+list.
+
+<p class="note">Other specifications use <a for=Event>relatedTargets</a> to define a
+<code>relatedTarget</code> attribute or equivalent functionality. [[UIEVENTS]] [[TOUCH-EVENTS]]
 
 <p>An <a>event</a> has an associated <dfn export for=Event>path</dfn>. A <a for=Event>path</a> is a
 <a for=/>list</a> of <a for=/>structs</a>. Each <a for=/>struct</a> consists of an
-<dfn for=Event/path>item</dfn> (an {{EventTarget}} object), <dfn for=Event/path>target</dfn> (null
-or an {{EventTarget}} object), a <dfn for=Event/path>relatedTarget</dfn> (null or an
-{{EventTarget}} object), <dfn for=Event/path>root-of-closed-tree</dfn> (a boolean), and a
+<dfn for=Event/path>item</dfn> (an {{EventTarget}} object), <dfn for=Event/path>target</dfn> (a
+<a>potential event target</a>), a
+<dfn id=event-path-relatedtarget for=Event/path>relatedTargets</dfn> (a <a for=/>list</a> of
+<a>potential event targets</a>), <dfn for=Event/path>root-of-closed-tree</dfn> (a boolean), and a
 <dfn for=Event/path>slot-in-closed-tree</dfn> (a boolean). A <a for=Event>path</a> is initially the
 empty list.</p>
-
-<p><a lt="Other applicable specifications">Specifications</a> may define
-<dfn export for=Event>retargeting steps</dfn> for all or some <a>events</a>.
-The algorithm is passed <var>event</var>, as indicated in the <a>dispatch</a>
-algorithm below.
 
 <dl class=domintro>
  <dt><code><var>event</var> = new <a constructor lt="Event()">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
@@ -1154,15 +1153,18 @@ for discussion).
   <p class="note"><var>legacy target override flag</var> is only used by HTML and only when
   <var>target</var> is a {{Window}} object.
 
- <li>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
- <a for=Event>relatedTarget</a> against <var>target</var> if <var>event</var>'s
- <a for=Event>relatedTarget</a> is non-null, and null otherwise.
+ <li><p>Let <var>relatedTargets</var> be a new <a for=/>list</a>.
 
- <li><p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not
- <var>event</var>'s <a for=Event>relatedTarget</a>, then return true.
+ <li><p><a for=list>For each</a> <var>relatedTarget</var> of <var>event</var>'s
+ <a for=Event>relatedTargets</a>, <a for=list>append</a> the result of <a>retargeting</a>
+ <var>relatedTarget</var> against <var>target</var> to <var>relatedTargets</var>.
+
+ <li><p>If <var>relatedTargets</var> <a for=list>contains</a> <var>target</var> and
+ <var>event</var>'s <a for=Event>relatedTargets</a> does not <a for=list>contain</a>
+ <var>target</var>, then return true.
 
  <li><p><a>Append to an event path</a> with <var>event</var>, <var>target</var>,
- <var>targetOverride</var>, <var>relatedTarget</var>, and false.
+ <var>targetOverride</var>, <var>relatedTargets</var>, and false.
 
  <li><p>Let <var>isActivationEvent</var> be true, if <var>event</var> is a {{MouseEvent}} object and
  <var>event</var>'s {{Event/type}} attribute is "<code>click</code>", and false otherwise.
@@ -1198,9 +1200,11 @@ for discussion).
    <li><p>If <var>parent</var> is <a for=slotable>assigned</a>, then set <var>slotable</var> to
    <var>parent</var>.
 
-   <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
-   <a for=Event>relatedTarget</a> against <var>parent</var> if <var>event</var>'s
-   <a for=Event>relatedTarget</a> is non-null, and null otherwise.
+   <li><p>Let <var>relatedTargets</var> be a new <a for=/>list</a>.
+
+   <li><p><a for=list>For each</a> <var>relatedTarget</var> of <var>event</var>'s
+   <a for=Event>relatedTargets</a>, <a for=list>append</a> the result of <a>retargeting</a>
+   <var>relatedTarget</var> against <var>target</var> to <var>relatedTargets</var>.
 
    <li>
     <p>If <var>target</var>'s <a for=tree>root</a> is a
@@ -1213,11 +1217,12 @@ for discussion).
      <var>parent</var>.
 
      <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>, null,
-     <var>relatedTarget</var>, and <var>slot-in-closed-tree</var>.
+     <var>relatedTargets</var>, and <var>slot-in-closed-tree</var>.
     </ol>
 
-   <li><p>Otherwise, if <var>parent</var> and <var>relatedTarget</var> are identical, then set
-   <var>parent</var> to null.
+   <li><p>Otherwise, if <var>relatedTargets</var> <a for=list>contains</a> <var>parent</var>, then
+   set <var>parent</var> to null.
+   <!-- XXX I'm not sure this is correct now relatedTargets is plural -->
 
    <li>
     <p>Otherwise, set <var>target</var> to <var>parent</var> and then:
@@ -1228,7 +1233,7 @@ for discussion).
      <var>activationTarget</var> to <var>target</var>.
 
      <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>,
-     <var>target</var>, <var>relatedTarget</var>, and <var>slot-in-closed-tree</var>.
+     <var>target</var>, <var>relatedTargets</var>, and <var>slot-in-closed-tree</var>.
     </ol>
 
    <li><p>If <var>parent</var> is non-null, then set <var>parent</var> to the result of invoking
@@ -1247,34 +1252,31 @@ for discussion).
   <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
 
   <ol>
-   <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <b>target</b> of the last tuple
-   in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or preceding
-   <var>tuple</var>, whose <b>target</b> is non-null.
+   <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <a for=Event/path>target</a> of
+   the last tuple in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or
+   preceding <var>tuple</var>, whose <a for=Event/path>target</a> is non-null.
 
-   <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to <var>tuple</var>'s
-   <b>relatedTarget</b>.
+   <li><p>Set <var>event</var>'s <a for=Event>relatedTargets</a> to <var>tuple</var>'s
+   <a for=Event/path>relatedTargets</a>.
 
-   <li><p>Run the <a>retargeting steps</a> with <var>event</var>.
-
-   <li><p>If <var>tuple</var>'s <b>target</b> is null, then <a>invoke</a> <var>tuple</var>'s
-   <b>item</b> with <var>event</var> and <var>legacyOutputDidListenersThrowFlag</var> if given.
+   <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a>
+   <var>tuple</var>'s <a for=Event/path>item</a> with <var>event</var> and
+   <var>legacyOutputDidListenersThrowFlag</var> if given.
   </ol>
 
  <li>
   <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in order:
 
   <ol>
-   <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <b>target</b> of the last tuple
-   in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or preceding
-   <var>tuple</var>, whose <b>target</b> is non-null.
+   <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <a for=Event/path>target</a> of
+   the last tuple in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or
+   preceding <var>tuple</var>, whose <a for=Event/path>target</a> is non-null.
 
-   <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to <var>tuple</var>'s
-   <b>relatedTarget</b>.
+   <li><p>Set <var>event</var>'s <a for=Event>relatedTargets</a> to <var>tuple</var>'s
+   <a for=Event/path>relatedTargets</a>.
 
-   <li><p>Run the <a>retargeting steps</a> with <var>event</var>.
-
-   <li><p>If <var>tuple</var>'s <b>target</b> is non-null, then set <var>event</var>'s
-   {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
+   <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is non-null, then set
+   <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
 
    <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
    {{Event/BUBBLING_PHASE}}.
@@ -1282,7 +1284,8 @@ for discussion).
    <li><p>If either <var>event</var>'s {{Event/eventPhase}} attribute is {{Event/BUBBLING_PHASE}}
    and <var>event</var>'s {{Event/bubbles}} attribute is true or <var>event</var>'s
    {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> <var>tuple</var>'s
-   <b>item</b> with <var>event</var> and <var>legacyOutputDidListenersThrowFlag</var> if given.
+   <a for=Event/path>item</a> with <var>event</var> and
+   <var>legacyOutputDidListenersThrowFlag</var> if given.
   </ol>
 
  <li><p>Unset <var>event</var>'s <a>dispatch flag</a>, <a>stop propagation flag</a>, and
@@ -1314,7 +1317,7 @@ for discussion).
 </ol>
 
 <p>To <dfn noexport id=concept-event-path-append>append to an event path</dfn>, given an
-<var>event</var>, <var>target</var>, <var>targetOverride</var>, <var>relatedTarget</var>, and a
+<var>event</var>, <var>target</var>, <var>targetOverride</var>, <var>relatedTargets</var>, and a
 <var>slot-in-closed-tree</var>, run these steps:</p>
 
 <ol>
@@ -1325,7 +1328,7 @@ for discussion).
 
  <li><p><a for=list>Append</a> a new <a for=/>struct</a> to <var>event</var>'s <a for=Event>path</a>
  whose <a for=Event/path>item</a> is <var>target</var>, <a for=Event/path>target</a> is
- <var>targetOverride</var>, <a for=Event/path>relatedTarget</a> is <var>relatedTarget</var>,
+ <var>targetOverride</var>, <a for=Event/path>relatedTargets</a> is <var>relatedTargets</var>,
  <a for=Event/path>root-of-closed-tree</a> is <var>root-of-closed-tree</var>, and
  <a for=Event/path>slot-in-closed-tree</a> is <var>slot-in-closed-tree</var>.
 </ol>
@@ -5621,6 +5624,8 @@ is an object or one of its <a>shadow-including ancestors</a>.
 <var>B</var>, repeat these steps until they return an object:</p>
 
 <ol>
+ <li><p>If <var>A</var> is null, then return null.
+
  <li><p>If <var>A</var>'s <a for=tree>root</a> is not a <a for=/>shadow root</a>, or <var>A</var>'s
  <a for=tree>root</a> is a <a>shadow-including inclusive ancestor</a> of <var>B</var>, then return
  <var>A</var>.

--- a/dom.bs
+++ b/dom.bs
@@ -798,10 +798,6 @@ method must, when invoked, run these steps:
 
 <h3 id=constructing-events>Constructing events</h3>
 
-<!-- XXX We need to add a callback of sorts here to be able to set relatedTarget and
-     touch target list properly. This is also needed for KeyboardEvent for some things and perhaps
-     more... -->
-
 <p>When a <dfn export for=Event id=concept-event-constructor>constructor</dfn> of the {{Event}}
 interface, or of an interface that inherits from the {{Event}} interface, is invoked, these steps
 must be run, given the arguments <var>type</var> and <var>eventInitDict</var>:

--- a/dom.bs
+++ b/dom.bs
@@ -1186,8 +1186,8 @@ for discussion).
    <a for=EventTarget>activation behavior</a>, then set <var>activationTarget</var> to
    <var>target</var>.
 
-   <li><p>Let <var>slotable</var> be <var>target</var>, if <var>target</var> is
-   <a for=slotable>assigned</a>, and null otherwise.
+   <li><p>Let <var>slotable</var> be <var>target</var>, if <var>target</var> is a <a>slotable</a>
+   and is <a for=slotable>assigned</a>, and null otherwise.
 
    <li><p>Let <var>slot-in-closed-tree</var> be false.
 

--- a/dom.bs
+++ b/dom.bs
@@ -468,21 +468,29 @@ signaling that something has occurred, e.g., that an image has completed downloa
 
 <p>A <dfn export>potential event target</dfn> is null or an {{EventTarget}} object.
 
-<p>An <a>event</a> has associated <dfn id=event-relatedtarget export for=Event>relatedTargets</dfn>
-(a <a for=/>list</a> of <a>potential event targets</a>). Unless stated otherwise it is the empty
-list.
+<p>An <a>event</a> has an associated
+<dfn id=event-relatedtarget export for=Event>relatedTarget</dfn> (a <a>potential event target</a>).
+Unless stated otherwise it is null.
 
-<p class="note">Other specifications use <a for=Event>relatedTargets</a> to define a
-<code>relatedTarget</code> attribute or equivalent functionality. [[UIEVENTS]] [[TOUCH-EVENTS]]
+<p class=note>Other specifications use <a for=Event>relatedTarget</a> to define a
+<code>relatedTarget</code> attribute. [[UIEVENTS]]
+
+<p>An <a>event</a> has an associated <dfn export for=Event>touch target list</dfn> (a
+<a for=/>list</a> of zero or more <a>potential event targets</a>). Unless stated otherwise it is the
+empty list.
+
+<p class=note>The <a for=Event>touch target list</a> is for the exclusive use of defining the
+{{TouchEvent}} interface and related interfaces. [[TOUCH-EVENTS]]
 
 <p>An <a>event</a> has an associated <dfn export for=Event>path</dfn>. A <a for=Event>path</a> is a
 <a for=/>list</a> of <a for=/>structs</a>. Each <a for=/>struct</a> consists of an
 <dfn for=Event/path>item</dfn> (an {{EventTarget}} object), <dfn for=Event/path>target</dfn> (a
 <a>potential event target</a>), a
-<dfn id=event-path-relatedtarget for=Event/path>relatedTargets</dfn> (a <a for=/>list</a> of
-<a>potential event targets</a>), <dfn for=Event/path>root-of-closed-tree</dfn> (a boolean), and a
-<dfn for=Event/path>slot-in-closed-tree</dfn> (a boolean). A <a for=Event>path</a> is initially the
-empty list.</p>
+<dfn id=event-path-relatedtarget for=Event/path>relatedTarget</dfn> (a
+<a>potential event target</a>), a <dfn for=Event/path>touch target list</dfn> (a <a for=/>list</a>
+of <a>potential event targets</a>), a <dfn for=Event/path>root-of-closed-tree</dfn> (a boolean), and
+a <dfn for=Event/path>slot-in-closed-tree</dfn> (a boolean). A <a for=Event>path</a> is initially
+the empty list.</p>
 
 <dl class=domintro>
  <dt><code><var>event</var> = new <a constructor lt="Event()">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
@@ -790,6 +798,10 @@ method must, when invoked, run these steps:
 
 
 <h3 id=constructing-events>Constructing events</h3>
+
+<!-- XXX We need to add a callback of sorts here to be able to set relatedTarget and
+     touch target list properly. This is also needed for KeyboardEvent for some things and perhaps
+     more... -->
 
 <p>When a <dfn export for=Event id=concept-event-constructor>constructor</dfn> of the {{Event}}
 interface, or of an interface that inherits from the {{Event}} interface, is invoked, these steps
@@ -1153,22 +1165,26 @@ for discussion).
   <p class="note"><var>legacy target override flag</var> is only used by HTML and only when
   <var>target</var> is a {{Window}} object.
 
- <li><p>Let <var>clearTargetsPostDispatch</var> be true if either <var>target</var> or one of
- <var>event</var>'s <a for=Event>relatedTargets</a> is a <a>node</a> and its <a for=tree>root</a> is
- a <a for=/>shadow root</a>, and false otherwise.
+ <li><p>Let <var>clearTargetsPostDispatch</var> be true if <var>target</var>, <var>event</var>'s
+ <a for=Event>relatedTarget</a>, or an {{EventTarget}} object in <var>event</var>'s
+ <a for=Event>touch target list</a> is a <a>node</a> and its <a for=tree>root</a> is a
+ <a for=/>shadow root</a>, and false otherwise.
 
- <li><p>Let <var>relatedTargets</var> be a new <a for=/>list</a>.
+ <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
+ <a for=Event>relatedTarget</a> against <var>target</var>.
 
- <li><p><a for=list>For each</a> <var>relatedTarget</var> of <var>event</var>'s
- <a for=Event>relatedTargets</a>, <a for=list>append</a> the result of <a>retargeting</a>
- <var>relatedTarget</var> against <var>target</var> to <var>relatedTargets</var>.
+ <li><p>If <var>target</var> is <var>relatedTarget</var> and <var>target</var> is not
+ <var>event</var>'s <a for=Event>relatedTarget</a>, then return true.
+ <!-- XXX Since we return early, we might want to unset more flags here. See #402. -->
 
- <li><p>If <var>relatedTargets</var> <a for=list>contains</a> <var>target</var> and
- <var>event</var>'s <a for=Event>relatedTargets</a> does not <a for=list>contain</a>
- <var>target</var>, then return true.
+ <li><p>Let <var>touchTargets</var> be a new <a for=/>list</a>.
+
+ <li><p><a for=list>For each</a> <var>touchTarget</var> of <var>event</var>'s
+ <a for=Event>touch target list</a>, <a for=list>append</a> the result of <a>retargeting</a>
+ <var>touchTarget</var> against <var>target</var> to <var>touchTargets</var>.
 
  <li><p><a>Append to an event path</a> with <var>event</var>, <var>target</var>,
- <var>targetOverride</var>, <var>relatedTargets</var>, and false.
+ <var>targetOverride</var>, <var>relatedTarget</var>, <var>touchTargets</var>, and false.
 
  <li><p>Let <var>isActivationEvent</var> be true, if <var>event</var> is a {{MouseEvent}} object and
  <var>event</var>'s {{Event/type}} attribute is "<code>click</code>", and false otherwise.
@@ -1204,11 +1220,14 @@ for discussion).
    <li><p>If <var>parent</var> is a <a>slotable</a> and is <a for=slotable>assigned</a>, then set
    <var>slotable</var> to <var>parent</var>.
 
-   <li><p>Let <var>relatedTargets</var> be a new <a for=/>list</a>.
+   <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
+   <a for=Event>relatedTarget</a> against <var>parent</var>.
 
-   <li><p><a for=list>For each</a> <var>relatedTarget</var> of <var>event</var>'s
-   <a for=Event>relatedTargets</a>, <a for=list>append</a> the result of <a>retargeting</a>
-   <var>relatedTarget</var> against <var>target</var> to <var>relatedTargets</var>.
+   <li><p>Let <var>touchTargets</var> be a new <a for=/>list</a>.
+
+   <li><p><a for=list>For each</a> <var>touchTarget</var> of <var>event</var>'s
+   <a for=Event>touchTargets</a>, <a for=list>append</a> the result of <a>retargeting</a>
+   <var>touchTarget</var> against <var>target</var> to <var>touchTargets</var>.
 
    <li>
     <p>If <var>parent</var> is a <a>node</a> and <var>target</var>'s <a for=tree>root</a> is a
@@ -1221,12 +1240,11 @@ for discussion).
      <var>parent</var>.
 
      <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>, null,
-     <var>relatedTargets</var>, and <var>slot-in-closed-tree</var>.
+     <var>relatedTarget</var>, <var>touchTargets</var>, and <var>slot-in-closed-tree</var>.
     </ol>
 
-   <li><p>Otherwise, if <var>relatedTargets</var> <a for=list>contains</a> <var>parent</var>, then
-   set <var>parent</var> to null.
-   <!-- XXX I'm not sure this is correct now relatedTargets is plural -->
+   <li><p>Otherwise, if <var>parent</var> is <var>relatedTarget</var>, then set <var>parent</var> to
+   null.
 
    <li>
     <p>Otherwise, set <var>target</var> to <var>parent</var> and then:
@@ -1237,7 +1255,8 @@ for discussion).
      <var>activationTarget</var> to <var>target</var>.
 
      <li><p><a>Append to an event path</a> with <var>event</var>, <var>parent</var>,
-     <var>target</var>, <var>relatedTargets</var>, and <var>slot-in-closed-tree</var>.
+     <var>target</var>, <var>relatedTarget</var>, <var>touchTargets</var>, and
+     <var>slot-in-closed-tree</var>.
     </ol>
 
    <li><p>If <var>parent</var> is non-null, then set <var>parent</var> to the result of invoking
@@ -1256,29 +1275,14 @@ for discussion).
   <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
 
   <ol>
-   <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <a for=Event/path>target</a> of
-   the last tuple in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or
-   preceding <var>tuple</var>, whose <a for=Event/path>target</a> is non-null.
-
-   <li><p>Set <var>event</var>'s <a for=Event>relatedTargets</a> to <var>tuple</var>'s
-   <a for=Event/path>relatedTargets</a>.
-
-   <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a>
-   <var>tuple</var>'s <a for=Event/path>item</a> with <var>event</var> and
-   <var>legacyOutputDidListenersThrowFlag</var> if given.
+   <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a> with
+   <var>tuple</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
   </ol>
 
  <li>
   <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in order:
 
   <ol>
-   <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <a for=Event/path>target</a> of
-   the last tuple in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or
-   preceding <var>tuple</var>, whose <a for=Event/path>target</a> is non-null.
-
-   <li><p>Set <var>event</var>'s <a for=Event>relatedTargets</a> to <var>tuple</var>'s
-   <a for=Event/path>relatedTargets</a>.
-
    <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is non-null, then set
    <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
 
@@ -1287,9 +1291,8 @@ for discussion).
 
    <li><p>If either <var>event</var>'s {{Event/eventPhase}} attribute is {{Event/BUBBLING_PHASE}}
    and <var>event</var>'s {{Event/bubbles}} attribute is true or <var>event</var>'s
-   {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> <var>tuple</var>'s
-   <a for=Event/path>item</a> with <var>event</var> and
-   <var>legacyOutputDidListenersThrowFlag</var> if given.
+   {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> with <var>tuple</var>,
+   <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
   </ol>
 
  <li><p>Unset <var>event</var>'s <a>dispatch flag</a>, <a>stop propagation flag</a>, and
@@ -1297,8 +1300,16 @@ for discussion).
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
- <li><p>If <a>clearTargetsPostDispatch</a>, then set <var>event</var>'s {{Event/target}} attribute
- to null and <var>event</var>'s <a for=Event>relatedTargets</a> to the empty list.
+ <li>
+  <p>If <var>clearTargetsPostDispatch</var>, then:
+
+  <ol>
+   <li><p>Set <var>event</var>'s {{Event/target}} attribute to null.
+
+   <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to null.
+
+   <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to the empty list.
+  </ol>
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 
@@ -1341,6 +1352,18 @@ for discussion).
 
 <ol>
  <li><p>If <var>event</var>'s <a>stop propagation flag</a> is set, then return.
+
+ <li><p>Set <var>event</var>'s {{Event/target}} attribute to the <a for=Event/path>target</a> of the
+ last tuple in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or
+ preceding <var>tuple</var>, whose <a for=Event/path>target</a> is non-null.
+
+ <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to <var>tuple</var>'s
+ <a for=Event/path>relatedTarget</a>.
+
+ <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to <var>tuple</var>'s
+ <a for=Event/path>touch target list</a>.
+
+ <li><p>Let <var>object</var> be <var>tuple</var>'s <a for=Event/path>item</a>.
 
  <li><p>Let <var>listeners</var> be a new <a for=/>list</a>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1153,6 +1153,10 @@ for discussion).
   <p class="note"><var>legacy target override flag</var> is only used by HTML and only when
   <var>target</var> is a {{Window}} object.
 
+ <li><p>Let <var>clearTargetsPostDispatch</var> be true if <var>target</var>'s or one of
+ <var>event</var>'s <a for=Event>relatedTargets</a>' <a for=tree>root</a> is a
+ <a for=/>shadow root</a>, and false otherwise.
+
  <li><p>Let <var>relatedTargets</var> be a new <a for=/>list</a>.
 
  <li><p><a for=list>For each</a> <var>relatedTarget</var> of <var>event</var>'s
@@ -1293,9 +1297,8 @@ for discussion).
 
  <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/NONE}}.
 
- <li><p>If {{Event/target}}'s <a for=tree>root</a> is a <a for=/>shadow root</a>, then set
- <var>event</var>'s {{Event/target}} attribute and <var>event</var>'s <a for=Event>relatedTarget</a>
- to null.
+ <li><p>If <a>clearTargetsPostDispatch</a>, then set <var>event</var>'s {{Event/target}} attribute
+ to null and <var>event</var>'s <a for=Event>relatedTargets</a> to the empty list.
 
  <li><p>Set <var>event</var>'s {{Event/currentTarget}} attribute to null.
 

--- a/dom.bs
+++ b/dom.bs
@@ -468,9 +468,8 @@ signaling that something has occurred, e.g., that an image has completed downloa
 
 <p>A <dfn export>potential event target</dfn> is null or an {{EventTarget}} object.
 
-<p>An <a>event</a> has an associated
-<dfn id=event-relatedtarget export for=Event>relatedTarget</dfn> (a <a>potential event target</a>).
-Unless stated otherwise it is null.
+<p>An <a>event</a> has an associated <dfn export for=Event>relatedTarget</dfn> (a
+<a>potential event target</a>). Unless stated otherwise it is null.
 
 <p class=note>Other specifications use <a for=Event>relatedTarget</a> to define a
 <code>relatedTarget</code> attribute. [[UIEVENTS]]

--- a/dom.bs
+++ b/dom.bs
@@ -1221,7 +1221,7 @@ for discussion).
 
      <li><p><a for=list>For each</a> <var>touchTarget</var> of <var>event</var>'s
      <a for=Event>touch target list</a>, <a for=list>append</a> the result of <a>retargeting</a>
-     <var>touchTarget</var> against <var>target</var> to <var>touchTargets</var>.
+     <var>touchTarget</var> against <var>parent</var> to <var>touchTargets</var>.
 
      <li>
       <p>If <var>parent</var> is a <a>node</a> and <var>target</var>'s <a for=tree>root</a> is a


### PR DESCRIPTION
@whatwg/components this fixes the following:

* Adds "touch target list" as a concept hold by event, so touch events can be retargeted. (This will require some special handling for Touch objects, but I think it's workable.)
* It now resets target/relatedTarget/touch target list post-dispatch based on pre-dispatch conditions.
* It makes dispatch account for non-nodes.

(The one thing remaining here is having a good look at event constructors and making sure we can make that work for the relatedTargets design. I think that requires some kind of callback type thing.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/585.html" title="Last updated on Mar 27, 2018, 10:30 AM GMT (67e64b4)">Preview</a> | <a href="https://whatpr.org/dom/585/5be84cc...67e64b4.html" title="Last updated on Mar 27, 2018, 10:30 AM GMT (67e64b4)">Diff</a>