### PR TITLE
Meta: export event listener's fields

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -946,12 +946,12 @@ when something has occurred.
 <a>event</a> and consists of:
 
 <ul class="brief">
- <li><dfn for="event listener">type</dfn> (a string)
- <li><dfn for="event listener">callback</dfn> (null or an {{EventListener}} object)
- <li><dfn for="event listener">capture</dfn> (a boolean, initially false)
- <li><dfn for="event listener">passive</dfn> (a boolean, initially false)
- <li><dfn for="event listener">once</dfn> (a boolean, initially false)
- <li><dfn for="event listener">removed</dfn> (a boolean for bookkeeping purposes, initially false)
+ <li><dfn export for="event listener">type</dfn> (a string)
+ <li><dfn export for="event listener">callback</dfn> (null or an {{EventListener}} object)
+ <li><dfn export for="event listener">capture</dfn> (a boolean, initially false)
+ <li><dfn export for="event listener">passive</dfn> (a boolean, initially false)
+ <li><dfn export for="event listener">once</dfn> (a boolean, initially false)
+ <li><dfn export for="event listener">removed</dfn> (a boolean for bookkeeping purposes, initially false)
 </ul>
 
 <p class="note no-backref">Although <a for="event listener">callback</a> is an {{EventListener}}


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/632.html" title="Last updated on Apr 10, 2018, 11:43 PM GMT (7b1ee4e)">Preview</a> | <a href="https://whatpr.org/dom/632/c80e017...7b1ee4e.html" title="Last updated on Apr 10, 2018, 11:43 PM GMT (7b1ee4e)">Diff</a>