### PR TITLE
Introduce "remove all event listeners" primitive

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1101,10 +1101,16 @@ method, when invoked, must run these steps:
  <var>once</var>.
 </ol>
 
-<p>To <dfn export>remove an event listener</dfn>, given an {{EventTarget}} object
-<var>eventTarget</var> and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
+<p>To <dfn>remove an event listener</dfn>, given an {{EventTarget}} object <var>eventTarget</var>
+and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
 <a for="event listener">removed</a> to true and <a for=list>remove</a> <var>listener</var> from
 <var>eventTarget</var>'s <a for=EventTarget>event listener list</a>.
+<!-- Intentionally not exported. -->
+
+<p>To <dfn export>remove all event listeners</dfn>, given an {{EventTarget}} object
+<var>eventTarget</var>, <a for=list>for each</a> <var>listener</var> of <var>eventTarget</var>'s
+<a for=EventTarget>event listener list</a>, <a>remove an event listener</a> with
+<var>eventTarget</var> and <var>listener</var>.
 
 <p class="note">HTML needs this to define <code>document.open()</code>. [[HTML]]
 

--- a/dom.bs
+++ b/dom.bs
@@ -1101,6 +1101,13 @@ method, when invoked, must run these steps:
  <var>once</var>.
 </ol>
 
+<p>To <dfn export>remove an event listener</dfn>, given an {{EventTarget}} object
+<var>eventTarget</var> and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
+<a for="event listener">removed</a> to true and <a for=list>remove</a> <var>listener</var> from
+<var>eventTarget</var>'s <a for=EventTarget>event listener list</a>.
+
+<p class="note">HTML needs this to define <code>document.open()</code>. [[HTML]]
+
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
@@ -1117,9 +1124,8 @@ method, when invoked, must run these steps:
  <li><p>If the <a>context object</a>'s <a for=EventTarget>event listener list</a>
  <a for=list>contains</a> an <a>event listener</a> whose <a for="event listener">type</a> is
  <var>type</var>, <a for="event listener">callback</a> is <var>callback</var>, and
- <a for="event listener">capture</a> is <var>capture</var>, then set that <a>event listener</a>'s
- <a for="event listener">removed</a> to true and <a for=list>remove</a> it from the
- <a>context object</a>'s <a for=EventTarget>event listener list</a>.
+ <a for="event listener">capture</a> is <var>capture</var>, then <a>remove an event listener</a>
+ with the <a>context object</a> and that <a>event listener</a>.
 </ol>
 
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when


### PR DESCRIPTION
This is needed for document.open(): https://github.com/whatwg/html/issues/2302.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/641.html" title="Last updated on Apr 27, 2018, 3:24 PM GMT (4b7bb04)">Preview</a> | <a href="https://whatpr.org/dom/641/4b2633f...4b7bb04.html" title="Last updated on Apr 27, 2018, 3:24 PM GMT (4b7bb04)">Diff</a>