### PR TITLE
Add AbstractRange and StaticRange

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -936,7 +936,7 @@ object, an <a>event listener</a> is a broader concept as can be seen above.
 which takes an <a>event</a> <var>event</var>, and returns an {{EventTarget}} object. Unless
 specified otherwise it returns null.
 
-<p class="note no-backref"><a for=/>nodes</a>, <a for=/>shadow roots</a>, and <a>documents</a>
+<p class="note no-backref"><a for=/>Nodes</a>, <a for=/>shadow roots</a>, and <a>documents</a>
 override the <a>get the parent</a> algorithm.
 
 <p>Each {{EventTarget}} object can have an associated
@@ -3539,14 +3539,11 @@ be initialized to null.
 
 <h4 id=garbage-collection>Garbage collection</h4>
 
-<a for=/>nodes</a> have a strong reference to
-<a>registered observers</a> in their
-list of <a>registered observers</a>.
+<p><a for=/>Nodes</a> have a strong reference to <a>registered observers</a> in their list of
+<a>registered observers</a>.
 
-<a>Registered observers</a> in a
-<a>node</a>'s list of
-<a>registered observers</a> have a weak
-reference to the <a>node</a>.
+<p><a>Registered observers</a> in a <a for=/>node</a>'s list of <a>registered observers</a> have a
+weak reference to the <a for=/>node</a>.
 
 
 <h3 id=interface-node>Interface {{Node}}</h3>
@@ -7266,9 +7263,9 @@ algorithms for the hairy details.
 <dfn export for="boundary point">node</dfn> (a <a for=/>node</a>) and an
 <dfn export id=concept-range-bp-offset for="boundary point">offset</dfn> (a non-negative integer).
 
-<p class="note no-backref">Generally speaking, a <a>boundary point</a>'s
-<a for="boundary point">offset</a> will be between 0 and the <a>boundary point</a>'s
-<a for="boundary point">node</a>'s <a>length</a>, inclusive.
+<p class="note no-backref">A correct <a>boundary point</a>'s <a for="boundary point">offset</a> will
+be between 0 and the <a>boundary point</a>'s <a for="boundary point">node</a>'s
+<a for=Node>length</a>, inclusive.
 
 <p>The <dfn export id=concept-range-bp-position for="boundary point">position</dfn> of a
 <a>boundary point</a> (<var>nodeA</var>, <var>offsetA</var>) relative to a <a>boundary point</a>
@@ -7450,7 +7447,7 @@ in a <a>live range</a> <var>range</var> if <var>node</var>'s <a for=tree>root</a
 
 <p>A <a for=/>node</a> is
 <dfn export for="live range" id=partially-contained>partially contained</dfn> in a <a>live range</a>
-if its an <a for=tree>inclusive ancestor</a> of the <a>live range</a>'s <a for=range>start node</a>
+if it's an <a for=tree>inclusive ancestor</a> of the <a>live range</a>'s <a for=range>start node</a>
 but not its <a for=range>end node</a>, or vice versa.
 
 <div class="note no-backref">
@@ -8689,33 +8686,27 @@ Firefox 12.0a1. -->
 these steps:
 
 <ol>
- <li>Let <var>s</var> be the empty string.
+ <li><p>Let <var>s</var> be the empty string.
 
- <li>If <a for=range>start node</a> is <a for=range>end node</a>, and it is a
- {{Text}} <a>node</a>, return the
- substring of that {{Text}} <a>node</a>'s <a for=CharacterData>data</a> beginning at
- <a for=range>start offset</a> and ending at
+ <li><p>If the <a>context object</a>'s <a for=range>start node</a> is the <a>context object</a>'s
+ <a for=range>end node</a> and it is a {{Text}} <a>node</a>, then return the substring of that
+ {{Text}} <a>node</a>'s <a for=CharacterData>data</a> beginning at the <a>context object</a>'s
+ <a for=range>start offset</a> and ending at the <a>context object</a>'s
  <a for=range>end offset</a>.
 
- <li>If <a for=range>start node</a> is a
- {{Text}} <a>node</a>, append to
- <var>s</var> the substring of that
- <a>node</a>'s
- <a for=CharacterData>data</a> from the
- <a for=range>start offset</a> until the end.
+ <li><p>If the <a>context object</a>'s <a for=range>start node</a> is a {{Text}} <a>node</a>, then
+ append the substring of that <a>node</a>'s <a for=CharacterData>data</a> from the
+ <a>context object</a>'s <a for=range>start offset</a> until the end to <var>s</var>.
 
- <li>Append the <a for=string>concatenation</a> of the <a for=CharacterData>data</a> of all {{Text}}
- <a for=/>nodes</a> that are <a for="live range">contained</a> in the <a>context object</a>, in <a>tree order</a>, to
- <var>s</var>.
+ <li><p>Append the <a for=string>concatenation</a> of the <a for=CharacterData>data</a> of all
+ {{Text}} <a for=/>nodes</a> that are <a for="live range">contained</a> in the
+ <a>context object</a>, in <a>tree order</a>, to <var>s</var>.
 
- <li>If <a for=range>end node</a> is a
- {{Text}} <a>node</a>, append to
- <var>s</var> the substring of that
- <a>node</a>'s
- <a for=CharacterData>data</a> from its start until the
- <a for=range>end offset</a>.
+ <li><p>If the <a>context object</a>'s <a for=range>end node</a> is a {{Text}} <a>node</a>, then
+ append the substring of that <a>node</a>'s <a for=CharacterData>data</a> from its start until the
+ <a>context object</a>'s <a for=range>end offset</a> to <var>s</var>.
 
- <li>Return <var>s</var>.
+ <li><p>Return <var>s</var>.
 </ol>
 
 <hr>
@@ -9642,7 +9633,7 @@ These are the changes made to the features described in
 
 {{Node}} now inherits from {{EventTarget}}.
 
-<a for=/>nodes</a> are implicitly
+<a for=/>Nodes</a> are implicitly
 <a>adopted</a> across
 <a>document</a> boundaries.
 

--- a/dom.bs
+++ b/dom.bs
@@ -516,7 +516,7 @@ algorithm below.
 
  <dt><code><var>event</var> . {{Event/composedPath()}}</code>
  <dd>Returns the <a for=Event/path>item</a> objects of <var>event</var>'s <a for=Event>path</a>
- (objects on which listeners will be invoked), except for any <a>nodes</a> in
+ (objects on which listeners will be invoked), except for any <a for=/>nodes</a> in
  <a for=/>shadow trees</a> of which the <a for=/>shadow root</a>'s <a for=ShadowRoot>mode</a> is
  "<code>closed</code>" that are not reachable from <var>event</var>'s {{Event/currentTarget}}.
 
@@ -936,8 +936,8 @@ object, an <a>event listener</a> is a broader concept as can be seen above.
 which takes an <a>event</a> <var>event</var>, and returns an {{EventTarget}} object. Unless
 specified otherwise it returns null.
 
-<p class="note no-backref"><a>Nodes</a>, <a for=/>shadow roots</a>, and <a>documents</a> override
-the <a>get the parent</a> algorithm.
+<p class="note no-backref"><a for=/>nodes</a>, <a for=/>shadow roots</a>, and <a>documents</a>
+override the <a>get the parent</a> algorithm.
 
 <p>Each {{EventTarget}} object can have an associated
 <dfn export for=EventTarget>activation behavior</dfn> algorithm. The
@@ -1759,8 +1759,8 @@ markup-based resource, ranging from short static documents to long essays or
 reports with rich multimedia, as well as to fully-fledged interactive
 applications.
 
-Each such document is represented as a <a>node tree</a>. Some of the <a>nodes</a> in a <a>tree</a>
-can have <a>children</a>, while others are always leaves.
+<p>Each such document is represented as a <a>node tree</a>. Some of the <a for=/>nodes</a> in a
+<a>tree</a> can have <a>children</a>, while others are always leaves.
 
 To illustrate, consider this HTML document:
 
@@ -1809,12 +1809,9 @@ It is represented as follows:
 https://software.hixie.ch/utilities/js/live-dom-viewer/?%3C!DOCTYPE%20html%3E%0D%0A%3Chtml%20class%3De%3E%0D%0A%20%3Chead%3E%3Ctitle%3EAliens%3F%3C%2Ftitle%3E%3C%2Fhead%3E%0D%0A%20%3Cbody%3EWhy%20yes.%3C%2Fbody%3E%0D%0A%3C%2Fhtml%3E
 -->
 
-Note that, due to the magic that is
-<a lt="html parser">HTML parsing</a>, not all
-<a>ASCII whitespace</a> were turned into
-{{Text}} <a>nodes</a>, but the general
-concept is clear. Markup goes in, a <a>tree</a> of
-<a>nodes</a> comes out.
+<p>Note that, due to the magic that is <a lt="html parser">HTML parsing</a>, not all
+<a>ASCII whitespace</a> were turned into {{Text}} <a for=/>nodes</a>, but the general concept is
+clear. Markup goes in, a <a>tree</a> of <a for=/>nodes</a> comes out.
 <!-- You /can/ explain that! harharhar -->
 
 <p class="note no-backref">The most excellent
@@ -1950,7 +1947,7 @@ otherwise it is the empty string.</p>
 
 <h5 id=light-tree-slotables>Slotables</h5>
 
-<p>{{Element}} and {{Text}} <a>nodes</a> are
+<p>{{Element}} and {{Text}} <a for=/>nodes</a> are
 <dfn export id=concept-slotable lt=slotable>slotables</dfn>.</p>
 
 <p class="note">A <a>slot</a> can be a <a>slotable</a>.
@@ -2216,16 +2213,16 @@ of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run the
  <var>node</var> into <var>parent</var>'s
  <a for=Node>node document</a>.
 
- <li><a>Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>.
+ <li><a for=/>Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>.
 
  <li>Return <var>node</var>.
  <!-- technically this is post-insert -->
 </ol>
 
 <p><a lt="Other applicable specifications">Specifications</a> may define
-<dfn export id=concept-node-insert-ext>insertion steps</dfn> for all or some <a>nodes</a>. The
-algorithm is passed <var ignore>insertedNode</var>, as indicated in the <a>insert</a> algorithm
-below.
+<dfn export id=concept-node-insert-ext>insertion steps</dfn> for all or some <a for=/>nodes</a>. The
+algorithm is passed <var ignore>insertedNode</var>, as indicated in the <a for=/>insert</a>
+algorithm below.
 <!-- See https://github.com/whatwg/dom/issues/34#issuecomment-125571750 for why we might need to
      adjust this further based on the requirements of the script element. There might be other ways
      to define that though as Olli suggests, so leaving that out for now. -->
@@ -2243,21 +2240,13 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   <p>If <var>child</var> is non-null, then:
 
   <ol>
-   <li>For each <a>range</a> whose
-   <a for=Range>start node</a> is
-   <var>parent</var> and
-   <a>start offset</a> is greater than
-   <var>child</var>'s <a for=tree>index</a>,
-   increase its <a>start offset</a> by
-   <var>count</var>.
+   <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>parent</var> and
+   <a for=range>start offset</a> is greater than <var>child</var>'s <a for=tree>index</a>, increase
+   its <a for=range>start offset</a> by <var>count</var>.
 
-   <li>For each <a>range</a> whose
-   <a for=Range>end node</a> is
-   <var>parent</var> and
-   <a>end offset</a> is greater than
-   <var>child</var>'s <a for=tree>index</a>,
-   increase its <a>end offset</a> by
-   <var>count</var>.
+   <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>parent</var> and
+   <a for=range>end offset</a> is greater than <var>child</var>'s <a for=tree>index</a>, increase
+   its <a for=range>end offset</a> by <var>count</var>.
   </ol>
 
  <li>Let <var>nodes</var> be <var>node</var>'s
@@ -2450,8 +2439,8 @@ within a <var>parent</var>, run these steps:
  <!-- This needs to come before insert as that removes the children of a
       DocumentFragment node. -->
 
- <li><a>Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var> with
- the <i>suppress observers flag</i> set.
+ <li><p><a for=/>Insert</a> <var>node</var> into <var>parent</var> before <var>reference child</var>
+ with the <i>suppress observers flag</i> set.
 
  <li><a>Queue a mutation record</a> of "<code>childList</code>" for target
  <var>parent</var> with addedNodes <var>nodes</var>, removedNodes <var>removedNodes</var>,
@@ -2485,8 +2474,7 @@ To <dfn export for=Node id=concept-node-replace-all>replace all</dfn> with a
  <a>tree order</a>, with the
  <i>suppress observers flag</i> set.
 
