### PR TITLE
Meta: fix link to the DOM Standard twitter page

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2,7 +2,7 @@
 Group: WHATWG
 H1: DOM
 Shortname: dom
-Text Macro: TWITTER domstandard
+Text Macro: TWITTER thedomstandard
 Abstract: DOM defines a platform-neutral model for events, aborting activities, and node trees.
 Translation: ja https://triple-underscore.github.io/DOM4-ja.html
 Ignored Terms: EmptyString, Array, Document


### PR DESCRIPTION
The twitter link in the header was changed unintentionally from [@thedomstandard](https://twitter.com/thedomstandard) to [@domstandard](https://twitter.com/domstandard) in commit https://github.com/whatwg/dom/commit/4953b84021fbeaf27df63c6c437e673f5db3c197.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/649.html" title="Last updated on May 22, 2018, 10:26 AM GMT (ca87be4)">Preview</a> | <a href="https://whatpr.org/dom/649/927e917...ca87be4.html" title="Last updated on May 22, 2018, 10:26 AM GMT (ca87be4)">Diff</a>