### PR TITLE
No longer allow the context object to be omitted

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -93,8 +93,7 @@ This specification standardizes the DOM. It does so as follows:
 [[!XML-NAMES]]
 
 <p>The term <dfn export>context object</dfn> means the object on which the algorithm,
-attribute getter, attribute setter, or method being discussed was called. When the
-<a>context object</a> is unambiguous, the term can be omitted.
+attribute getter, attribute setter, or method being discussed was called.
 
 <p>When extensions are needed, the DOM Standard can be updated accordingly, or a new standard
 can be written that hooks into the provided extensibility hooks for


### PR DESCRIPTION
It's never really unambiguous to omit it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/647.html" title="Last updated on May 18, 2018, 2:23 PM GMT (b3b21e3)">Preview</a> | <a href="https://whatpr.org/dom/647/21e7ec3...b3b21e3.html" title="Last updated on May 18, 2018, 2:23 PM GMT (b3b21e3)">Diff</a>