- <li>If <var>node</var> is not null,
- <a>insert</a> <var>node</var> into
+ <li><p>If <var>node</var> is not null, then <a for=/>insert</a> <var>node</var> into
  <var>parent</var> before null with the <i>suppress observers flag</i> set.
 
  <li><a>Queue a mutation record</a> of "<code>childList</code>" for
@@ -2513,7 +2501,7 @@ To <dfn export id=concept-node-pre-remove>pre-remove</dfn> a <var>child</var> fr
 
 
 <p><a lt="Other applicable specifications">Specifications</a> may define
-<dfn export id=concept-node-remove-ext>removing steps</dfn> for all or some <a>nodes</a>. The
+<dfn export id=concept-node-remove-ext>removing steps</dfn> for all or some <a for=/>nodes</a>. The
 algorithm is passed <var ignore>removedNode</var>, and optionally <var ignore>oldParent</var>, as
 indicated in the <a for=/>remove</a> algorithm below.
 
@@ -2524,33 +2512,20 @@ with an optional <i>suppress observers flag</i>, run these steps:
  <li>Let <var>index</var> be <var>node</var>'s
  <a for=tree>index</a>.
 
- <li>For each <a>range</a> whose
- <a for=Range>start node</a> is an
- <a>inclusive descendant</a> of
- <var>node</var>, set its
- <a for=Range>start</a> to
+ <li><p>For each <a>live range</a> whose <a for=range>start node</a> is an
+ <a>inclusive descendant</a> of <var>node</var>, set its <a for=range>start</a> to
  (<var>parent</var>, <var>index</var>).
 
- <li>For each <a>range</a> whose
- <a for=Range>end node</a> is an
- <a>inclusive descendant</a> of
- <var>node</var>, set its
- <a for=Range>end</a> to
- (<var>parent</var>, <var>index</var>).
+ <li><p>For each <a>live range</a> whose <a for=range>end node</a> is an <a>inclusive descendant</a>
+ of <var>node</var>, set its <a for=range>end</a> to (<var>parent</var>, <var>index</var>).
 
- <li>For each <a>range</a> whose
- <a for=Range>start node</a> is
- <var>parent</var> and
- <a>start offset</a> is greater than
- <var>index</var>, decrease its
- <a>start offset</a> by one.
+ <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>parent</var> and
+ <a for=range>start offset</a> is greater than <var>index</var>, decrease its
+ <a for=range>start offset</a> by 1.
 
- <li>For each <a>range</a> whose
- <a for=Range>end node</a> is
- <var>parent</var> and
- <a>end offset</a> is greater than
- <var>index</var>, decrease its
- <a>end offset</a> by one.
+ <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>parent</var> and
+ <a for=range>end offset</a> is greater than <var>index</var>, decrease its
+ <a for=range>end offset</a> by 1.
 
  <li><p>For each {{NodeIterator}} object <var>iterator</var> whose
  <a for=traversal>root</a>'s <a for=Node>node document</a> is <var>node</var>'s
@@ -2714,26 +2689,20 @@ Element includes ParentNode;
 
  <dt><code><var>node</var> . <a method for=ParentNode lt="prepend()">prepend</a>(<var>nodes</var>)</code>
  <dd>
-  Inserts <var>nodes</var> before the
-  <a for=tree>first child</a> of
-  <var>node</var>, while replacing strings in <var>nodes</var>
-  with equivalent {{Text}} <a>nodes</a>.
+  <p>Inserts <var>nodes</var> before the <a for=tree>first child</a> of <var>node</var>, while
+  replacing strings in <var>nodes</var> with equivalent {{Text}} <a for=/>nodes</a>.
 
-  <a>Throws</a> a
-  "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of the
-  <a>node tree</a> are violated.
+  <p><a>Throws</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of
+  the <a>node tree</a> are violated.
   <!-- "NotFoundError" is impossible -->
 
  <dt><code><var>node</var> . <a method for=ParentNode lt="append()">append</a>(<var>nodes</var>)</code>
  <dd>
-  Inserts <var>nodes</var> after the
-  <a>last child</a> of
-  <var>node</var>, while replacing strings in <var>nodes</var>
-  with equivalent {{Text}} <a>nodes</a>.
+  <p>Inserts <var>nodes</var> after the <a>last child</a> of <var>node</var>, while replacing
+  strings in <var>nodes</var> with equivalent {{Text}} <a for=/>nodes</a>.
 
-  <a>Throws</a> a
-  "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of the
-  <a>node tree</a> are violated.
+  <p><a>Throws</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of
+  the <a>node tree</a> are violated.
   <!-- "NotFoundError" is impossible -->
 
  <dt><code><var>node</var> . <a method for=ParentNode lt="querySelector()">querySelector</a>(<var>selectors</var>)</code>
@@ -2848,33 +2817,27 @@ CharacterData includes ChildNode;
 <dl class=domintro>
  <dt><code><var>node</var> . {{before(...nodes)}}</code>
  <dd>
-  Inserts <var>nodes</var> just before <var>node</var>,
-  while replacing strings in <var>nodes</var> with equivalent
-  {{Text}} <a>nodes</a>.
+  <p>Inserts <var>nodes</var> just before <var>node</var>, while replacing strings in
+  <var>nodes</var> with equivalent {{Text}} <a for=/>nodes</a>.
 
-  <a>Throws</a> a
-  "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of the
-  <a>node tree</a> are violated.
+  <p><a>Throws</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of
+  the <a>node tree</a> are violated.
 
  <dt><code><var>node</var> . {{after(...nodes)}}</code>
  <dd>
-  Inserts <var>nodes</var> just after <var>node</var>,
-  while replacing strings in <var>nodes</var> with equivalent
-  {{Text}} <a>nodes</a>.
+  <p>Inserts <var>nodes</var> just after <var>node</var>, while replacing strings in
+  <var>nodes</var> with equivalent {{Text}} <a for=/>nodes</a>.
 
-  <a>Throws</a> a
-  "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of the
-  <a>node tree</a> are violated.
+  <p><a>Throws</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of
+  the <a>node tree</a> are violated.
 
  <dt><code><var>node</var> . {{replaceWith(...nodes)}}</code>
  <dd>
-  Replaces <var>node</var> with <var>nodes</var>, while
-  replacing strings in <var>nodes</var> with equivalent
-  {{Text}} <a>nodes</a>.
+  <p>Replaces <var>node</var> with <var>nodes</var>, while replacing strings in <var>nodes</var>
+  with equivalent {{Text}} <a for=/>nodes</a>.
 
-  <a>Throws</a> a
-  "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of the
-  <a>node tree</a> are violated.
+  <p><a>Throws</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of
+  the <a>node tree</a> are violated.
 
  <dt><code><var>node</var> . {{ChildNode/remove()}}</code>
  <dd>Removes <var>node</var>.
@@ -2972,7 +2935,7 @@ the result of <a>find a slot</a> given <a>context object</a> and with the <i>ope
 <h4 id=old-style-collections>Old-style collections: {{NodeList}} and {{HTMLCollection}}</h4>
 
 A <dfn export id=concept-collection>collection</dfn> is an object that represents a list of
-<a>nodes</a>. A <a>collection</a> can be either
+<a for=/>nodes</a>. A <a>collection</a> can be either
 <dfn export for=collection id=concept-collection-live lt="live collection" local-lt="live">live</dfn>
 or <dfn export for=collection id=concept-collection-static lt="static collection">static</dfn>.
 Unless otherwise stated, a <a>collection</a> must be <a for=collection>live</a>.
@@ -2993,9 +2956,7 @@ within the <a>collection</a> must be sorted in <a>tree order</a>.
 
 <h5 id=interface-nodelist>Interface {{NodeList}}</h5>
 
-A {{NodeList}} object is a
-<a>collection</a> of
-<a>nodes</a>.
+<p>A {{NodeList}} object is a <a>collection</a> of <a for=/>nodes</a>.
 
 <pre class=idl>
 [Exposed=Window]
