### PR TITLE
Make the two ways of event creation share a path

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -809,19 +809,10 @@ interface, or of an interface that inherits from the {{Event}} interface, is inv
 must be run, given the arguments <var>type</var> and <var>eventInitDict</var>:
 
 <ol>
- <li><p>Create a new object <var>event</var> using this interface.
-
- <li><p>Set <var>event</var>'s <a>initialized flag</a>.
+ <li><p>Let <var>event</var> be the result of running the <a>inner event creation steps</a> with
+ this interface, null, now, and <var>eventInitDict</var>.
 
  <li><p>Initialize <var>event</var>'s {{Event/type}} attribute to <var>type</var>.
-
- <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
- representing the high resolution time from the <a>time origin</a> to the occurrence of the call
- to the <var>event</var>'s <a>constructor</a>.
-
- <li><p>For each <a>dictionary member</a> present in <var>eventInitDict</var>, find the attribute on
- <var>event</var> whose <a spec=webidl>identifier</a> matches the key of the
- <a>dictionary member</a> and then set the attribute to the value of that <a>dictionary member</a>.
 
  <li><p>Return <var>event</var>.
 </ol>
@@ -832,34 +823,27 @@ using <var>eventInterface</var>, which must be either {{Event}} or an interface 
 it, and optionally given a <a>Realm</a> <var>realm</var>, run these steps:</p>
 
 <ol>
+ <li><p>If <var>realm</var> is not given, then set it to null.
+
  <li>
-  <p>Create a new object <var>event</var> using <var>eventInterface</var>. If <var>realm</var>
-  is given, use that Realm; otherwise, use the default behavior defined in Web IDL.
+  <p>Let <var>dictionary</var> be the result of <a lt="converted to an IDL value">converting</a>
+  the JavaScript value undefined to the dictionary type accepted by <var>eventInterface</var>'s
+  constructor. (This dictionary type will either be {{EventInit}} or a dictionary that inherits from
+  it.)
 
-  <p class="XXX">As of the time of this writing Web IDL does not yet define any default behavior;
-  see <a href="https://github.com/heycam/webidl/issues/135">heycam/webidl#135</a>.
+  <p class="XXX">This does not work if members are required; see
+  <a href="https://github.com/whatwg/dom/issues/600">whatwg/dom#600</a>.
 
- <li><p>Set <var>event</var>'s <a>initialized flag</a>.
+ <li>
+  <p>Let <var>event</var> be the result of running the <a>inner event creation steps</a> with
+  <var>eventInterface</var>, <var>realm</var>, the occurrence that the event is signaling, and
+  <var>dictionary</var>.
 
- <li><p>Let <var>defaultEventInitDict</var> be the result of
- <a lt="converted to an IDL value">converting</a> the JavaScript value undefined to the dictionary
- type accepted by <var>eventInterface</var>'s constructor. (This dictionary type will either be
- {{EventInit}} or a dictionary that inherits from it.)
-
- <li>For each <a>dictionary member</a> present in <var>defaultEventInitDict</var>, find the
- attribute on <var>event</var> whose <a spec=webidl>identifier</a> matches the key of the
- <a>dictionary member</a> and then set the attribute to the default value of that
- <a>dictionary member</a>.
-
- <li><p>Set <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
- representing the high resolution time from the <a>time origin</a> to the occurrence that the
- event is signaling.
-
- <p class=note>For example, in macOS the occurrence time for input actions are available via the
- timestamp property of corresponding <code>NSEvent</code> objects. So in this case, the
- {{Event/timeStamp}} value will be equivalent to the <code>NSEvent</code>'s timestamp offset by
- <a>time origin</a>, translated in milliseconds, and with its precision adjusted to meet the minimum
- <a>clock resolution</a>.
+  <p class=note>For example, in macOS the occurrence time for input actions are available via the
+  timestamp property of corresponding <code>NSEvent</code> objects. So in this case, the
+  {{Event/timeStamp}} value will be equivalent to the <code>NSEvent</code>'s timestamp offset by
+  <a>time origin</a>, translated in milliseconds, and with its precision adjusted to meet the
+  minimum <a>clock resolution</a>.
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to true.
 
@@ -870,6 +854,30 @@ it, and optionally given a <a>Realm</a> <var>realm</var>, run these steps:</p>
 separately <a lt="create an event">create</a> and <a>dispatch</a> events, instead of simply
 <a lt="fire an event">firing</a> them. It ensures the event's attributes are initialized to the
 correct defaults.</p>
