### PR TITLE
Don't store is value when it won't be useful

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6052,6 +6052,15 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
    <li><p>Let <var>interface</var> be the <a>element interface</a> for <var>localName</var> and
    <var>namespace</var>.
 
+   <li>
+    <p>If <var>localName</var> is a <a>valid custom element name</a>, or <var>is</var> is not a
+    <a>valid custom element name</a>, then set <var>is</var> to null.</p>
+
+    <p class="note">In this case, even though <var>is</var> was supplied, there's no way that this
+    element will ever be <a lt="upgrade an element">upgraded</a>, so we shouldn't store the
+    <a for=Element><code>is</code> value</a>.</p>
+   </li>
+
    <li><p>Set <var>result</var> to a new <a for=/>element</a> that implements <var>interface</var>,
    with no attributes, <a for=Element>namespace</a> set to <var>namespace</var>,
    <a for=Element>namespace prefix</a> set to <var>prefix</var>, <a for=Element>local name</a> set


### PR DESCRIPTION
Fixes #659.

I believe the impact of this is entirely on the serialization of elements created this way.

EDIT: this also impacts whether `:defined` matches.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 15, 2021, 7:33 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Fdom%2Fd7d69f121ba81d21b4d98a66e915387649132c51%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20661)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%23661.)._
</details>
