### PR TITLE
Stop defining nodeName in terms of tagName

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3717,7 +3717,7 @@ that is a <a>document</a>.
 
   <dl>
    <dt>{{Element}}
-   <dd>Its {{Element/tagName}} attribute value.
+   <dd>Its <a for=Element>blurred qualified name</a>.
 
    <dt>{{Attr}}
    <dd>Its <a for=Attr>qualified name</a>.
@@ -3804,13 +3804,12 @@ The <dfn attribute for=Node>localName</dfn> attribute
 must return the local name that is associated with the node, if it has one,
 and null otherwise.-->
 
-The <dfn attribute for=Node>nodeName</dfn> attribute's getter, when invoked, must return
-the first matching statement, switching on the <a>context object</a>:
+<p>The <dfn attribute for=Node>nodeName</dfn> attribute's getter, when invoked, must return the
+first matching statement, switching on the <a>context object</a>:
 
 <dl class=switch>
  <dt>{{Element}}
- <dd>Its {{Element/tagName}} attribute value.
- <!-- XXX internal concept -->
+ <dd>Its <a for=Element>blurred qualified name</a>.
 
  <dt>{{Attr}}
  <dd>Its <a for=Attr>qualified name</a>.
@@ -5820,7 +5819,21 @@ execute correctly the first time, it is not executed again by an
 <a for=Element>namespace prefix</a>, followed by "<code>:</code>", followed by its
 <a for=Element>local name</a>, otherwise.
 
-<p class=note>User agents could have this as an internal slot as an optimization.
+<p>An <a for=/>element</a>'s <dfn for=Element>blurred qualified name</dfn> is the return value of
+these steps:
+
+<ol>
+ <li><p>Let <var>qualifiedName</var> be <a>context object</a>'s <a for=Element>qualified name</a>.
+
+ <li><p>If the <a>context object</a> is in the <a>HTML namespace</a> and its
+ <a for=Node>node document</a> is an <a>HTML document</a>, then set <var>qualifiedName</var> to
+ <var>qualifiedName</var> in <a>ASCII uppercase</a>.
+
+ <li>Return <var>qualifiedName</var>.
+</ol>
+
+<p class=note>User agents could optimize <a for=Element>qualified name</a> and
+<a for=Element>blurred qualified name</a> by storing them in internal slots.
 
 <p>To
 <dfn export id=concept-create-element lt="create an element|creating an element">create an element</dfn>,
@@ -6289,8 +6302,7 @@ A <a>node</a>'s
  <a for=Element>local name</a>.
 
  <dt><var>qualifiedName</var> = <var>element</var> . {{Element/tagName}}
- <dd>Returns the <a for=Element>qualified name</a>. (The return value is uppercased in an
- <a>HTML document</a>.)
+ <dd>Returns the <a for=Element>blurred qualified name</a>.
 </dl>
 
 <p>The <dfn attribute for=Element><code>namespaceURI</code></dfn> attribute's getter must return
@@ -6302,18 +6314,8 @@ the <a>context object</a>'s <a for=Element>namespace</a>.
 <p>The <dfn attribute for=Element><code>localName</code></dfn> attribute's getter must return the
 <a>context object</a>'s <a for=Element>local name</a>.
 
-<p>The <dfn attribute for=Element><code>tagName</code></dfn> attribute's getter must run these
-steps:
-
-<ol>
- <li><p>Let <var>qualifiedName</var> be <a>context object</a>'s <a for=Element>qualified name</a>.
-
- <li><p>If the <a>context object</a> is in the <a>HTML namespace</a> and its
- <a for=Node>node document</a> is an <a>HTML document</a>, then set <var>qualifiedName</var> to
- <var>qualifiedName</var> in <a>ASCII uppercase</a>.
-
- <li>Return <var>qualifiedName</var>.
-</ol>
+<p>The <dfn attribute for=Element><code>tagName</code></dfn> attribute's getter must return the
+<a>context object</a>'s <a for=Element>blurred qualified name</a>.
 
 <hr>
 

--- a/dom.bs
+++ b/dom.bs
@@ -3717,7 +3717,7 @@ that is a <a>document</a>.
 
   <dl>
    <dt>{{Element}}
-   <dd>Its <a for=Element>blurred qualified name</a>.
+   <dd>Its <a for=Element>HTML-uppercased qualified name</a>.
 
    <dt>{{Attr}}
    <dd>Its <a for=Attr>qualified name</a>.
@@ -3809,7 +3809,7 @@ first matching statement, switching on the <a>context object</a>:
 
 <dl class=switch>
  <dt>{{Element}}
- <dd>Its <a for=Element>blurred qualified name</a>.
+ <dd>Its <a for=Element>HTML-uppercased qualified name</a>.
 
  <dt>{{Attr}}
  <dd>Its <a for=Attr>qualified name</a>.
@@ -5819,8 +5819,8 @@ execute correctly the first time, it is not executed again by an
 <a for=Element>namespace prefix</a>, followed by "<code>:</code>", followed by its
 <a for=Element>local name</a>, otherwise.
 
-<p>An <a for=/>element</a>'s <dfn for=Element>blurred qualified name</dfn> is the return value of
-these steps:
+<p>An <a for=/>element</a>'s <dfn for=Element>HTML-uppercased qualified name</dfn> is the return
+value of these steps:
 
 <ol>
  <li><p>Let <var>qualifiedName</var> be <a>context object</a>'s <a for=Element>qualified name</a>.
@@ -5833,7 +5833,7 @@ these steps:
 </ol>
 
 <p class=note>User agents could optimize <a for=Element>qualified name</a> and
-<a for=Element>blurred qualified name</a> by storing them in internal slots.
+<a for=Element>HTML-uppercased qualified name</a> by storing them in internal slots.
 
 <p>To
 <dfn export id=concept-create-element lt="create an element|creating an element">create an element</dfn>,
@@ -6302,7 +6302,7 @@ A <a>node</a>'s
  <a for=Element>local name</a>.
 
  <dt><var>qualifiedName</var> = <var>element</var> . {{Element/tagName}}
- <dd>Returns the <a for=Element>blurred qualified name</a>.
+ <dd>Returns the <a for=Element>HTML-uppercased qualified name</a>.
 </dl>
 
 <p>The <dfn attribute for=Element><code>namespaceURI</code></dfn> attribute's getter must return
@@ -6315,7 +6315,7 @@ the <a>context object</a>'s <a for=Element>namespace</a>.
 <a>context object</a>'s <a for=Element>local name</a>.
 
 <p>The <dfn attribute for=Element><code>tagName</code></dfn> attribute's getter must return the
-<a>context object</a>'s <a for=Element>blurred qualified name</a>.
+<a>context object</a>'s <a for=Element>HTML-uppercased qualified name</a>.
 
 <hr>
 


### PR DESCRIPTION
Fixes #297.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/593.html" title="Last updated on Mar 13, 2018, 8:13 AM GMT (4bb937b)">Preview</a> | <a href="https://whatpr.org/dom/593/510fa87...4bb937b.html" title="Last updated on Mar 13, 2018, 8:13 AM GMT (4bb937b)">Diff</a>