### PR TITLE
Fix TreeWalker's nextNode()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9172,8 +9172,9 @@ steps:
      {{TreeWalker/currentNode}} attribute to <var>node</var> and return <var>node</var>.
     </ol>
 
-   <li><p>If there is a <a>node</a> that is <a>following</a> <var>node</var> and is not
-   <a>following</a> <a for=traversal>root</a>, then set <var>node</var> to the first such
+   <li><p>If there is a <a>node</a> that is <a>following</a> <var>node</var>, is not a
+   <a for=tree>descendant</a> of <var>node</var>, and is not <a for=tree>following</a> the
+   <a>context object</a>'s <a for=traversal>root</a>, then set <var>node</var> to the first such
    <a>node</a>. Otherwise, return null.
    <!-- Implemented as iterating over parent/nextSibling -->
 

--- a/dom.bs
+++ b/dom.bs
@@ -9172,11 +9172,23 @@ steps:
      {{TreeWalker/currentNode}} attribute to <var>node</var> and return <var>node</var>.
     </ol>
 
-   <li><p>If there is a <a>node</a> that is <a>following</a> <var>node</var>, is not a
-   <a for=tree>descendant</a> of <var>node</var>, and is not <a for=tree>following</a> the
-   <a>context object</a>'s <a for=traversal>root</a>, then set <var>node</var> to the first such
-   <a>node</a>. Otherwise, return null.
-   <!-- Implemented as iterating over parent/nextSibling -->
+   <li><p>Let <var>sibling</var> be null.
+
+   <li><p>Let <var>temporary</var> be <var>node</var>.
+
+   <li>
+    <p>While <var>temporary</var> is non-null:
+
+    <ol>
+     <li><p>If <var>temporary</var> is the <a>context object</a>'s <a for=traversal>root</a>, then
+     return null.
+
+     <li><p>Set <var>sibling</var> to <var>temporary</var>'s <a for=tree>next sibling</a>.
+
+     <li><p>If <var>sibling</var> is non-null, then <a for=iteration>break</a>.
+
+     <li><p>Set <var>temporary</var> to <var>temporary</var>'s <a for=tree>parent</a>.
+    </ol>
 
    <li><p>Set <var>result</var> to the result of <a for=Node>filtering</a> <var>node</var>.
 


### PR DESCRIPTION
The prose supposed to be equivalent to iterating over following siblings and siblings of ancestors did not skip over descendants.

See https://github.com/whatwg/dom/issues/87#issuecomment-374385254.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/612.html" title="Last updated on Mar 22, 2018, 5:39 PM GMT (ae2fb6b)">Preview</a> | <a href="https://whatpr.org/dom/612/02f7143...ae2fb6b.html" title="Last updated on Mar 22, 2018, 5:39 PM GMT (ae2fb6b)">Diff</a>