+
+<p>The <dfn noexport>inner event creation steps</dfn>, given an <var>interface</var>,
+<var>realm</var>, <var>time</var>, and <var>dictionary</var>, are as follows:</p>
+
+<ol>
+ <li>
+  <p>Let <var>event</var> be the result of creating a new object using <var>eventInterface</var>. If
+  <var>realm</var> is non-null, then use that Realm; otherwise, use the default behavior defined in
+  Web IDL.
+
+  <p class="XXX">As of the time of this writing Web IDL does not yet define any default behavior;
+  see <a href="https://github.com/heycam/webidl/issues/135">heycam/webidl#135</a>.
+
+ <li><p>Set <var>event</var>'s <a>initialized flag</a>.
+
+ <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
+ representing the high resolution time from the <a>time origin</a> to <var>time</var>.
+
+ <li><p><a for=map>For each</a> <var>member</var> → <var>value</var> in <var>dictionary</var>, if
+ <var>event</var> has an attribute whose <a spec=webidl>identifier</a> is <var>member</var>, then
+ set that attribute to <var>value</var>.
+
+ <li><p>Return <var>event</var>.
+</ol>
 
 
 <h3 id=defining-event-interfaces>Defining event interfaces</h3>

--- a/dom.bs
+++ b/dom.bs
@@ -708,10 +708,6 @@ false.
 The <dfn attribute for=Event><code>timeStamp</code></dfn> attribute must return the value it was
 initialized to.
 
-<p class=warning> User agents are strongly encouraged to set minimum resolution of the
-{{Event/timeStamp}} attribute to 5 microseconds following the existing <a>clock resolution</a>
-recommendation. [[!HR-TIME]]
-
 <hr>
 
 To <dfn export for=Event id=concept-event-initialize>initialize</dfn> an
@@ -836,14 +832,11 @@ it, and optionally given a <a>Realm</a> <var>realm</var>, run these steps:</p>
 
  <li>
   <p>Let <var>event</var> be the result of running the <a>inner event creation steps</a> with
-  <var>eventInterface</var>, <var>realm</var>, the occurrence that the event is signaling, and
-  <var>dictionary</var>.
+  <var>eventInterface</var>, <var>realm</var>, the time of the occurrence that the event is
+  signaling, and <var>dictionary</var>.
 
-  <p class=note>For example, in macOS the occurrence time for input actions are available via the
-  timestamp property of corresponding <code>NSEvent</code> objects. So in this case, the
-  {{Event/timeStamp}} value will be equivalent to the <code>NSEvent</code>'s timestamp offset by
-  <a>time origin</a>, translated in milliseconds, and with its precision adjusted to meet the
-  minimum <a>clock resolution</a>.
+  <p class=example>In macOS the time of the occurrence for input actions are available via the
+  <code>timestamp</code> property of <code>NSEvent</code> objects.
 
  <li><p>Initialize <var>event</var>'s {{Event/isTrusted}} attribute to true.
 
@@ -869,8 +862,13 @@ correct defaults.</p>
 
  <li><p>Set <var>event</var>'s <a>initialized flag</a>.
 
- <li><p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
- representing the high resolution time from the <a>time origin</a> to <var>time</var>.
+ <li>
+  <p>Initialize <var>event</var>'s {{Event/timeStamp}} attribute to a {{DOMHighResTimeStamp}}
+  representing the high resolution time from the <a>time origin</a> to <var>time</var>.
+
+  <p class=warning>User agents should set a minimum resolution of <var>event</var>'s
+  {{Event/timeStamp}} attribute to 5 microseconds following the existing <a>clock resolution</a>
+  recommendation. [[!HR-TIME]]
 
  <li><p><a for=map>For each</a> <var>member</var> → <var>value</var> in <var>dictionary</var>, if
  <var>event</var> has an attribute whose <a spec=webidl>identifier</a> is <var>member</var>, then

--- a/dom.bs
+++ b/dom.bs
@@ -874,7 +874,7 @@ correct defaults.</p>
 
  <li><p><a for=map>For each</a> <var>member</var> → <var>value</var> in <var>dictionary</var>, if
  <var>event</var> has an attribute whose <a spec=webidl>identifier</a> is <var>member</var>, then
- set that attribute to <var>value</var>.
+ initialize that attribute to <var>value</var>.
 
  <li><p>Return <var>event</var>.
 </ol>


### PR DESCRIPTION
This introduces the "inner event creation steps" so we don't duplicate a bunch of logic.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/603.html" title="Last updated on Mar 16, 2018, 7:13 AM GMT (cfb07fa)">Preview</a> | <a href="https://whatpr.org/dom/603/06dae65...cfb07fa.html" title="Last updated on Mar 16, 2018, 7:13 AM GMT (cfb07fa)">Diff</a>