@@ -3007,19 +2968,13 @@ interface NodeList {
 </pre>
 
 <dl class=domintro>
- <dt><var>collection</var> . {{NodeList/length}}</code>
- <dd>
-  Returns the number of <a>nodes</a> in the
-  <a>collection</a>.
+ <dt><var>collection</var> . {{NodeList/length}}
+ <dd>Returns the number of <a for=/>nodes</a> in the <a>collection</a>.
 
  <dt><var>element</var> = <var>collection</var> . {{NodeList/item(index)}}
  <dt><var>element</var> = <var>collection</var>[<var>index</var>]
- <dd>
-  Returns the <a>node</a> with index
-  <var>index</var> from the
-  <a>collection</a>. The
-  <a>nodes</a> are sorted in
-  <a>tree order</a>.
+ <dd>Returns the <a>node</a> with index <var>index</var> from the <a>collection</a>. The
+ <a for=/>nodes</a> are sorted in <a>tree order</a>.
 </dl>
 
 <div class=impl>
@@ -3236,12 +3191,12 @@ dictionary MutationObserverInit {
 
 A {{MutationObserver}} object can be used to observe mutations
 to the <a>tree</a> of
-<a>nodes</a>.
+<a for=/>nodes</a>.
 
 Each {{MutationObserver}} object has these associated concepts:
 <ul>
  <li>A <dfn export for=MutationObserver id=concept-mo-callback>callback</dfn> set on creation.
- <li>A list of <a>nodes</a> on which it is a <a>registered observer</a>'s <b>observer</b> that is initially empty.
+ <li>A list of <a for=/>nodes</a> on which it is a <a>registered observer</a>'s <b>observer</b> that is initially empty.
  <li>A list of {{MutationRecord}} objects called the
  <dfn export for=MutationObserver id=concept-mo-queue>record queue</dfn> that is initially empty.
 </ul>
@@ -3253,7 +3208,7 @@ Each {{MutationObserver}} object has these associated concepts:
  <var>callback</var>. The <var>callback</var> is invoked with a
  list of {{MutationRecord}} objects as first argument and the
  constructed {{MutationObserver}} object as second argument. It is
- invoked after <a>nodes</a> registered with the
+ invoked after <a for=/>nodes</a> registered with the
  {{MutationObserver/observe()}} method, are
  mutated.
 
@@ -3374,11 +3329,11 @@ method, when invoked, must run these steps:
  <li><p>Otherwise, add a new <a>registered observer</a> to <var>target</var>'s list of
  <a>registered observers</a> with the <a>context object</a> as the <b>observer</b> and
  <var>options</var> as the <b>options</b>, and add <var>target</var> to <a>context object</a>'s list
- of <a>nodes</a> on which it is registered.
+ of <a for=/>nodes</a> on which it is registered.
 </ol>
 
 <p>The <dfn method for=MutationObserver><code>disconnect()</code></dfn> method, when invoked, must
-for each <a>node</a> <var>node</var> in <a>context object</a>'s list of <a>nodes</a>, remove any
+for each <a>node</a> <var>node</var> in <a>context object</a>'s list of <a for=/>nodes</a>, remove any
 <a>registered observer</a> on <var>node</var> for which <a>context object</a> is the
 <b>observer</b>, and also empty <a>context object</a>'s <a>record queue</a>.
 
@@ -3518,7 +3473,7 @@ interface MutationRecord {
  {{CharacterData}} <a>node</a>. And
  "<code>childList</code>" if it was a mutation to the
  <a>tree</a> of
- <a>nodes</a>.
+ <a for=/>nodes</a>.
 
  <dt><code><var>record</var> . {{MutationRecord/target}}</code>
  <dd>Returns the <a>node</a> the mutation
@@ -3533,13 +3488,13 @@ interface MutationRecord {
 
  <dt><code><var>record</var> . {{MutationRecord/addedNodes}}</code>
  <dt><code><var>record</var> . {{MutationRecord/removedNodes}}</code>
- <dd>Return the <a>nodes</a> added and removed
+ <dd>Return the <a for=/>nodes</a> added and removed
  respectively.
 
  <dt><code><var>record</var> . {{MutationRecord/previousSibling}}</code>
  <dt><code><var>record</var> . {{MutationRecord/nextSibling}}</code>
  <dd>Return the <a lt="previous sibling">previous</a> and <a for=tree>next sibling</a> respectively
- of the added or removed <a>nodes</a>, and null otherwise.
+ of the added or removed <a for=/>nodes</a>, and null otherwise.
 
  <dt><code><var>record</var> . {{MutationRecord/attributeName}}</code>
  <dd>Returns the
@@ -3584,7 +3539,7 @@ be initialized to null.
 
 <h4 id=garbage-collection>Garbage collection</h4>
 
-<a>Nodes</a> have a strong reference to
+<a for=/>nodes</a> have a strong reference to
 <a>registered observers</a> in their
 list of <a>registered observers</a>.
 
@@ -3661,7 +3616,7 @@ dictionary GetRootNodeOptions {
 </pre>
 
 <p class="note no-backref">{{Node}} is an abstract interface and does not exist as <a>node</a>. It
-is used by all <a>nodes</a> ({{Document}}, {{DocumentType}}, {{DocumentFragment}}, {{Element}},
+is used by all <a for=/>nodes</a> ({{Document}}, {{DocumentType}}, {{DocumentFragment}}, {{Element}},
 {{Text}}, {{ProcessingInstruction}}, and {{Comment}}).
 
 Each <a>node</a> has an associated
@@ -3903,7 +3858,7 @@ if the <a>context object</a> is a <a>document</a>, and the <a>context object</a>
 <a for=Node>node document</a> otherwise.
 
 <p class="note">The <a for=Node>node document</a> of a <a>document</a> is that <a>document</a> itself. All
-<a>nodes</a> have a <a for=Node>node document</a> at all times.
+<a for=/>nodes</a> have a <a for=Node>node document</a> at all times.
 
 <p>The <dfn method for=Node><code>getRootNode(<var>options</var>)</code></dfn> method, when invoked,
 must return <a>context object</a>'s <a>shadow-including root</a> if <var>options</var>'s
@@ -4035,7 +3990,7 @@ the empty string instead, and then do as described below, switching on <a>contex
  <dt><code><var>node</var> . {{Node/normalize()}}</code>
  <dd>Removes <a for=Node>empty</a> <a>exclusive <code>Text</code> nodes</a> and concatenates the
  <a for=CharacterData>data</a> of remaining <a>contiguous exclusive <code>Text</code> nodes</a>
- into the first of their <a>nodes</a>.
+ into the first of their <a for=/>nodes</a>.
 </dl>
 
 <p>The <dfn method for=Node><code>normalize()</code></dfn> method, when invoked, must run these
@@ -4061,23 +4016,23 @@ steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>no
   <p>While <var>currentNode</var> is an <a>exclusive <code>Text</code> node</a>:
 
   <ol>
-   <li><p>For each <a>range</a> whose <a for=Range>start node</a> is <var>currentNode</var>, add
-   <var>length</var> to its <a>start offset</a> and set its <a for=Range>start node</a> to
+   <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>currentNode</var>,
+   add <var>length</var> to its <a for=range>start offset</a> and set its
+   <a for=range>start node</a> to <var>node</var>.
+
+   <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>currentNode</var>, add
+   <var>length</var> to its <a for=range>end offset</a> and set its <a for=range>end node</a> to
    <var>node</var>.
 
-   <li><p>For each <a>range</a> whose <a for=Range>end node</a> is <var>currentNode</var>, add
-   <var>length</var> to its <a>end offset</a> and set its <a for=Range>end node</a> to
-   <var>node</var>.
+   <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>currentNode</var>'s
+   <a for=tree>parent</a> and <a for=range>start offset</a> is <var>currentNode</var>'s
+   <a for=tree>index</a>, set its <a for=range>start node</a> to <var>node</var> and its
+   <a for=range>start offset</a> to <var>length</var>.
 
-   <li><p>For each <a>range</a> whose <a for=Range>start node</a> is <var>currentNode</var>'s
-   <a for=tree>parent</a> and <a>start offset</a> is <var>currentNode</var>'s <a for=tree>index</a>,
-   set its <a for=Range>start node</a> to <var>node</var> and its <a>start offset</a> to
-   <var>length</var>.
-
-   <li><p>For each <a>range</a> whose <a for=Range>end node</a> is <var>currentNode</var>'s
-   <a for=tree>parent</a> and <a>end offset</a> is <var>currentNode</var>'s <a for=tree>index</a>,
-   set its <a for=Range>end node</a> to <var>node</var> and its <a>end offset</a> to
-   <var>length</var>.
+   <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>currentNode</var>'s
+   <a for=tree>parent</a> and <a for=range>end offset</a> is <var>currentNode</var>'s
+   <a for=tree>index</a>, set its <a for=range>end node</a> to <var>node</var> and its
+   <a for=range>end offset</a> to <var>length</var>.
 
    <li><p>Add <var>currentNode</var>'s <a for=Node>length</a> to <var>length</var>.
 
@@ -4108,7 +4063,7 @@ does so specifically in a way that preserves the <a>child text content</a>.
 <div class=impl>
 
 <a lt="Other applicable specifications">Specifications</a> may define
-<dfn export id=concept-node-clone-ext>cloning steps</dfn> for all or some <a>nodes</a>. The
+<dfn export id=concept-node-clone-ext>cloning steps</dfn> for all or some <a for=/>nodes</a>. The
 algorithm is passed <var>copy</var>, <var>node</var>, <var>document</var>, and an optional
 <i>clone children flag</i>, as indicated in the <a lt="clone a node">clone</a> algorithm.
 
@@ -4705,7 +4660,7 @@ dictionary ElementCreationOptions {
 };
 </pre>
 
-{{Document}} <a>nodes</a> are simply
+{{Document}} <a for=/>nodes</a> are simply
 known as <dfn export id=concept-document lt="document">documents</dfn>.
 
 Each <a>document</a> has an associated
@@ -5170,7 +5125,7 @@ when invoked, must run these steps:
 
 <a lt="Other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-adopt-ext>adopting steps</dfn> for all or some
-<a>nodes</a>. The algorithm is passed <var>node</var> and
+<a for=/>nodes</a>. The algorithm is passed <var>node</var> and
 <var>oldDocument</var>, as indicated in the
 <a>adopt</a> algorithm.
 
@@ -5327,10 +5282,11 @@ invoked, must run these steps:
 
 <hr>
 
-The <dfn method for=Document><code>createRange()</code></dfn> method, when invoked, must return a
-new <a>range</a> with (<a>context object</a>, 0) as its <a for=Range>start</a> and <a for=Range>end</a>.
+<p>The <dfn method for=Document><code>createRange()</code></dfn> method, when invoked, must return a
+new <a>live range</a> with (<a>context object</a>, 0) as its <a for=range>start</a> and
+<a for=range>end</a>.
 
-<p class=note>The {{Range/Range()}} constructor ought to be used instead.
+<p class=note>The {{Range/Range()}} constructor can be used instead.
 
 <hr>
 
@@ -5535,7 +5491,7 @@ interface DocumentType : Node {
 };
 </pre>
 
-<p>{{DocumentType}} <a>nodes</a> are simply known as
+<p>{{DocumentType}} <a for=/>nodes</a> are simply known as
 <dfn export id=concept-doctype lt="doctype">doctypes</dfn>.
 
 <p><a>Doctypes</a> have an associated
@@ -5603,7 +5559,7 @@ interface ShadowRoot : DocumentFragment {
 enum ShadowRootMode { "open", "closed" };
 </pre>
 
-<p>{{ShadowRoot}} <a>nodes</a> are simply known as
+<p>{{ShadowRoot}} <a for=/>nodes</a> are simply known as
 <dfn export id=concept-shadow-root lt="shadow root">shadow roots</dfn>.
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>mode</dfn> ("<code>open</code>"
@@ -5743,7 +5699,7 @@ dictionary ShadowRootInit {
 };
 </pre>
 
-<p>{{Element}} <a>nodes</a> are simply known as
+<p>{{Element}} <a for=/>nodes</a> are simply known as
 <dfn export id=concept-element lt=element>elements</dfn>.
 
 <p><a for=/>Elements</a> have an associated
@@ -6827,7 +6783,7 @@ interface Attr : Node {
   readonly attribute boolean specified; // useless; always returns true
 };</pre>
 
-<p>{{Attr}} <a>nodes</a> are simply known as
+<p>{{Attr}} <a for=/>nodes</a> are simply known as
 <dfn export id=concept-attribute lt="attribute">attributes</dfn>. They are sometimes referred
 to as <em>content attributes</em> to avoid confusion with IDL attributes.
 
@@ -6923,7 +6879,7 @@ interface CharacterData : Node {
 </pre>
 
 <p class="note no-backref">{{CharacterData}} is an abstract interface and does not exist as
-<a>node</a>. It is used by {{Text}}, {{ProcessingInstruction}}, and {{Comment}} <a>nodes</a>.
+<a>node</a>. It is used by {{Text}}, {{ProcessingInstruction}}, and {{Comment}} <a for=/>nodes</a>.
 
 Each <a>node</a> inheriting from the
 {{CharacterData}} interface has an associated mutable string
@@ -6959,32 +6915,24 @@ To <dfn export id=concept-cd-replace>replace data</dfn> of node <var>node</var> 
  <var>node</var>'s <a for=CharacterData>data</a>.
 
  <!-- ranges -->
- <li>For each <a>range</a> whose
- <a for=Range>start node</a> is
- <var>node</var> and
- <a>start offset</a> is greater than
- <var>offset</var> but less than or equal to <var>offset</var>
- plus <var>count</var>, set its
- <a>start offset</a> to
+ <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>node</var> and
+ <a for=range>start offset</a> is greater than <var>offset</var> but less than or equal to
+ <var>offset</var> plus <var>count</var>, set its <a for=range>start offset</a> to
  <var>offset</var>.
 
- <li>For each <a>range</a> whose
- <a for=Range>end node</a> is
- <var>node</var> and
- <a>end offset</a> is greater than
- <var>offset</var> but less than or equal to <var>offset</var>
- plus <var>count</var>, set its
- <a>end offset</a> to
- <var>offset</var>.
+ <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>node</var> and
+ <a for=range>end offset</a> is greater than <var>offset</var> but less than or equal to
+ <var>offset</var> plus <var>count</var>, set its <a for=range>end offset</a> to <var>offset</var>.
 
- <li>For each <a>range</a> whose <a for=Range>start node</a> is <var>node</var> and
- <a>start offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its
- <a>start offset</a> by <var>data</var>'s <a for="JavaScript string">length</a> and decrease it by
- <var>count</var>.
+ <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>node</var> and
+ <a for=range>start offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its
+ <a for=range>start offset</a> by <var>data</var>'s <a for="JavaScript string">length</a> and
+ decrease it by <var>count</var>.
 
- <li>For each <a>range</a> whose <a for=Range>end node</a> is <var>node</var> and <a>end offset</a>
- is greater than <var>offset</var> plus <var>count</var>, increase its <a>end offset</a> by
- <var>data</var>'s <a for="JavaScript string">length</a> and decrease it by <var>count</var>.
+ <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>node</var> and
+ <a for=range>end offset</a> is greater than <var>offset</var> plus <var>count</var>, increase its
+ <a for=range>end offset</a> by <var>data</var>'s <a for="JavaScript string">length</a> and decrease
+ it by <var>count</var>.
 
  <li>If <var>node</var> is a {{Text}} node and its <a>parent</a> is not null, run the
  <a>child text content change steps</a> for <var>node</var>'s <a>parent</a>.
@@ -7123,7 +7071,7 @@ if any, and its <a>contiguous exclusive <code>Text</code> nodes</a>, and <var>no
 the {{Text}} node <a>children</a> of <var>node</var>, in <a>tree order</a>.
 
 <p>This and <a lt="other applicable specifications">other specifications</a> may define
-<dfn export id=concept-node-text-change-ext>child text content change steps</dfn> for <a>nodes</a>.
+<dfn export id=concept-node-text-change-ext>child text content change steps</dfn> for <a for=/>nodes</a>.
 
 <hr>
 
@@ -7163,51 +7111,30 @@ To <dfn export id=concept-text-split lt="split a Text node">split</dfn> a {{Text
   <p>If <var>parent</var> is not null, then:
 
   <ol>
-   <li><a>Insert</a>
-   <var>new node</var> into <var>parent</var> before
-   <var>node</var>'s
+   <li><p><a for=/>Insert</a> <var>new node</var> into <var>parent</var> before <var>node</var>'s
    <a for=tree>next sibling</a>.
    <!-- Do this before we replace data, so that the data replacement won't
    mutate ranges prematurely:
    https://www.w3.org/Bugs/Public/show_bug.cgi?id=15325 -->
 
-   <li>For each <a>range</a> whose
-   <a for=Range>start node</a> is
-   <var>node</var> and
-   <a>start offset</a> is greater than
-   <var>offset</var>, set its
-   <a for=Range>start node</a> to
-   <var>new node</var> and decrease its
-   <a>start offset</a> by
-   <var>offset</var>.
+   <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>node</var> and
+   <a for=range>start offset</a> is greater than <var>offset</var>, set its
+   <a for=range>start node</a> to <var>new node</var> and decrease its <a for=range>start offset</a>
+   by <var>offset</var>.
 
-   <li>For each <a>range</a> whose
-   <a for=Range>end node</a> is
-   <var>node</var> and
-   <a>end offset</a> is greater than
-   <var>offset</var>, set its
-   <a for=Range>end node</a> to
-   <var>new node</var> and decrease its
-   <a>end offset</a> by
-   <var>offset</var>.
+   <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>node</var> and
+   <a for=range>end offset</a> is greater than <var>offset</var>, set its <a for=range>end node</a>
+   to <var>new node</var> and decrease its <a for=range>end offset</a> by <var>offset</var>.
 
    <!-- This shit is complicated:
         https://www.w3.org/Bugs/Public/show_bug.cgi?id=19968 -->
-   <li>For each <a>range</a> whose
-   <a for=Range>start node</a> is
-   <var>parent</var> and
-   <a>start offset</a> is equal to
-   the <a for=tree>index</a> of
-   <var>node</var> + 1, increase its
-   <a>start offset</a> by one.
+   <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>parent</var> and
+   <a for=range>start offset</a> is equal to the <a for=tree>index</a> of <var>node</var> plus 1,
+   increase its <a for=range>start offset</a> by 1.
 
-   <li>For each <a>range</a> whose
-   <a for=Range>end node</a> is
-   <var>parent</var> and
-   <a>end offset</a> is equal to
-   the <a for=tree>index</a> of
-   <var>node</var> + 1, increase its
-   <a>end offset</a> by one.
+   <li><p>For each <a>live range</a> whose <a for=range>end node</a> is <var>parent</var> and
+   <a for=range>end offset</a> is equal to the <a for=tree>index</a> of <var>node</var> plus 1,
+   increase its <a for=range>end offset</a> by 1.
   </ol>
 
  <li><a>Replace data</a> with node
@@ -7244,7 +7171,7 @@ interface ProcessingInstruction : CharacterData {
 };</pre>
 
 
-{{ProcessingInstruction}} <a>nodes</a>
+{{ProcessingInstruction}} <a for=/>nodes</a>
 have an associated <dfn export id=concept-pi-target for=ProcessingInstruction>target</dfn>.
 
 The <dfn attribute for=ProcessingInstruction>target</dfn>
@@ -7279,22 +7206,14 @@ invoked, must return a new {{Comment}} <a>node</a> whose <a for=CharacterData>da
 
 <h3 id=introduction-to-dom-ranges>Introduction to "DOM Ranges"</h3>
 
-A {{Range}} object (<a>range</a>)
-represents a sequence of content within a
-<a>node tree</a>. Each
-<a>range</a> has a
-<a for=Range>start</a> and an
-<a for=Range>end</a> which are
-<a>boundary points</a>. A
-<a>boundary point</a> is a tuple consisting of
-a <a>node</a> and a non-negative numeric
-<a for="boundary point">offset</a>. So in other words, a
-<a>range</a> represents a piece of content within
-a <a>node tree</a> between two
+<p>{{StaticRange}} and {{Range}} objects (<a>ranges</a>) represent a sequence of content within a
+<a>node tree</a>. Each <a>range</a> has a <a for=range>start</a> and an <a for=range>end</a> which
+are <a>boundary points</a>. A <a>boundary point</a> is a <a for=/>tuple</a> consisting of a
+<a for="boundary point">node</a> and an <a for="boundary point">offset</a>. So in other words, a
+<a>range</a> represents a piece of content within a <a>node tree</a> between two
 <a>boundary points</a>.
 
-<a>Ranges</a> are frequently used in editing
-for selecting and copying content.
+<p><a>Ranges</a> are frequently used in editing for selecting and copying content.
 
 <ul class="domTree">
  <li class="t1">{{Element}}: <code>p</code>
@@ -7310,7 +7229,7 @@ for selecting and copying content.
 </ul>
 <!-- http://w3cmemes.tumblr.com/post/35332222321/css-2-1-syndata-is-awesome -->
 
-In the <a>node tree</a> above, a
+<p>In the <a>node tree</a> above, a
 <a>range</a> can be used to represent the sequence
 “syndata is awes”. Assuming <var ignore>p</var> is assigned to the
 <code>p</code> <a for="/">element</a>, and
@@ -7326,25 +7245,147 @@ range.setEnd(secondText, 4)
 // range now stringifies to the aforementioned quote
 </code></pre>
 
-<p class="note no-backref"><a>Attributes</a> such as
-<code>src</code> and <code>alt</code> in the
-<a>node tree</a> above cannot be represented
-by a <a>range</a>. The
-<a>ranges</a> concept is only useful for
-<a>nodes</a>.
+<p class="note no-backref"><a>Attributes</a> such as <code>src</code> and <code>alt</code> in the
+<a>node tree</a> above cannot be represented by a <a>range</a>. <a>Ranges</a> are only useful for
+<a for=/>nodes</a>.
 
-<a>Ranges</a> are affected by mutations to the
-<a>node tree</a>. Such mutations will not
-invalidate a <a>range</a> and will try to ensure
-that the <a>range</a> still represents the same
-piece of content. Necessarily, a <a>range</a>
-might itself be modified as part of the mutation to the
-<a>node tree</a> when e.g. part of the content
-it represents is mutated.
+<p>{{Range}} objects, unlike {{StaticRange}} objects, are affected by mutations to the
+<a>node tree</a>. Therefore they are also known as <a>live ranges</a>. Such mutations will not
+invalidate them and will try to ensure that it still represents the same piece of content.
+Necessarily, a <a>live range</a> might itself be modified as part of the mutation to the
+<a>node tree</a> when, e.g., part of the content it represents is mutated.
 
-<p class="note no-backref">See the <a>insert</a> and <a for=/>remove</a> algorithms, the
+<p class="note no-backref">See the <a for=/>insert</a> and <a for=/>remove</a> algorithms, the
 {{Node/normalize()}} method, and the <a>replace data</a> and <a lt="split a Text node">split</a>
 algorithms for the hairy details.
+
+
+<h3 id=boundary-points>Boundary points</h3>
+
+<p>A <dfn export id=concept-range-bp>boundary point</dfn> is a <a for=/>tuple</a> consisting of a
+<dfn export for="boundary point">node</dfn> (a <a for=/>node</a>) and an
+<dfn export id=concept-range-bp-offset for="boundary point">offset</dfn> (a non-negative integer).
+
+<p class="note no-backref">Generally speaking, a <a>boundary point</a>'s
+<a for="boundary point">offset</a> will be between 0 and the <a>boundary point</a>'s
+<a for="boundary point">node</a>'s <a>length</a>, inclusive.
+
+<p>The <dfn export id=concept-range-bp-position for="boundary point">position</dfn> of a
+<a>boundary point</a> (<var>nodeA</var>, <var>offsetA</var>) relative to a <a>boundary point</a>
+(<var>nodeB</var>, <var>offsetB</var>) is
+<dfn export id=concept-range-bp-before for="boundary point">before</dfn>,
+<dfn export id=concept-range-bp-equal for="boundary point">equal</dfn>, or
+<dfn export id=concept-range-bp-after for="boundary point">after</dfn>, as returned by these steps:
+
+<ol>
+ <li><p>Assert: <var>nodeA</var> and <var>nodeB</var> have the same <a for=tree>root</a>.
+
+ <li>If <var>nodeA</var> is <var>nodeB</var>, then return <a for="boundary point">equal</a> if
+ <var>offsetA</var> is <var>offsetB</var>, <a for="boundary point">before</a> if <var>offsetA</var>
+ is less than <var>offsetB</var>, and <a for="boundary point">after</a> if <var>offsetA</var> is
+ greater than <var>offsetB</var>.
+
+ <li><p>If <var>nodeA</var> is <a>following</a> <var>nodeB</var>, then if the
+ <a for="boundary point">position</a> of (<var>nodeB</var>, <var>offsetB</var>) relative to
+ (<var>nodeA</var>, <var>offsetA</var>) is <a for="boundary point">before</a>, return
+ <a for="boundary point">after</a>, and if it is <a for="boundary point">after</a>, return
+ <a for="boundary point">before</a>.
+
+ <li>
+  <p>If <var>nodeA</var> is an <a>ancestor</a> of <var>nodeB</var>:
+
+  <ol>
+   <li><p>Let <var>child</var> be <var>nodeB</var>.
+
+   <li><p>While <var>child</var> is not a <a for=tree>child</a> of <var>nodeA</var>, set
+   <var>child</var> to its <a for=tree>parent</a>.
+
+   <li><p>If <var>child</var>'s <a for=tree>index</a> is less than <var>offsetA</var>, then return
+   <a for="boundary point">after</a>.
+  </ol>
+
+ <li><p>Return <a for="boundary point">before</a>.
+</ol>
+
+
+<h3 id=interface-abstractrange>Interface {{AbstractRange}}</h3>
+
+<pre class=idl>
+[Exposed=Window]
+interface AbstractRange {
+  readonly attribute Node startContainer;
+  readonly attribute unsigned long startOffset;
+  readonly attribute Node endContainer;
+  readonly attribute unsigned long endOffset;
+  readonly attribute boolean collapsed;
+};
+</pre>
+
+<p>Objects implementing the {{AbstractRange}} interface are known as
+<dfn export id=concept-range lt="range">ranges</dfn>.
+
+<p>A <a>range</a> has two associated <a>boundary points</a> — a
+<dfn export id=concept-range-start for=range>start</dfn> and
+<dfn export id=concept-range-end for=range>end</dfn>.
+
+<p>For convenience, a <a>range</a>'s
+<dfn export id=concept-range-start-node for=range>start node</dfn> is its <a for=range>start</a>'s
+<a for="boundary point">node</a>, its
+<dfn export id=concept-range-start-offset for=range>start offset</dfn> is its
+<a for=range>start</a>'s <a for="boundary point">offset</a>, its
+<dfn export id=concept-range-end-node for=range>end node</dfn> is its <a for=range>end</a>'s
+<a for="boundary point">node</a>,  and its
+<dfn export id=concept-range-end-offset for=range>end offset</dfn> is its <a for=range>end</a>'s
+<a for="boundary point">offset</a>.
+
+<p>A <a>range</a> is <dfn for=range>collapsed</dfn> if its <a for=range>start node</a> is its
+<a for=range>end node</a> and its <a for=range>start offset</a> is its <a for=range>end offset</a>.
+
+<dl class=domintro>
+ <dt><code><var>node</var> = <var>range</var> . <a attribute for=AbstractRange>startContainer</a></code>
+ <dd>Returns <var>range</var>'s <a for=range>start node</a>.
+
+ <dt><code><var>offset</var> = <var>range</var> . <a attribute for=AbstractRange>startOffset</a></code>
+ <dd>Returns <var>range</var>'s <a for=range>start offset</a>.
+
+ <dt><code><var>node</var> = <var>range</var> . <a attribute for=AbstractRange>endContainer</a></code>
+ <dd>Returns <var>range</var>'s <a for=range>end node</a>.
+
+ <dt><code><var>offset</var> = <var>range</var> . <a attribute for=AbstractRange>endOffset</a></code>
+ <dd>Returns <var>range</var>'s <a for=range>end offset</a>.
+
+ <dt><code><var ignore>collapsed</var> = <var>range</var> . <a attribute for=AbstractRange>collapsed</a></code>
+ <dd>Returns true if <var>range</var> is <a for=range>collapsed</a>, and false otherwise.
+</dl>
+
+<p>The
+<dfn id=dom-range-startcontainer attribute for=AbstractRange><code>startContainer</code></dfn>
+attribute's getter must return the <a>context object</a>'s <a for=range>start node</a>.
+
+<p>The <dfn id=dom-range-startoffset attribute for=AbstractRange><code>startOffset</code></dfn>
+attribute's getter must return the <a>context object</a>'s <a for=range>start offset</a>.
+
+<p>The <dfn id=dom-range-endcontainer attribute for=AbstractRange><code>endContainer</code></dfn>
+attribute's getter must return the <a>context object</a>'s <a for=range>end node</a>.
+
+<p>The <dfn id=dom-range-endoffset attribute for=AbstractRange><code>endOffset</code></dfn>
+attribute's getter must return the <a>context object</a>'s <a for=range>end offset</a>.
+
+<p>The <dfn id=dom-range-collapsed attribute for=AbstractRange><code>collapsed</code></dfn>
+attribute's getter must return true if the <a>context object</a> is <a for=range>collapsed</a>, and
+false otherwise.
+
+
+<h3 id=interface-staticrange>Interface {{StaticRange}}</h3>
+
+<pre class=idl>
+[Exposed=Window]
+interface StaticRange : AbstractRange {
+};
+</pre>
+
+<p class=note>A future version of the {{StaticRange}} interface will provide a non-throwing
+constructor.
 
 
 <h3 id=interface-range>Interface {{Range}}</h3>
@@ -7352,12 +7393,7 @@ algorithms for the hairy details.
 <pre class=idl>
 [Constructor,
  Exposed=Window]
-interface Range {
-  readonly attribute Node startContainer;
-  readonly attribute unsigned long startOffset;
-  readonly attribute Node endContainer;
-  readonly attribute unsigned long endOffset;
-  readonly attribute boolean collapsed;
+interface Range : AbstractRange {
   readonly attribute Node commonAncestorContainer;
 
   void setStart(Node node, unsigned long offset);
@@ -7394,189 +7430,73 @@ interface Range {
 };
 </pre>
 
-{{Range}} objects are simply known as
-<dfn export id=concept-range lt="range">ranges</dfn>.
+<p>Objects implementing the {{Range}} interface are known as
+<dfn export id=concept-live-range>live ranges</dfn>.
 
-A <dfn export id=concept-range-bp>boundary point</dfn> is a
-(<a>node</a>,
-<dfn export id=concept-range-bp-offset for="boundary point">offset</dfn>) tuple, where
-<a for="boundary point">offset</a> is a non-negative
-integer.
+<p class="note">Algorithms that modify a <a>tree</a> (in particular the <a for=/>insert</a>,
+<a for=/>remove</a>, <a>replace data</a>, and <a lt="split a Text node">split</a> algorithms) modify
+<a>live ranges</a> associated with that <a>tree</a>.
 
-<p class="note no-backref">Generally speaking, a
-<a>boundary point</a>'s
-<a for="boundary point">offset</a> will be between zero and
-the <a>boundary point</a>'s
-<a>node</a>
-<a>length</a>, inclusive. Algorithms that
-modify a <a>tree</a> (in particular the
-<a>insert</a>,
-<a for=/>remove</a>,
-<a>replace data</a>, and
-<a lt="split a Text node">split</a> algorithms) also modify
-<a>ranges</a> associated with that
-<a>tree</a>.
-
-If the two <a>nodes</a> of
-<a>boundary points</a>
-(<var>node A</var>, <var>offset A</var>) and
-(<var>node B</var>, <var>offset B</var>) have the same
-<a for=tree>root</a>, the
-<dfn export id=concept-range-bp-position for=Range>position</dfn> of the first relative to
-the second is either <dfn export id=concept-range-bp-before for=Range>before</dfn>,
-<dfn export id=concept-range-bp-equal for=Range>equal</dfn>, or
-<dfn export id=concept-range-bp-after for=Range>after</dfn>,
-as returned by the following algorithm:
-
-<ol>
- <li>If <var>node A</var> is the same as <var>node B</var>,
- return <a for=Range>equal</a> if
- <var>offset A</var> is the same as <var>offset B</var>,
- <a for=Range>before</a> if
- <var>offset A</var> is less than <var>offset B</var>, and
- <a for=Range>after</a> if
- <var>offset A</var> is greater than <var>offset B</var>.
-
- <li>If <var>node A</var> is
- <a>following</a>
- <var>node B</var>, compute the
- <a for=Range>position</a> of
- (<var>node B</var>, <var>offset B</var>) relative to
- (<var>node A</var>, <var>offset A</var>). If it is
- <a for=Range>before</a>, return
- <a for=Range>after</a>. If it is
- <a for=Range>after</a>, return
- <a for=Range>before</a>.
-
- <li>
-  If <var>node A</var> is an
-  <a>ancestor</a> of
-  <var>node B</var>:
-
-  <ol>
-   <li>Let <var>child</var> equal <var>node B</var>.
-
-   <li>While <var>child</var> is not a
-   <a for=tree>child</a> of <var>node A</var>,
-   set <var>child</var> to its
-   <a for=tree>parent</a>.
-
-   <li>If the <a for=tree>index</a> of
-   <var>child</var> is less than <var>offset A</var>, return
-   <a for=Range>after</a>.
-  </ol>
-
- <li>Return <a for=Range>before</a>.
-</ol>
-
-Each <a>range</a> has two associated
-<a>boundary points</a> — a
-<dfn export id=concept-range-start for=Range>start</dfn> and
-<dfn export id=concept-range-end for=Range>end</dfn>.
-
-For convenience, <dfn export id=concept-range-start-node for=Range>start node</dfn> is
-<a for=Range>start</a>'s
-<a>node</a>,
-<dfn export id=concept-range-start-offset for=Range>start offset</dfn> is
-<a for=Range>start</a>'s
-<a for="boundary point">offset</a>,
-<dfn export id=concept-range-end-node for=Range>end node</dfn> is
-<a for=Range>end</a>'s
-<a>node</a>,  and
-<dfn export id=concept-range-end-offset for=Range>end offset</dfn> is
-<a for=Range>end</a>'s
-<a for="boundary point">offset</a>.
-
-The <dfn export id=concept-range-root for=Range>root</dfn> of a
-<a>range</a> is the
-<a for=tree>root</a> of its
-<a for=Range>start node</a>.
+<p>The <dfn export id=concept-range-root for="live range">root</dfn> of a <a>live range</a> is the
+<a for=tree>root</a> of its <a for=range>start node</a>.
 <!-- start and end have an identical root -->
 
-A <a>node</a> <var>node</var> is <dfn export for=Range id=contained>contained</dfn> in a
-<a>range</a> <var>range</var> if <var>node</var>'s <a for=tree>root</a> is the same as
-<var>range</var>'s <a for=Range>root</a>, and (<var>node</var>, 0) is <a for=Range>after</a>
-<var>range</var>'s <a for=Range>start</a>, and (<var>node</var>, <a>length</a> of <var>node</var>)
-is <a for=Range>before</a> <var>range</var>'s <a for=Range>end</a>.
+<p>A <a for=/>node</a> <var>node</var> is <dfn export for="live range" id=contained>contained</dfn>
+in a <a>live range</a> <var>range</var> if <var>node</var>'s <a for=tree>root</a> is
+<var>range</var>'s <a for="live range">root</a>, and (<var>node</var>, 0) is
+<a for="boundary point">after</a> <var>range</var>'s <a for=range>start</a>, and
+(<var>node</var>, <var>node</var>'s <a>length</a>) is <a for="boundary point">before</a>
+<var>range</var>'s <a for=range>end</a>.
 
-A <a>node</a> is <dfn export for=Range id=partially-contained>partially contained</dfn> in a
-<a>range</a> if it is an <a for=tree>inclusive ancestor</a> of the <a>range</a>'s
-<a for=Range>start node</a> but not its <a for=Range>end node</a>, or vice versa.
+<p>A <a for=/>node</a> is
+<dfn export for="live range" id=partially-contained>partially contained</dfn> in a <a>live range</a>
+if its an <a for=tree>inclusive ancestor</a> of the <a>live range</a>'s <a for=range>start node</a>
+but not its <a for=range>end node</a>, or vice versa.
 
-<div class=note>
- Some facts to better understand these definitions:
+<div class="note no-backref">
+ <p>Some facts to better understand these definitions:
 
  <ul>
-  <li>The content that one would think of as being within the
-  <a>range</a> consists of all
-  <a>contained</a> <a>nodes</a>, plus
-  possibly some of the contents of the
-  <a for=Range>start node</a> and
-  <a for=Range>end node</a> if those are
-  {{Text}}, {{ProcessingInstruction}}, or
-  {{Comment}} <a>nodes</a>.
+  <li><p>The content that one would think of as being within the <a>live range</a> consists of all
+  <a for="live range">contained</a> <a for=/>nodes</a>, plus possibly some of the contents of the
+  <a for=range>start node</a> and <a for=range>end node</a> if those are {{Text}},
+  {{ProcessingInstruction}}, or {{Comment}} <a for=/>nodes</a>.
 
-  <li>The <a>nodes</a> that are contained in a
-  <a>range</a> will generally not be contiguous,
-  because the <a for=tree>parent</a> of a
-  <a>contained</a> <a>node</a> will not
-  always be <a>contained</a>.
+  <li><p>The <a for=/>nodes</a> that are contained in a <a>live range</a> will generally not be
+  contiguous, because the <a for=tree>parent</a> of a <a for="live range">contained</a>
+  <a for=/>node</a> will not always be <a for="live range">contained</a>.
 
-  <li>However, the <a>descendants</a>
-  of a <a>contained</a> <a>node</a> are
-  <a>contained</a>, and if two
-  <a for=tree>siblings</a> are
-  <a>contained</a>, so are any
-  <a for=tree>siblings</a> that lie between them.
+  <li><p>However, the <a>descendants</a> of a <a for="live range">contained</a> <a for=/>node</a>
+  are <a for="live range">contained</a>, and if two <a for=tree>siblings</a> are
+  <a for="live range">contained</a>, so are any <a for=tree>siblings</a> that lie between them.
 
-  <li>The <a for=Range>start node</a> and
-  <a for=Range>end node</a> of a
-  <a>range</a> are never <a>contained</a>
-  within it.
+  <li><p>The <a for=range>start node</a> and <a for=range>end node</a> of a <a>live range</a> are
+  never <a for="live range">contained</a> within it.
 
-  <li>The first <a>contained</a>
-  <a>node</a> (if there are any) will always be
-  after the <a for=Range>start node</a>, and the
-  last <a>contained</a> <a>node</a> will
-  always be equal to or before the
-  <a for=Range>end node</a>'s last
+  <li><p>The first <a for="live range">contained</a> <a for=/>node</a> (if there are any) will
+  always be after the <a for=range>start node</a>, and the last <a for="live range">contained</a>
+  <a for=/>node</a> will always be equal to or before the <a for=range>end node</a>'s last
   <a>descendant</a>.
 
-  <li>There exists a partially contained
-  <a>node</a> if and only if the
-  <a for=Range>start node</a> and
-  <a for=Range>end node</a> are different.
+  <li><p>There exists a <a for="live range">partially contained</a> <a for=/>node</a> if and only if
+  the <a for=range>start node</a> and <a for=range>end node</a> are different.
 
-  <li>The {{Range/commonAncestorContainer}} attribute value is neither <a>contained</a>
-  nor <a>partially contained</a>.
+  <li><p>The {{Range/commonAncestorContainer}} attribute value is neither
+  <a for="live range">contained</a> nor <a for="live range">partially contained</a>.
 
-  <li>If the <a for=Range>start node</a> is an
-  <a>ancestor</a> of the
-  <a for=Range>end node</a>, the common
-  <a for=tree>inclusive ancestor</a> will
-  be the <a for=Range>start node</a>. Exactly one
-  of its <a>children</a> will be
-  <a>partially contained</a>, and a
-  <a for=tree>child</a> will be <a>contained</a>
-  if and only if it <a lt="preceding">precedes</a> the
-  <a>partially contained</a>
-  <a for=tree>child</a>. If the
-  <a for=Range>end node</a> is an
-  <a>ancestor</a> of the
-  <a for=Range>start node</a>, the opposite
-  holds.
+  <li><p>If the <a for=range>start node</a> is an <a>ancestor</a> of the <a for=range>end node</a>,
+  the common <a for=tree>inclusive ancestor</a> will be the <a for=range>start node</a>. Exactly one
+  of its <a>children</a> will be <a for="live range">partially contained</a>, and a
+  <a for=tree>child</a> will be <a for="live range">contained</a> if and only if it
+  <a lt="preceding">precedes</a> the <a for="live range">partially contained</a>
+  <a for=tree>child</a>. If the <a for=range>end node</a> is an <a>ancestor</a> of the
+  <a for=range>start node</a>, the opposite holds.
 
-  <li>If the <a for=Range>start node</a> is
-  not an
-  <a for=tree>inclusive ancestor</a> of
-  the <a for=Range>end node</a>, nor vice versa,
-  the common
-  <a for=tree>inclusive ancestor</a> will
-  be distinct from both of them. Exactly two of its
-  <a>children</a> will be
-  <a>partially contained</a>, and a
-  <a for=tree>child</a> will be contained if and only
-  if it lies between those two.
+  <li><p>If the <a for=range>start node</a> is not an <a for=tree>inclusive ancestor</a> of the
+  <a for=range>end node</a>, nor vice versa, the common <a for=tree>inclusive ancestor</a> will be
+  distinct from both of them. Exactly two of its <a>children</a> will be
+  <a for="live range">partially contained</a>, and a <a for=tree>child</a> will be contained if and
+  only if it lies between those two.
  </ul>
 </div>
 
@@ -7584,71 +7504,36 @@ A <a>node</a> is <dfn export for=Range id=partially-contained>partially containe
 
 <dl class=domintro>
  <dt><code><var>range</var> = new <a constructor>Range()</a></code>
- <dd>Returns a new <a>range</a>.
+ <dd>Returns a new <a>live range</a>.
 </dl>
 
 <p>The <dfn constructor for=Range><code>Range()</code></dfn> constructor, when invoked, must return
-a new <a>range</a> with (<a>current global object</a>'s <a>associated <code>Document</code></a>, 0)
-as its <a for=Range>start</a> and <a for=Range>end</a>.
+a new <a>live range</a> with
+(<a>current global object</a>'s <a>associated <code>Document</code></a>, 0) as its
+<a for=range>start</a> and <a for=range>end</a>.
 
 <hr>
 
 <dl class=domintro>
- <dt><var>node</var> = <var>range</var> . {{Range/startContainer}}
- <dd>Returns <var>range</var>'s
- <a for=Range>start node</a>.
-
- <dt><var>offset</var> = <var>range</var> . {{Range/startOffset}}
- <dd>Returns <var>range</var>'s
- <a>start offset</a>.
-
- <dt><var>node</var> = <var>range</var> . {{Range/endContainer}}
- <dd>Returns <var>range</var>'s
- <a for=Range>end node</a>.
-
- <dt><var>offset</var> = <var>range</var> . {{Range/endOffset}}
- <dd>Returns <var>range</var>'s
- <a>end offset</a>.
-
- <dt><var ignore>collapsed</var> = <var>range</var> . {{Range/collapsed}}
- <dd>Returns true if <var>range</var>'s
- <a for=Range>start</a> and
- <a for=Range>end</a> are the same, and false otherwise.
-
  <dt><var>container</var> = <var>range</var> . {{Range/commonAncestorContainer}}
  <dd>Returns the <a>node</a>, furthest away from
  the <a>document</a>, that is an
  <a>ancestor</a> of both
  <var>range</var>'s
- <a for=Range>start node</a> and
- <a for=Range>end node</a>.
+ <a for=range>start node</a> and
+ <a for=range>end node</a>.
 </dl>
-
-<p>The <dfn attribute for=Range><code>startContainer</code></dfn> attribute's getter must return the
-<a for=Range>start node</a>.
-
-<p>The <dfn attribute for=Range><code>startOffset</code></dfn> attribute's getter must return the
-<a>start offset</a>.
-
-<p>The <dfn attribute for=Range><code>endContainer</code></dfn> attribute's getter must return the
-<a for=Range>end node</a>.
-
-<p>The <dfn attribute for=Range><code>endOffset</code></dfn> attribute's getter must return the
-<a>end offset</a>.
-
-<p>The <dfn attribute for=Range><code>collapsed</code></dfn> attribute's getter must return true if
-<a for=Range>start</a> is the same as <a for=Range>end</a>, and false otherwise.
 
 <p>The <dfn attribute for=Range><code>commonAncestorContainer</code></dfn> attribute's getter must
 run these steps:
 
 <ol>
  <li>Let <var>container</var> be
- <a for=Range>start node</a>.
+ <a for=range>start node</a>.
 
  <li>While <var>container</var> is not an
  <a for=tree>inclusive ancestor</a> of
- <a for=Range>end node</a>, let
+ <a for=range>end node</a>, let
  <var>container</var> be <var>container</var>'s
  <a for=tree>parent</a>.
 
@@ -7679,31 +7564,31 @@ steps:
    <dd>
     <ol>
      <li>If <var>bp</var> is
-     <a for=Range>after</a> the
-     <var>range</var>'s <a for=Range>end</a>, or
+     <a for="boundary point">after</a> the
+     <var>range</var>'s <a for=range>end</a>, or
      if <var>range</var>'s
-     <a for=Range>root</a> is not equal to
+     <a for="live range">root</a> is not equal to
      <var>node</var>'s <a for=tree>root</a>, set
-     <var>range</var>'s <a for=Range>end</a> to
+     <var>range</var>'s <a for=range>end</a> to
      <var>bp</var>.
 
      <li>Set <var>range</var>'s
-     <a for=Range>start</a> to <var>bp</var>.
+     <a for=range>start</a> to <var>bp</var>.
     </ol>
    <dt>If these steps were invoked as "set the end"
    <dd>
     <ol>
      <li>If <var>bp</var> is
-     <a for=Range>before</a> the
-     <var>range</var>'s <a for=Range>start</a>,
+     <a for="boundary point">before</a> the
+     <var>range</var>'s <a for=range>start</a>,
      or if <var>range</var>'s
-     <a for=Range>root</a> is not equal to
+     <a for="live range">root</a> is not equal to
      <var>node</var>'s <a for=tree>root</a>, set
-     <var>range</var>'s <a for=Range>start</a>
+     <var>range</var>'s <a for=range>start</a>
      to <var>bp</var>.
 
      <li>Set <var>range</var>'s
-     <a for=Range>end</a> to <var>bp</var>.
+     <a for=range>end</a> to <var>bp</var>.
     </ol>
   </dl>
 </ol>
@@ -7737,17 +7622,13 @@ invoked, must run these steps:
 must run these steps:
 
 <ol>
- <li>Let <var>parent</var> be <var>node</var>'s
- <a for=tree>parent</a>.
+ <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>.
 
- <li>If <var>parent</var> is null, then <a>throw</a> an "{{InvalidNodeTypeError!!exception}}"
+ <li><p>If <var>parent</var> is null, then <a>throw</a> an "{{InvalidNodeTypeError!!exception}}"
  {{DOMException}}.
 
- <li><a>Set the start</a> of the
- <a>context object</a> to
- <a>boundary point</a>
- (<var>parent</var>, <var>node</var>'s
- <a for=tree>index</a> plus one).
+ <li><p><a>Set the start</a> of the <a>context object</a> to <a>boundary point</a>
+ (<var>parent</var>, <var>node</var>'s <a for=tree>index</a> plus 1).
 </ol>
 
 <p>The <dfn method for=Range><code>setEndBefore(<var>node</var>)</code></dfn>, when invoked, method
@@ -7770,46 +7651,39 @@ must run these steps:
 must run these steps:
 
 <ol>
- <li>Let <var>parent</var> be <var>node</var>'s
- <a for=tree>parent</a>.
+ <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>.
 
- <li>If <var>parent</var> is null, then <a>throw</a> an "{{InvalidNodeTypeError!!exception}}"
+ <li><p>If <var>parent</var> is null, then <a>throw</a> an "{{InvalidNodeTypeError!!exception}}"
  {{DOMException}}.
 
- <li><a>Set the end</a> of the
- <a>context object</a> to
- <a>boundary point</a>
- (<var>parent</var>, <var>node</var>'s <a for=tree>index</a> plus one).
+ <li><p><a>Set the end</a> of the <a>context object</a> to <a>boundary point</a>
+ (<var>parent</var>, <var>node</var>'s <a for=tree>index</a> plus 1).
 </ol>
 
 <p>The <dfn method for=Range><code>collapse(<var>toStart</var>)</code></dfn> method, when invoked,
-must if <var>toStart</var> is true, set <a for=Range>end</a> to <a for=Range>start</a>, and set
-<a for=Range>start</a> to <a for=Range>end</a> otherwise.
+must if <var>toStart</var> is true, set <a for=range>end</a> to <a for=range>start</a>, and set
+<a for=range>start</a> to <a for=range>end</a> otherwise.
 
-<p>To <dfn export id=concept-range-select for=Range>select</dfn> a <a>node</a> <var>node</var>
+<p>To <dfn export id=concept-range-select for=range>select</dfn> a <a for=/>node</a> <var>node</var>
 within a <a>range</a> <var>range</var>, run these steps:
 
 <ol>
- <li>Let <var>parent</var> be <var>node</var>'s
- <a for=tree>parent</a>.
+ <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>.
 
- <li>If <var>parent</var> is null, <a>throw</a> an
- "{{InvalidNodeTypeError!!exception}}" {{DOMException}}.
+ <li><p>If <var>parent</var> is null, then <a>throw</a> an "{{InvalidNodeTypeError!!exception}}"
+ {{DOMException}}.
 
- <li>Let <var>index</var> be <var>node</var>'s
- <a for=tree>index</a>.
+ <li><p>Let <var>index</var> be <var>node</var>'s <a for=tree>index</a>.
 
- <li>Set <var>range</var>'s <a for=Range>start</a> to
- <a>boundary point</a>
+ <li><p>Set <var>range</var>'s <a for=range>start</a> to <a>boundary point</a>
  (<var>parent</var>, <var>index</var>).
 
- <li>Set <var>range</var>'s <a for=Range>end</a> to
- <a>boundary point</a>
- (<var>parent</var>, <var>index</var> plus one).
+ <li><p>Set <var>range</var>'s <a for=range>end</a> to <a>boundary point</a>
+ (<var>parent</var>, <var>index</var> plus 1).
 </ol>
 
 <p>The <dfn method for=Range><code>selectNode(<var>node</var>)</code></dfn> method, when invoked,
-must <a for=Range>select</a> <var>node</var> within <a>context object</a>.
+must <a for=range>select</a> <var>node</var> within <a>context object</a>.
 
 <p>The <dfn method for=Range><code>selectNodeContents(<var>node</var>)</code></dfn> method, when
 invoked, must run these steps:
@@ -7823,11 +7697,11 @@ invoked, must run these steps:
  <li>Let <var>length</var> be the
  <a>length</a> of <var>node</var>.
 
- <li>Set <a for=Range>start</a> to the
+ <li>Set <a for=range>start</a> to the
  <a>boundary point</a>
  (<var>node</var>, 0).
 
- <li>Set <a for=Range>end</a> to the
+ <li>Set <a for=range>end</a> to the
  <a>boundary point</a>
  (<var>node</var>, <var>length</var>).
 </ol>
@@ -7871,8 +7745,8 @@ method, when invoked, must run these steps:
  Opera) instead of a nonstandard exception type.
  -->
 
- <li>If <a>context object</a>'s <a for=Range>root</a> is not the same as <var>sourceRange</var>'s
- <a for=Range>root</a>, then <a>throw</a> a "{{WrongDocumentError!!exception}}" {{DOMException}}.
+ <li>If <a>context object</a>'s <a for="live range">root</a> is not the same as <var>sourceRange</var>'s
+ <a for="live range">root</a>, then <a>throw</a> a "{{WrongDocumentError!!exception}}" {{DOMException}}.
 
  <li>
   If <var>how</var> is:
@@ -7880,30 +7754,30 @@ method, when invoked, must run these steps:
    <dt>{{Range/START_TO_START}}:
    <dd>
     Let <var>this point</var> be the <a>context object</a>'s
-    <a for=Range>start</a>.
+    <a for=range>start</a>.
     Let <var>other point</var> be <var>sourceRange</var>'s
-    <a for=Range>start</a>.
+    <a for=range>start</a>.
 
    <dt>{{Range/START_TO_END}}:
    <dd>
     Let <var>this point</var> be the <a>context object</a>'s
-    <a for=Range>end</a>.
+    <a for=range>end</a>.
     Let <var>other point</var> be <var>sourceRange</var>'s
-    <a for=Range>start</a>.
+    <a for=range>start</a>.
 
     <dt>{{Range/END_TO_END}}:
     <dd>
      Let <var>this point</var> be the <a>context object</a>'s
-     <a for=Range>end</a>.
+     <a for=range>end</a>.
      Let <var>other point</var> be <var>sourceRange</var>'s
-     <a for=Range>end</a>.
+     <a for=range>end</a>.
 
     <dt>{{Range/END_TO_START}}:
     <dd>
      Let <var>this point</var> be the <a>context object</a>'s
-     <a for=Range>start</a>.
+     <a for=range>start</a>.
      Let <var>other point</var> be <var>sourceRange</var>'s
-     <a for=Range>end</a>.
+     <a for=range>end</a>.
    </dl>
 
   <li>
@@ -7911,13 +7785,13 @@ method, when invoked, must run these steps:
    <var>this point</var> relative to <var>other point</var> is
 
    <dl class=switch>
-    <dt><a for=Range>before</a>
+    <dt><a for="boundary point">before</a>
     <dd>Return &minus;1.
 
-    <dt><a for=Range>equal</a>
+    <dt><a for="boundary point">equal</a>
     <dd>Return 0.
 
-    <dt><a for=Range>after</a>
+    <dt><a for="boundary point">after</a>
     <dd>Return 1.
    </dl>
 </ol>
@@ -7926,7 +7800,7 @@ method, when invoked, must run these steps:
 run these steps:
 
 <ol>
- <li>If <a for=Range>start</a> is <a for=Range>end</a>, then return.
+ <li><p>If the <a>context object</a> is <a for=range>collapsed</a>, then return.
  <!-- This might actually make no difference, but it's not immediately
  obvious what would happen otherwise if the start/end were text/comment:
  are all the substeps of the next step actually no-ops, or could some have
@@ -7936,10 +7810,10 @@ run these steps:
  <var>original start offset</var>, <var>original end node</var>,
  and <var>original end offset</var> be the
  <a>context object</a>'s
- <a for=Range>start node</a>,
- <a>start offset</a>,
- <a for=Range>end node</a>, and
- <a>end offset</a>, respectively.
+ <a for=range>start node</a>,
+ <a for=range>start offset</a>,
+ <a for=range>end node</a>, and
+ <a for=range>end offset</a>, respectively.
 
  <li>If <var>original start node</var> and
  <var>original end node</var> are the same, and they are a
@@ -7952,12 +7826,12 @@ run these steps:
  <var>original start offset</var>, and data the empty string, and then return.
 
  <li>Let <var>nodes to remove</var> be a list of all the
- <a>nodes</a> that are <a>contained</a> in
+ <a for=/>nodes</a> that are <a for="live range">contained</a> in
  the <a>context object</a>, in
  <a>tree order</a>, omitting any
  <a>node</a> whose
  <a for=tree>parent</a> is also
- <a>contained</a> in the <a>context object</a>.
+ <a for="live range">contained</a> in the <a>context object</a>.
 
  <li>If <var>original start node</var> is an
  <a for=tree>inclusive ancestor</a> of
@@ -7986,7 +7860,7 @@ run these steps:
 
     <p class="note no-backref">If <var>reference node</var>'s
     <a for=tree>parent</a> were null, it would be the
-    <a for=Range>root</a> of the
+    <a for="live range">root</a> of the
     <a>context object</a>, so would be an
     <a for=tree>inclusive ancestor</a> of
     <var>original end node</var>, and we could not reach this point.
@@ -8014,23 +7888,20 @@ run these steps:
  <var>original end node</var>, offset 0, count
  <var>original end offset</var> and data the empty string.
 
- <li>Set <a for=Range>start</a> and
- <a for=Range>end</a> to
+ <li>Set <a for=range>start</a> and
+ <a for=range>end</a> to
  (<var>new node</var>, <var>new offset</var>).
 </ol>
 
-To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">extract</dfn> a
-<a>range</a> <var>range</var>, run these steps:
+<p>To <dfn export id=concept-range-extract for="live range">extract</dfn> a <a>live range</a>
+<var>range</var>, run these steps:
 
 <ol>
- <li>Let <var>fragment</var> be a new {{DocumentFragment}}
- <a>node</a> whose
- <a for=Node>node document</a> is <var>range</var>'s
- <a for=Range>start node</a>'s
+ <li><p>Let <var>fragment</var> be a new {{DocumentFragment}} <a for=/>node</a> whose
+ <a for=Node>node document</a> is <var>range</var>'s <a for=range>start node</a>'s
  <a for=Node>node document</a>.
 
- <li>If <var>range</var>'s <a for=Range>start</a> is its <a for=Range>end</a>, return
- <var>fragment</var>.
+ <li><p>If <var>range</var> is <a for=range>collapsed</a>, then return <var>fragment</var>.
  <!-- This is only really needed when the start and end nodes are
  text/comment, to avoid creating an empty clone as the child of the
  fragment. (Opera 11 actually does include such an empty clone, it seems,
@@ -8040,10 +7911,10 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
 
  <li>Let <var>original start node</var>, <var>original start offset</var>,
  <var>original end node</var>, and <var>original end offset</var> be
- <var>range</var>'s <a for=Range>start node</a>,
- <a>start offset</a>,
- <a for=Range>end node</a>, and
- <a>end offset</a>, respectively.
+ <var>range</var>'s <a for=range>start node</a>,
+ <a for=range>start offset</a>,
+ <a for=range>end node</a>, and
+ <a for=range>end offset</a>, respectively.
 
  <li>
   If <var>original start node</var> is <var>original end node</var>, and they are a
@@ -8088,7 +7959,7 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
  <a for=tree>inclusive ancestor</a> of
  <var>original end node</var>, set <var>first partially contained child</var>
  to the first <a for=tree>child</a> of
- <var>common ancestor</var> that is <a>partially contained</a> in
+ <var>common ancestor</var> that is <a for="live range">partially contained</a> in
  <var>range</var>.
 
  <li>Let <var>last partially contained child</var> be null.
@@ -8099,13 +7970,13 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
   <var>original start node</var>, set
   <var>last partially contained child</var> to the last
   <a for=tree>child</a> of <var>common ancestor</var> that is
-  <a>partially contained</a> in <var>range</var>.
+  <a for="live range">partially contained</a> in <var>range</var>.
 
   <p class="note no-backref">These variable assignments do actually always make sense.
   For instance, if <var>original start node</var> is not an
   <a for=tree>inclusive ancestor</a> of
   <var>original end node</var>, <var>original start node</var> is itself
-  <a>partially contained</a> in <var>range</var>, and so are all its
+  <a for="live range">partially contained</a> in <var>range</var>, and so are all its
   <a>ancestors</a> up until a
   <a for=tree>child</a> of <var>common ancestor</var>.
   <var>common ancestor</var> cannot be <var>original start node</var>, because
@@ -8115,7 +7986,7 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
 
  <li>Let <var>contained children</var> be a list of all
  <a>children</a> of
- <var>common ancestor</var> that are <a>contained</a> in
+ <var>common ancestor</var> that are <a for="live range">contained</a> in
  <var>range</var>, in <a>tree order</a>.
 
  <li>
@@ -8157,7 +8028,7 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
 
     <p class="note no-backref">If <var>reference node</var>'s
     <a for=tree>parent</a> is null, it would be the
-    <a for=Range>root</a> of <var>range</var>, so would be an
+    <a for="live range">root</a> of <var>range</var>, so would be an
     <a for=tree>inclusive ancestor</a> of
     <var>original end node</var>, and we could not reach this point.
   </ol>
@@ -8210,10 +8081,10 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>range</a>
-   whose <a for=Range>start</a> is
+   <li>Let <var>subrange</var> be a new <a>live range</a>
+   whose <a for=range>start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
-   whose <a for=Range>end</a> is
+   whose <a for=range>end</a> is
    (<var>first partially contained child</var>, <var>first partially contained child</var>'s <a>length</a>).
 
    <li>Let <var>subfragment</var> be the result of
@@ -8265,10 +8136,10 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>range</a>
-   whose <a for=Range>start</a> is
+   <li>Let <var>subrange</var> be a new <a>live range</a>
+   whose <a for=range>start</a> is
    (<var>last partially contained child</var>, 0) and whose
-   <a for=Range>end</a> is
+   <a for=range>end</a> is
    (<var>original end node</var>, <var>original end offset</var>).
 
    <li>Let <var>subfragment</var> be the result of
@@ -8278,8 +8149,8 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
    <var>clone</var>.
   </ol>
 
- <li>Set <var>range</var>'s <a for=Range>start</a> and
- <a for=Range>end</a> to
+ <li>Set <var>range</var>'s <a for=range>start</a> and
+ <a for=range>end</a> to
  (<var>new node</var>, <var>new offset</var>).
 
  <li>Return <var>fragment</var>.
@@ -8288,18 +8159,16 @@ To <dfn export id=concept-range-extract lt="extract a range" local-lt="extract">
 <p>The <dfn method for=Range><code>extractContents()</code></dfn> method, when invoked, must return
 the result of <a lt="extract a range">extracting</a> <a>context object</a>.
 
-<p>To <dfn export id=concept-range-clone lt="clone the contents of a range">clone the contents</dfn>
-of a <a>range</a> <var>range</var>, run these steps:
+<p>To
+<dfn export id=concept-range-clone for="live range" lt="clone the contents|cloning the contents">clone the contents</dfn>
+of a <a>live range</a> <var>range</var>, run these steps:
 
 <ol>
- <li>Let <var>fragment</var> be a new {{DocumentFragment}}
- <a>node</a> whose
- <a for=Node>node document</a> is <var>range</var>'s
- <a for=Range>start node</a>'s
+ <li><p>Let <var>fragment</var> be a new {{DocumentFragment}} <a for=/>node</a> whose
+ <a for=Node>node document</a> is <var>range</var>'s <a for=range>start node</a>'s
  <a for=Node>node document</a>.
 
- <li>If <var>range</var>'s <a for=Range>start</a> is its <a for=Range>end</a>, return
- <var>fragment</var>.
+ <li><p>If <var>range</var> is <a for=range>collapsed</a>, then return <var>fragment</var>.
  <!-- This is only really needed when the start and end nodes are
  text/comment, to avoid creating an empty clone as the child of the
  fragment. (Opera 11 actually does include such an empty clone, it seems,
@@ -8309,10 +8178,10 @@ of a <a>range</a> <var>range</var>, run these steps:
 
  <li>Let <var>original start node</var>, <var>original start offset</var>,
  <var>original end node</var>, and <var>original end offset</var> be
- <var>range</var>'s <a for=Range>start node</a>,
- <a>start offset</a>,
- <a for=Range>end node</a>, and
- <a>end offset</a>, respectively.
+ <var>range</var>'s <a for=range>start node</a>,
+ <a for=range>start offset</a>,
+ <a for=range>end node</a>, and
+ <a for=range>end offset</a>, respectively.
 
  <li>
   If <var>original start node</var> is <var>original end node</var>, and they are a
@@ -8351,7 +8220,7 @@ of a <a>range</a> <var>range</var>, run these steps:
  <a for=tree>inclusive ancestor</a> of
  <var>original end node</var>, set <var>first partially contained child</var>
  to the first <a for=tree>child</a> of
- <var>common ancestor</var> that is <a>partially contained</a> in
+ <var>common ancestor</var> that is <a for="live range">partially contained</a> in
  <var>range</var>.
 
  <li>Let <var>last partially contained child</var> be null.
@@ -8362,13 +8231,13 @@ of a <a>range</a> <var>range</var>, run these steps:
   <var>original start node</var>, set
   <var>last partially contained child</var> to the last
   <a for=tree>child</a> of <var>common ancestor</var> that is
-  <a>partially contained</a> in <var>range</var>.
+  <a for="live range">partially contained</a> in <var>range</var>.
 
   <p class="note no-backref">These variable assignments do actually always make sense.
   For instance, if <var>original start node</var> is not an
   <a for=tree>inclusive ancestor</a> of
   <var>original end node</var>, <var>original start node</var> is itself
-  <a>partially contained</a> in <var>range</var>, and so are all its
+  <a for="live range">partially contained</a> in <var>range</var>, and so are all its
   <a>ancestors</a> up until a
   <a for=tree>child</a> of <var>common ancestor</var>.
   <var>common ancestor</var> cannot be <var>original start node</var>, because
@@ -8378,7 +8247,7 @@ of a <a>range</a> <var>range</var>, run these steps:
 
  <li>Let <var>contained children</var> be a list of all
  <a>children</a> of
- <var>common ancestor</var> that are <a>contained</a> in
+ <var>common ancestor</var> that are <a for="live range">contained</a> in
  <var>range</var>, in <a>tree order</a>.
 
  <li>
@@ -8428,14 +8297,14 @@ of a <a>range</a> <var>range</var>, run these steps:
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>range</a>
-   whose <a for=Range>start</a> is
+   <li>Let <var>subrange</var> be a new <a>live range</a>
+   whose <a for=range>start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
-   whose <a for=Range>end</a> is
+   whose <a for=range>end</a> is
    (<var>first partially contained child</var>, <var>first partially contained child</var>'s <a>length</a>).
 
-   <li>Let <var>subfragment</var> be the result of
-   <a lt="clone the contents of a range">cloning the contents</a> of <var>subrange</var>.
+   <li><p>Let <var>subfragment</var> be the result of <a for="live range">cloning the contents</a>
+   of <var>subrange</var>.
 
    <li><a>Append</a> <var>subfragment</var> to
    <var>clone</var>.
@@ -8487,14 +8356,14 @@ of a <a>range</a> <var>range</var>, run these steps:
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>range</a>
-   whose <a for=Range>start</a> is
+   <li>Let <var>subrange</var> be a new <a>live range</a>
+   whose <a for=range>start</a> is
    (<var>last partially contained child</var>, 0) and whose
-   <a for=Range>end</a> is
+   <a for=range>end</a> is
    (<var>original end node</var>, <var>original end offset</var>).
 
-   <li>Let <var>subfragment</var> be the result of
-   <a lt="clone the contents of a range">cloning the contents</a> of <var>subrange</var>.
+   <li><p>Let <var>subfragment</var> be the result of <a for="live range">cloning the contents</a>
+   of <var>subrange</var>.
 
    <li><a>Append</a> <var>subfragment</var> to
    <var>clone</var>.
@@ -8504,14 +8373,13 @@ of a <a>range</a> <var>range</var>, run these steps:
 </ol>
 
 <p>The <dfn method for=Range><code>cloneContents()</code></dfn> method, when invoked, must return
-the result of <a lt="clone the contents of a range">cloning the contents</a> of
-<a>context object</a>.
+the result of <a for="live range">cloning the contents</a> of the <a>context object</a>.
 
-<p>To <dfn export id=concept-range-insert lt="range insert">insert</dfn> a <a>node</a>
-<var>node</var> into a <a>range</a> <var>range</var>, run these steps:
+<p>To <dfn export id=concept-range-insert for="live range">insert</dfn> a <a for=/>node</a>
+<var>node</var> into a <a>live range</a> <var>range</var>, run these steps:
 
 <ol>
- <li>If <var>range</var>'s <a for=Range>start node</a> is a {{ProcessingInstruction}} or {{Comment}}
+ <li>If <var>range</var>'s <a for=range>start node</a> is a {{ProcessingInstruction}} or {{Comment}}
  <a>node</a>, is a {{Text}} <a>node</a> whose <a for=tree>parent</a> is null, or is <var>node</var>,
  then <a>throw</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}}.
 
@@ -8533,7 +8401,7 @@ the result of <a lt="clone the contents of a range">cloning the contents</a> of
  -->
  <li>Let <var>referenceNode</var> be null.
 
- <li>If <var>range</var>'s <a for=Range>start node</a>
+ <li>If <var>range</var>'s <a for=range>start node</a>
  is a {{Text}} <a>node</a>,
  set <var>referenceNode</var> to that {{Text}}
  <a>node</a>. <!-- This will change when we split
@@ -8541,13 +8409,13 @@ the result of <a lt="clone the contents of a range">cloning the contents</a> of
 
  <li>Otherwise, set <var>referenceNode</var> to the
  <a for=tree>child</a> of
- <a for=Range>start node</a> whose
+ <a for=range>start node</a> whose
  <a for=tree>index</a> is
- <a>start offset</a>, and null if
+ <a for=range>start offset</a>, and null if
  there is no such <a for=tree>child</a>.
 
  <li>Let <var>parent</var> be <var>range</var>'s
- <a for=Range>start node</a> if <var>referenceNode</var>
+ <a for=range>start node</a> if <var>referenceNode</var>
  is null, and <var>referenceNode</var>'s
  <a for=tree>parent</a> otherwise.
 
@@ -8563,9 +8431,9 @@ the result of <a lt="clone the contents of a range">cloning the contents</a> of
  of <var>node</var> into <var>parent</var> before
  <var>referenceNode</var>.
 
- <li>If <var>range</var>'s <a for=Range>start node</a> is a {{Text}} <a>node</a>, set
+ <li>If <var>range</var>'s <a for=range>start node</a> is a {{Text}} <a>node</a>, set
  <var>referenceNode</var> to the result of <a lt="split a Text node">splitting</a> it with
- offset <var>range</var>'s <a>start offset</a>.
+ offset <var>range</var>'s <a for=range>start offset</a>.
 
  <li>If <var>node</var> is <var>referenceNode</var>, set <var>referenceNode</var> to its
  <a for=tree>next sibling</a>.
@@ -8608,14 +8476,12 @@ the result of <a lt="clone the contents of a range">cloning the contents</a> of
  <li><a>Pre-insert</a>
  <var>node</var> into <var>parent</var> before <var>referenceNode</var>.
 
- <li>If <var>range</var>'s <a for=Range>start</a> and
- <a for=Range>end</a> are the same, set <var>range</var>'s
- <a for=Range>end</a> to
- (<var>parent</var>, <var>newOffset</var>).
+ <li><p>If <var>range</var> is <a for=range>collapsed</a>, then set <var>range</var>'s
+ <a for=range>end</a> to (<var>parent</var>, <var>newOffset</var>).
 </ol>
 
 <p>The <dfn method for=Range><code>insertNode(<var>node</var>)</code></dfn> method, when invoked,
-must <a>range insert</a> <var>node</var> into <a>context object</a>.
+must <a for="live range">insert</a> <var>node</var> into the <a>context object</a>.
 
 <p>The <dfn method for=Range><code>surroundContents(<var>newParent</var>)</code></dfn> method, when
 invoked, must run these steps:
@@ -8633,7 +8499,7 @@ check first thing, which matches everyone but Firefox.
 
 <ol>
  <li>If a non-{{Text}} <a>node</a> is
- <a>partially contained</a> in the <a>context object</a>,
+ <a for="live range">partially contained</a> in the <a>context object</a>,
  then <a>throw</a> an "{{InvalidStateError!!exception}}" {{DOMException}}.
  <!-- Makes some sense: otherwise we'd clone a bunch of containers, which is
  unexpected. -->
@@ -8676,12 +8542,12 @@ check first thing, which matches everyone but Firefox.
  <a for=Node>replace all</a> with null within
  <var>newParent</var>.
 
- <li><a>Range insert</a> <var>newParent</var> into <a>context object</a>.
+ <li><p><a for="live range">Insert</a> <var>newParent</var> into the <a>context object</a>.
 
  <li><a>Append</a> <var>fragment</var> to
  <var>newParent</var>.
 
- <li><a for=Range>Select</a> <var>newParent</var> within
+ <li><a for=range>Select</a> <var>newParent</var> within
  <a>context object</a>.
  <!-- Generally this isn't needed, because insertNode() will already do it,
  but it makes a difference in at least one corner case (when the original
@@ -8689,7 +8555,8 @@ check first thing, which matches everyone but Firefox.
 </ol>
 
 <p>The <dfn method for=Range><code>cloneRange()</code></dfn> method, when invoked, must return a new
-<a>range</a> with the same <a for=Range>start</a> and <a for=Range>end</a> as <a>context object</a>.
+<a>live range</a> with the same <a for=range>start</a> and <a for=range>end</a> as the
+<a>context object</a>.
 
 <p>The <dfn method for=Range><code>detach()</code></dfn> method, when invoked, must do nothing.
 <span class=note>Its functionality (disabling a {{Range}} object) was removed, but the method itself
@@ -8716,7 +8583,7 @@ method, when invoked, must run these steps:
 
 <ol>
  <li>If <var>node</var>'s <a for=tree>root</a> is
- different from the <a>context object</a>'s <a for=Range>root</a>, return false.
+ different from the <a>context object</a>'s <a for="live range">root</a>, return false.
  <!-- This happens even if the offset is negative or too large, or if the node
  is a doctype, in both Firefox 9.0a2 and Chrome 16 dev. -->
 
@@ -8738,10 +8605,10 @@ method, when invoked, must run these steps:
  best to throw anyway. -->
 
  <li>If (<var>node</var>, <var>offset</var>) is
- <a for=Range>before</a>
- <a for=Range>start</a> or
- <a for=Range>after</a>
- <a for=Range>end</a>, return false.
+ <a for="boundary point">before</a>
+ <a for=range>start</a> or
+ <a for="boundary point">after</a>
+ <a for=range>end</a>, return false.
 
  <li>Return true.
 </ol>
@@ -8753,7 +8620,7 @@ and Opera Next 12.00 alpha all do. -->
 
 <ol>
  <li>If <var>node</var>'s <a for=tree>root</a> is different from the <a>context object</a>'s
- <a for=Range>root</a>, then <a>throw</a> a "{{WrongDocumentError!!exception}}" {{DOMException}}.
+ <a for="live range">root</a>, then <a>throw</a> a "{{WrongDocumentError!!exception}}" {{DOMException}}.
  <!-- Opera Next 12.00 alpha seems to return -1 in this case.  The spec matches
  Firefox 12.0a1 and Chrome 17 dev. -->
 
@@ -8769,12 +8636,12 @@ and Opera Next 12.00 alpha all do. -->
  alpha, which don't throw.  See comment for isPointInRange(). -->
 
  <li>If (<var>node</var>, <var>offset</var>) is
- <a for=Range>before</a>
- <a for=Range>start</a>, return &minus;1.
+ <a for="boundary point">before</a>
+ <a for=range>start</a>, return &minus;1.
 
  <li>If (<var>node</var>, <var>offset</var>) is
- <a for=Range>after</a>
- <a for=Range>end</a>, return 1.
+ <a for="boundary point">after</a>
+ <a for=range>end</a>, return 1.
 
  <li>Return 0.
 </ol>
@@ -8789,7 +8656,7 @@ Firefox 12.0a1. -->
 <ol>
  <li>If <var>node</var>'s <a for=tree>root</a>
  is different from the <a>context object</a>'s
- <a for=Range>root</a>, return false.
+ <a for="live range">root</a>, return false.
  <!-- It seems like for doctypes, Opera Next 12.00 alpha throws
  InvalidNodeTypeError instead of returning false.  The spec follows Chrome
  17 dev. -->
@@ -8805,11 +8672,11 @@ Firefox 12.0a1. -->
  <a for=tree>index</a>.
 
  <li>If (<var>parent</var>, <var>offset</var>) is
- <a for=Range>before</a>
- <a for=Range>end</a> and (<var>parent</var>,
- <var>offset</var> + 1) is
- <a for=Range>after</a>
- <a for=Range>start</a>, return true.
+ <a for="boundary point">before</a>
+ <a for=range>end</a> and (<var>parent</var>,
+ <var>offset</var> plus 1) is
+ <a for="boundary point">after</a>
+ <a for=range>start</a>, return true.
 
  <li>Return false.
 </ol>
@@ -8824,29 +8691,29 @@ these steps:
 <ol>
  <li>Let <var>s</var> be the empty string.
 
- <li>If <a for=Range>start node</a> is <a for=Range>end node</a>, and it is a
+ <li>If <a for=range>start node</a> is <a for=range>end node</a>, and it is a
  {{Text}} <a>node</a>, return the
  substring of that {{Text}} <a>node</a>'s <a for=CharacterData>data</a> beginning at
- <a>start offset</a> and ending at
- <a>end offset</a>.
+ <a for=range>start offset</a> and ending at
+ <a for=range>end offset</a>.
 
- <li>If <a for=Range>start node</a> is a
+ <li>If <a for=range>start node</a> is a
  {{Text}} <a>node</a>, append to
  <var>s</var> the substring of that
  <a>node</a>'s
  <a for=CharacterData>data</a> from the
- <a>start offset</a> until the end.
+ <a for=range>start offset</a> until the end.
 
  <li>Append the <a for=string>concatenation</a> of the <a for=CharacterData>data</a> of all {{Text}}
- <a>nodes</a> that are <a>contained</a> in the <a>context object</a>, in <a>tree order</a>, to
+ <a for=/>nodes</a> that are <a for="live range">contained</a> in the <a>context object</a>, in <a>tree order</a>, to
  <var>s</var>.
 
- <li>If <a for=Range>end node</a> is a
+ <li>If <a for=range>end node</a> is a
  {{Text}} <a>node</a>, append to
  <var>s</var> the substring of that
  <a>node</a>'s
  <a for=CharacterData>data</a> from its start until the
- <a>end offset</a>.
+ <a for=range>end offset</a>.
 
  <li>Return <var>s</var>.
 </ol>
@@ -9775,7 +9642,7 @@ These are the changes made to the features described in
 
 {{Node}} now inherits from {{EventTarget}}.
 
-<a>Nodes</a> are implicitly
+<a for=/>nodes</a> are implicitly
 <a>adopted</a> across
 <a>document</a> boundaries.
 
@@ -9892,7 +9759,7 @@ These are the changes made to the features described in the
 <ul>
  <li><dfn interface>RangeException</dfn> has been removed.
 
- <li>{{Range}} objects can now be moved between <a>documents</a> and used on <a>nodes</a> that are
+ <li>{{Range}} objects can now be moved between <a>documents</a> and used on <a for=/>nodes</a> that are
  not <a>in a document tree</a>.
 
  <li>A wild {{Range/Range()}} constructor appeared.


### PR DESCRIPTION
This refactors large parts of the DOM Standard to reclassify Range
objects as "live ranges" rather than "ranges". The bits shared
between StaticRange and Range objects are put on a shared superclass
named AbstractRange.

This also introduces a "collapsed" definition and uses it throughout.

It does not contain everything from
https://w3c.github.io/staticrange/. I based this draft on the IDL
present in implementations, coupled with the desire for a superclass.
Extensions beyond this seem best addressed as follow-ups.

Tests: ...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/589.html" title="Last updated on Mar 16, 2018, 7:34 AM GMT (71954ff)">Preview</a> | <a href="https://whatpr.org/dom/589/06dae65...71954ff.html" title="Last updated on Mar 16, 2018, 7:34 AM GMT (71954ff)">Diff</a>