### PR TITLE
Change add/remove event listener behavior for service workers

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1151,21 +1151,16 @@ and an <a>event listener</a> <var>listener</var>, run these steps:
 
 <ol>
  <li>
-  <p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object, its associated
-  <a for="ServiceWorkerGlobalScope">service worker</a>'s <a for="service worker">script
-  resource</a>'s <a for="script resource">has ever been evaluated flag</a> is set, and
-  <var>listener</var>'s <a for="event listener">type</a> matches the {{Event/type}} attribute value
-  of any of the <a>service worker events</a>, then <a>report a warning to the console</a> with a
-  description explaining that the <a>service worker event</a> has to be added before the script
-  evaluation completes, otherwise the user agent might not start the <a>service worker</a> for the
-  <a>event</a>. [[!SERVICE-WORKERS]]
+  <p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object, its
+  <a for="ServiceWorkerGlobalScope">service worker</a>'s
+  <a for="service worker">script resource</a>'s
+  <a for="script resource">has ever been evaluated flag</a> is set, and <var>listener</var>'s
+  <a for="event listener">type</a> matches the {{Event/type}} attribute value of any of the
+  <a>service worker events</a>, then <a>report a warning to the console</a> that this might not give
+  the expected results. [[!SERVICE-WORKERS]]
 
-  <p class="note no-backref">To avoid unnecessary delays, Service Workers [[!SERVICE-WORKERS]]
-  permits skipping event dispatch when no <a>event listeners</a> for the <a>service worker event</a>
-  have been deterministically added in the <a>service worker</a>’s <a for="service worker">set of
-  event types to handle</a> during the very first script evaluation. The <a>event listener</a> in
-  this step will still be added, but the implementations have to inform developers about this
-  behavior.
+  <p class="note no-backref">Service workers are only started for event listeners added during the
+  first script evaluation.
 
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 
@@ -1195,31 +1190,35 @@ method, when invoked, must run these steps:
  <var>once</var>.
 </ol>
 
-<p>To <dfn>remove an event listener</dfn>, given an {{EventTarget}} object <var>eventTarget</var>
-and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
-<a for="event listener">removed</a> to true and <a for=list>remove</a> <var>listener</var> from
-<var>eventTarget</var>'s <a for=EventTarget>event listener list</a>.
-<!-- Intentionally not exported. -->
+<p>To <dfn export>remove an event listener</dfn>, given an {{EventTarget}} object
+<var>eventTarget</var> and an <a>event listener</a> <var>listener</var>, run these steps:
+
+<ol>
+ <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object and its
+ <a for="ServiceWorkerGlobalScope">service worker</a>'s
+ <a for="service worker">set of event types to handle</a> contains <var>type</var>, then
+ <a>report a warning to the console</a> that this might not give the expected results.
+ [[!SERVICE-WORKERS]]
+
+ <li><p>Set <var>listener</var>'s <a for="event listener">removed</a> to true and
+ <a for=list>remove</a> <var>listener</var> from <var>eventTarget</var>'s
+ <a for=EventTarget>event listener list</a>.
+</ol>
+
+<p class=note>HTML needs this to define event handlers. [[HTML]]
 
 <p>To <dfn export>remove all event listeners</dfn>, given an {{EventTarget}} object
 <var>eventTarget</var>, <a for=list>for each</a> <var>listener</var> of <var>eventTarget</var>'s
 <a for=EventTarget>event listener list</a>, <a>remove an event listener</a> with
 <var>eventTarget</var> and <var>listener</var>.
 
-<p class="note">HTML needs this to define <code>document.open()</code>. [[HTML]]
+<p class=note>HTML needs this to define <code>document.open()</code>. [[HTML]]
 
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object and its associated
- <a for="ServiceWorkerGlobalScope">service worker</a>'s <a for="service worker">set of event types
- to handle</a> contains <var>type</var>, then <a>report a warning to the console</a> with a
- description explaining that the user agent will still start the <a>service worker</a> for the
- <a>service worker event</a> whose {{Event/type}} attribute value matches <var>type</var>.
- [[!SERVICE-WORKERS]]
-
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 
  <li><p>If the <a>context object</a>'s <a for=EventTarget>event listener list</a>

