### PR TITLE
Define event constructing steps

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -792,6 +792,14 @@ method must, when invoked, run these steps:
 
 <h3 id=constructing-events>Constructing events</h3>
 
+<a lt="Other applicable specifications">Specifications</a> may define
+<dfn export id=concept-event-constructor-ext>event constructing steps</dfn> for all or some
+<a for=/>events</a>. The algorithm is passed an <var>event</var> as indicated in the
+<a>inner event creation steps</a>.
+
+<p class=note>This construct can be used by {{Event}} subclasses that have a more complex structure
+than a simple 1:1 mapping between their initializing dictionary members and IDL attributes.
+
 <p>When a <dfn export for=Event id=concept-event-constructor>constructor</dfn> of the {{Event}}
 interface, or of an interface that inherits from the {{Event}} interface, is invoked, these steps
 must be run, given the arguments <var>type</var> and <var>eventInitDict</var>:
@@ -865,6 +873,8 @@ correct defaults.</p>
  <li><p><a for=map>For each</a> <var>member</var> → <var>value</var> in <var>dictionary</var>, if
  <var>event</var> has an attribute whose <a spec=webidl>identifier</a> is <var>member</var>, then
  initialize that attribute to <var>value</var>.
+
+ <li><p>Run the <a>event constructing steps</a> with <var>event</var>.
 
  <li><p>Return <var>event</var>.
 </ol>


### PR DESCRIPTION
This hook can be used by complex Event subclasses, such as KeyboardEvent and TouchEvent, to initialize their internal state upon creation.

Fixes #414.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/614.html" title="Last updated on Mar 23, 2018, 12:46 PM GMT (b8e54d8)">Preview</a> | <a href="https://whatpr.org/dom/614/5be84cc...b8e54d8.html" title="Last updated on Mar 23, 2018, 12:46 PM GMT (b8e54d8)">Diff</a>