--- a/dom.bs
+++ b/dom.bs
@@ -1151,12 +1151,14 @@ and an <a>event listener</a> <var>listener</var>, run these steps:
 
 <ol>
  <li>
-  <p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object and its associated
-  <a>service worker</a>'s <a for="service worker">script resource</a>'s
-  <a for="script resource">has ever been evaluated flag</a> is set, then
-  <a>report a warning to the console</a> with a description explaining that the
-  <a>service worker event</a> is to be added synchronously, otherwise the user agent may not start
-  the <a>service worker</a> for the <a>event</a>. [[!SERVICE-WORKERS]]
+  <p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object, its associated
+  <a for="ServiceWorkerGlobalScope">service worker</a>'s <a for="service worker">script
+  resource</a>'s <a for="script resource">has ever been evaluated flag</a> is set, and
+  <var>listener</var>'s <a for="event listener">type</a> matches the {{Event/type}} attribute value
+  of any of the <a>service worker events</a>, then <a>report a warning to the console</a> with a
+  description explaining that the <a>service worker event</a> has to be added before the script
+  evaluation completes, otherwise the user agent might not start the <a>service worker</a> for the
+  <a>event</a>. [[!SERVICE-WORKERS]]
 
   <p class="note no-backref">To avoid unnecessary delays, Service Workers [[!SERVICE-WORKERS]]
   permits skipping event dispatch when no <a>event listeners</a> for the <a>service worker event</a>
@@ -1211,11 +1213,11 @@ and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object and its associated
- <a>service worker</a>'s <a for="service worker">script resource</a>'s
- <a for="script resource">has ever been evaluated flag</a> is set, then
- <a>report a warning to the console</a> with a description explaining that the user agent will still
- start the <a>service worker</a> for the <a>service worker event</a> that was synchronously added.
+ <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object, its associated
+ <a for="ServiceWorkerGlobalScope">service worker</a>'s <a for="service worker">set of event types
+ to handle</a> contains <var>type</var>, then <a>report a warning to the console</a> with a
+ description explaining that the user agent will still start the <a>service worker</a> for the
+ <a>service worker event</a> whose {{Event/type}} attribute value matches <var>type</var>.
  [[!SERVICE-WORKERS]]
 
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.

--- a/dom.bs
+++ b/dom.bs
@@ -1150,17 +1150,13 @@ participate in a tree structure.</p>
 and an <a>event listener</a> <var>listener</var>, run these steps:
 
 <ol>
- <li>
-  <p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object, its
-  <a for="ServiceWorkerGlobalScope">service worker</a>'s
-  <a for="service worker">script resource</a>'s
-  <a for="script resource">has ever been evaluated flag</a> is set, and <var>listener</var>'s
-  <a for="event listener">type</a> matches the {{Event/type}} attribute value of any of the
-  <a>service worker events</a>, then <a>report a warning to the console</a> that this might not give
-  the expected results. [[!SERVICE-WORKERS]]
-
-  <p class="note no-backref">Service workers are only started for event listeners added during the
-  first script evaluation.
+ <li><p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object, its
+ <a for="ServiceWorkerGlobalScope">service worker</a>'s
+ <a for="service worker">script resource</a>'s
+ <a for="script resource">has ever been evaluated flag</a> is set, and <var>listener</var>'s
+ <a for="event listener">type</a> matches the {{Event/type}} attribute value of any of the
+ <a>service worker events</a>, then <a>report a warning to the console</a> that this might not give
+ the expected results. [[!SERVICE-WORKERS]]
 
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1213,7 +1213,7 @@ and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object, its associated
+ <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object and its associated
  <a for="ServiceWorkerGlobalScope">service worker</a>'s <a for="service worker">set of event types
  to handle</a> contains <var>type</var>, then <a>report a warning to the console</a> with a
  description explaining that the user agent will still start the <a>service worker</a> for the

--- a/dom.bs
+++ b/dom.bs
@@ -1151,15 +1151,18 @@ and an <a>event listener</a> <var>listener</var>, run these steps:
 
 <ol>
  <li>
-  <p>If <var>eventTarget</var>'s <a>relevant global object</a> is a {{ServiceWorkerGlobalScope}}
-  object and its associated <a>service worker</a>'s <a for="service worker">script resource</a>'s
-  <a for="script resource">has ever been evaluated flag</a> is set, then <a>throw</a> a
-  <code>TypeError</code>.
-  [[!SERVICE-WORKERS]]
+  <p>If <var>listener</var> observes a <a>functional event</a>, <var>eventTarget</var> is a
+  {{ServiceWorkerGlobalScope}} object, and its associated <a>service worker</a>'s <a for="service
+  worker">script resource</a>'s <a for="script resource">has ever been evaluated flag</a> is set,
+  then the user agent must show a message on a developer console that the user agent stores the event
+  <a for="event listener">type</a> of the <a>functional event</a> for the <a>service worker</a> only
+  during the very first evalution of the <a>service worker</a> script, and the asynchronously added
+  <a>functional event</a> will not start the <a>service worker</a>. [[!SERVICE-WORKERS]]
 
-  <p class="note no-backref">To optimize storing the event types allowed for the service worker and
-  to avoid non-deterministic changes to the event listeners, invocation of the method is allowed
-  only during the very first evaluation of the service worker script.
+  <p class="note no-backref">To optimize storing the event types allowed for the <a>service
+  worker</a>, Service Workers specification does not store the asynchronously added event <a
+  for="event listener">type</a>. The <a>event listener</a> will still be added under this condition,
+  but the implmentations have to inform developers about this behavior.
 
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 
@@ -1207,11 +1210,13 @@ and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>If the <a>context object</a>'s <a>relevant global object</a> is a
- {{ServiceWorkerGlobalScope}} object and its associated <a>service worker</a>'s
- <a for="service worker">script resource</a>'s
- <a for="script resource">has ever been evaluated flag</a> is set, then <a>throw</a> a
- <code>TypeError</code>. [[!SERVICE-WORKERS]]
+ <li><p>If <var>type</var> is one of the <a>functional events</a>'s <a for="event
+ listener">type</a>, the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object, and its
+ associated <a>service worker</a>'s <a for="service worker">script resource</a>'s <a for="script
+ resource">has ever been evaluated flag</a> is set, then the user agent must show a message on a
+ developer console that the user agent will still start the <a>service worker</a> for the
+ <a>functional event</a> that has been stored during the very first evalution of the <a>service
+ worker</a> script and is asynchronously removed. [[!SERVICE-WORKERS]]
 
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1152,16 +1152,16 @@ and an <a>event listener</a> <var>listener</var>, run these steps:
 <ol>
  <li>
   <p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object and its associated
-  <a>service worker</a>'s <a for="service worker">script resource</a>'s <a for="script resource">has
-  ever been evaluated flag</a> is set, then the user agent must <a>report a warning to the
-  console</a> with a description explaining that the <a>service worker event</a> should be added
-  synchronously, otherwise the user agent will not start</a> the <a>service worker</a> for the
-  <a>event</a>. [[!SERVICE-WORKERS]]
+  <a>service worker</a>'s <a for="service worker">script resource</a>'s
+  <a for="script resource">has ever been evaluated flag</a> is set, then
+  <a>report a warning to the console</a> with a description explaining that the
+  <a>service worker event</a> is to be added synchronously, otherwise the user agent will not start
+  the <a>service worker</a> for the <a>event</a>. [[!SERVICE-WORKERS]]
 
-  <p class="note no-backref">To optimize with the set of <a>service worker events</a> to handle, the
-  Service Workers specification does not store the asynchronously added event. The <a>event
-  listener</a> will still be added under this condition, but the implmentations have to inform
-  developers about this behavior.
+  <p class="note no-backref">To optimize with the set of <a>service worker events</a> to handle,
+  asynchronously added <a>service worker events</a> are not added to the <a>service worker</a>'s
+  <a for="service worker">set of event types to handle</a>. The <a>event listener</a> will still be
+  added under this condition, but the implmentations have to inform developers about this behavior.
 
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 
@@ -1210,10 +1210,11 @@ method, when invoked, must run these steps:
 
 <ol>
  <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object and its associated
- <a>service worker</a>'s <a for="service worker">script resource</a>'s <a for="script resource">has
- ever been evaluated flag</a> is set, then the user agent must <a>report a warning to the
- console</a> with a description explaining that the user agent will still start the <a>service
- worker</a> for the <a>service worker event</a> that was synchronously added. [[!SERVICE-WORKERS]]
+ <a>service worker</a>'s <a for="service worker">script resource</a>'s
+ <a for="script resource">has ever been evaluated flag</a> is set, then
+ <a>report a warning to the console</a> with a description explaining that the user agent will still
+ start the <a>service worker</a> for the <a>service worker event</a> that was synchronously added.
+ [[!SERVICE-WORKERS]]
 
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1154,10 +1154,11 @@ and an <a>event listener</a> <var>listener</var>, run these steps:
   <p>If <var>listener</var> observes a <a>functional event</a>, <var>eventTarget</var> is a
   {{ServiceWorkerGlobalScope}} object, and its associated <a>service worker</a>'s <a for="service
   worker">script resource</a>'s <a for="script resource">has ever been evaluated flag</a> is set,
-  then the user agent must show a message on a developer console that the user agent stores the event
-  <a for="event listener">type</a> of the <a>functional event</a> for the <a>service worker</a> only
-  during the very first evalution of the <a>service worker</a> script, and the asynchronously added
-  <a>functional event</a> will not start the <a>service worker</a>. [[!SERVICE-WORKERS]]
+  then the user agent must <a>report a warning to the console</a> with a description that explains
+  that the user agent stores the event <a for="event listener">type</a> of the <a>functional
+  event</a> for the <a>service worker</a> only during the very first evalution of the <a>service
+  worker</a> script, and the asynchronously added <a>functional event</a> will not start the
+  <a>service worker</a>. [[!SERVICE-WORKERS]]
 
   <p class="note no-backref">To optimize storing the event types allowed for the <a>service
   worker</a>, Service Workers specification does not store the asynchronously added event <a
@@ -1213,10 +1214,10 @@ method, when invoked, must run these steps:
  <li><p>If <var>type</var> is one of the <a>functional events</a>'s <a for="event
  listener">type</a>, the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object, and its
  associated <a>service worker</a>'s <a for="service worker">script resource</a>'s <a for="script
- resource">has ever been evaluated flag</a> is set, then the user agent must show a message on a
- developer console that the user agent will still start the <a>service worker</a> for the
- <a>functional event</a> that has been stored during the very first evalution of the <a>service
- worker</a> script and is asynchronously removed. [[!SERVICE-WORKERS]]
+ resource">has ever been evaluated flag</a> is set, then the user agent must <a>report a warning to
+ the console</a> with a description that explains that the user agent will still start the
+ <a>service worker</a> for the <a>functional event</a> that has been stored during the very first
+ evalution of the <a>service worker</a> script and is asynchronously removed. [[!SERVICE-WORKERS]]
 
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1151,19 +1151,17 @@ and an <a>event listener</a> <var>listener</var>, run these steps:
 
 <ol>
  <li>
-  <p>If <var>listener</var> observes a <a>functional event</a>, <var>eventTarget</var> is a
-  {{ServiceWorkerGlobalScope}} object, and its associated <a>service worker</a>'s <a for="service
-  worker">script resource</a>'s <a for="script resource">has ever been evaluated flag</a> is set,
-  then the user agent must <a>report a warning to the console</a> with a description that explains
-  that the user agent stores the event <a for="event listener">type</a> of the <a>functional
-  event</a> for the <a>service worker</a> only during the very first evalution of the <a>service
-  worker</a> script, and the asynchronously added <a>functional event</a> will not start the
-  <a>service worker</a>. [[!SERVICE-WORKERS]]
+  <p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object and its associated
+  <a>service worker</a>'s <a for="service worker">script resource</a>'s <a for="script resource">has
+  ever been evaluated flag</a> is set, then the user agent must <a>report a warning to the
+  console</a> with a description explaining that the <a>service worker event</a> should be added
+  synchronously, otherwise the user agent will not start</a> the <a>service worker</a> for the
+  <a>event</a>. [[!SERVICE-WORKERS]]
 
-  <p class="note no-backref">To optimize storing the event types allowed for the <a>service
-  worker</a>, Service Workers specification does not store the asynchronously added event <a
-  for="event listener">type</a>. The <a>event listener</a> will still be added under this condition,
-  but the implmentations have to inform developers about this behavior.
+  <p class="note no-backref">To optimize with the set of <a>service worker events</a> to handle, the
+  Service Workers specification does not store the asynchronously added event. The <a>event
+  listener</a> will still be added under this condition, but the implmentations have to inform
+  developers about this behavior.
 
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 
@@ -1211,13 +1209,11 @@ and an <a>event listener</a> <var>listener</var>, set <var>listener</var>'s
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>type</var> is one of the <a>functional events</a>'s <a for="event
- listener">type</a>, the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object, and its
- associated <a>service worker</a>'s <a for="service worker">script resource</a>'s <a for="script
- resource">has ever been evaluated flag</a> is set, then the user agent must <a>report a warning to
- the console</a> with a description that explains that the user agent will still start the
- <a>service worker</a> for the <a>functional event</a> that has been stored during the very first
- evalution of the <a>service worker</a> script and is asynchronously removed. [[!SERVICE-WORKERS]]
+ <li><p>If the <a>context object</a> is a {{ServiceWorkerGlobalScope}} object and its associated
+ <a>service worker</a>'s <a for="service worker">script resource</a>'s <a for="script resource">has
+ ever been evaluated flag</a> is set, then the user agent must <a>report a warning to the
+ console</a> with a description explaining that the user agent will still start the <a>service
+ worker</a> for the <a>service worker event</a> that was synchronously added. [[!SERVICE-WORKERS]]
 
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1155,13 +1155,15 @@ and an <a>event listener</a> <var>listener</var>, run these steps:
   <a>service worker</a>'s <a for="service worker">script resource</a>'s
   <a for="script resource">has ever been evaluated flag</a> is set, then
   <a>report a warning to the console</a> with a description explaining that the
-  <a>service worker event</a> is to be added synchronously, otherwise the user agent will not start
+  <a>service worker event</a> is to be added synchronously, otherwise the user agent may not start
   the <a>service worker</a> for the <a>event</a>. [[!SERVICE-WORKERS]]
 
-  <p class="note no-backref">To optimize with the set of <a>service worker events</a> to handle,
-  asynchronously added <a>service worker events</a> are not added to the <a>service worker</a>'s
-  <a for="service worker">set of event types to handle</a>. The <a>event listener</a> will still be
-  added under this condition, but the implmentations have to inform developers about this behavior.
+  <p class="note no-backref">To avoid unnecessary delays, Service Workers [[!SERVICE-WORKERS]]
+  permits skipping event dispatch when no <a>event listeners</a> for the <a>service worker event</a>
+  have been deterministically added in the <a>service worker</a>’s <a for="service worker">set of
+  event types to handle</a> during the very first script evaluation. The <a>event listener</a> in
+  this step will still be added, but the implementations have to inform developers about this
+  behavior.
 
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 


### PR DESCRIPTION
This changes addEventListener() and removeEventListener() to not throw even
after the very first evalution of the service worker script. Instead, this
specifies user agents have to show a console warning that the asynchronously
added listener's event type will not affect service worker's behavior with the
functional event stored during the first evaluation.

This change referneces the funcional event concept defined in Service Workers
spec, and confines the EventTarge object of the specified behavior to
ServiceWorkerGlobalScope object instead of all the platform object in the global
object.

Related SW issue: https://github.com/w3c/ServiceWorker/issues/1004.
Related SW PR: https://github.com/w3c/ServiceWorker/pull/1322.
Fixes https://github.com/whatwg/dom/issues/371.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/653.html" title="Last updated on Nov 4, 2019, 8:51 AM UTC (8946b24)">Preview</a> | <a href="https://whatpr.org/dom/653/57512fa...8946b24.html" title="Last updated on Nov 4, 2019, 8:51 AM UTC (8946b24)">Diff</a>