### PR TITLE
Refactor toggle attribute

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6189,6 +6189,24 @@ in an <a for="/">element</a> <var>element</var>, run these steps:
 
 <hr>
 
+To <dfn export id=concept-element-attributes-get-valid-by-name>get a valid attribute by name</dfn>
+given a <var>qualifiedName</var>, and <a for="/">element</a> <var>element</var>, run these steps:
+
+<ol>
+ <li><p>If <var>qualifiedName</var> does not match the <code><a type>Name</a></code> production in
+ XML, then <a>throw</a> an "{{InvalidCharacterError!!exception}}" {{DOMException}}.
+
+ <li><p>If <var>element</var> is in the <a>HTML namespace</a> and its <a for=Node>node document</a>
+ is an <a>HTML document</a>, then set <var>qualifiedName</var> to <var>qualifiedName</var> in
+ <a>ASCII lowercase</a>.
+
+ <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
+ <li><p>Let <var>attribute</var> be the first <a>attribute</a> in <var>element</var>'s <a for=Element>attribute list</a>
+ whose <a for=Attr>qualified name</a> is <var>qualifiedName</var>, and null otherwise.
+
+ <li>Return <var>qualifiedName</var>, and <var>attribute</var>.
+</ol>
+
 To <dfn export id=concept-element-attributes-get-by-name>get an attribute by name</dfn> given a
 <var>qualifiedName</var> and <a for="/">element</a> <var>element</var>, run these steps:
 
@@ -6528,17 +6546,7 @@ method, when invoked, must these steps:
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>qualifiedName</var> does not match the <code><a type>Name</a></code> production in
- XML, then <a>throw</a> an "{{InvalidCharacterError!!exception}}" {{DOMException}}.
-
- <li><p>If the <a>context object</a> is in the <a>HTML namespace</a> and its
- <a for=Node>node document</a> is an <a>HTML document</a>, then set <var>qualifiedName</var> to
- <var>qualifiedName</var> in <a>ASCII lowercase</a>.
-
- <li><p>Let <var>attribute</var> be the first <a>attribute</a> in <a>context object</a>'s
- <a for=Element>attribute list</a> whose <a for=Attr>qualified name</a> is <var>qualifiedName</var>,
- and null otherwise.
- <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
+ <li><p>Let <var>qualifiedName</var> and <var>attribute</var> be the result of running <a>get a valid attribute by name</a> given the <var>qualifiedName</var> and <a>context object</a>
 
  <li><p>If <var>attribute</var> is null, create an <a>attribute</a> whose
  <a for="Attr">local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is
@@ -6590,17 +6598,7 @@ when invoked, must run these steps:
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>If <var>qualifiedName</var> does not match the <code><a type>Name</a></code> production in
- XML, then <a>throw</a> an "{{InvalidCharacterError!!exception}}" {{DOMException}}.
-
- <li><p>If the <a>context object</a> is in the <a>HTML namespace</a> and its
- <a for=Node>node document</a> is an <a>HTML document</a>, then set <var>qualifiedName</var> to
- <var>qualifiedName</var> in <a>ASCII lowercase</a>.
-
- <li><p>Let <var>attribute</var> be the first <a>attribute</a> in the <a>context object</a>'s
- <a for=Element>attribute list</a> whose <a for=Attr>qualified name</a> is <var>qualifiedName</var>,
- and null otherwise.
- <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
+ <li><p>Let <var>qualifiedName</var> and <var>attribute</var> be the result of running <a>get a valid attribute by name</a> given the <var>qualifiedName</var> and <a>context object</a>
 
  <li>
   <p>If <var>attribute</var> is null, then:

--- a/dom.bs
+++ b/dom.bs
@@ -6189,6 +6189,22 @@ in an <a for="/">element</a> <var>element</var>, run these steps:
 
 <hr>
 
+
+To <dfn export id=concept-element-attributes-set-by-name>create an attribute by value</dfn>
+given a <var>qualifiedName</var>, <var>value</var> and <a for="/">element</a> <var>element</var>, run these steps:
+
+<ol>
+ <li><p>Create an <a>attribute</a> whose
+ <a for="Attr">local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is
+ <var>value</var>, and <a for=Node>node document</a> is <a>context object</a>'s
+ <a for=Node>node document</a>.
+
+ <li><a lt="append an attribute">Append</a> this <a>attribute</a> to
+ <a>element</a>
+
+ <li>Return.
+</ol>
+
 To <dfn export id=concept-element-attributes-get-valid-by-name>get a valid attribute by name</dfn>
 given a <var>qualifiedName</var>, and <a for="/">element</a> <var>element</var>, run these steps:
 
@@ -6548,11 +6564,8 @@ method, when invoked, must run these steps:
 <ol>
  <li><p>Let <var>qualifiedName</var> and <var>attribute</var> be the result of running <a>get a valid attribute by name</a> given the <var>qualifiedName</var> and <a>context object</a>
 
- <li><p>If <var>attribute</var> is null, create an <a>attribute</a> whose
- <a for="Attr">local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is
- <var>value</var>, and <a for=Node>node document</a> is <a>context object</a>'s
- <a for=Node>node document</a>, then <a lt="append an attribute">append</a> this <a>attribute</a> to
- <a>context object</a>, and then return.
+
+ <li><p>If <var>attribute</var> is null, run <a>create an attribute by value</a> given the <var>qualifiedName</var>, <var>value</var> and <a>context object</a>, and then return.
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> from <a>context object</a> to
  <var>value</var>.
@@ -6606,13 +6619,7 @@ method, when invoked, must run these steps:
   <ol>
    <li><p>If <var>force</var> is given and is false, return false.
 
-   <li><p>Create an <a>attribute</a> whose
-   <a for="Attr">local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is the empty
-   string, and <a for=Node>node document</a> is the <a>context object</a>'s
-   <a for=Node>node document</a>.
-
-   <li><a lt="append an attribute">Append</a> this <a>attribute</a>
-   to the <a>context object</a>.
+   <li><p>Run <a>create an attribute by value</a> given the <var>qualifiedName</var>, <var>the empty string</var> and <a>context object</a>.
 
    <li>Return true.
   </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -6606,20 +6606,25 @@ method, when invoked, must run these steps:
   <p>If <var>attribute</var> is null, then:
 
   <ol>
-   <li><p>If <var>force</var> is not given or is true, create an <a>attribute</a> whose
+   <li><p>If <var>force</var> is given and is false, return false.
+
+   <li><p>Create an <a>attribute</a> whose
    <a for="Attr">local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is the empty
    string, and <a for=Node>node document</a> is the <a>context object</a>'s
-   <a for=Node>node document</a>, then <a lt="append an attribute">append</a> this <a>attribute</a>
-   to the <a>context object</a>, and then return true.
+   <a for=Node>node document</a>.
 
-   <li><p>Return false.
+   <li><a lt="append an attribute">Append</a> this <a>attribute</a>
+   to the <a>context object</a>.
+
+   <li>Return true.
   </ol>
 
- <li><p>Otherwise, if <var>force</var> is not given or is false,
- <a lt="remove an attribute by name">remove an attribute</a> given <var>qualifiedName</var> and the
- <a>context object</a>, and then return false.
+ <li><p>Otherwise, if <var>force</var> is given and is true, return true.
 
- <li><p>Return true.
+ <li><p><a lt="remove an attribute by name">Remove an attribute</a> given <var>qualifiedName</var> and the
+ <a>context object</a>.
+
+ <li>Return false.
 </ol>
 
 <p>The


### PR DESCRIPTION
Solves:
https://github.com/whatwg/dom/issues/657
https://github.com/whatwg/html/issues/3779

As I understand it vars are not mutable and are instead copied, right? This mean I still have to copy from `"get an attribute by name"` the code.

Would there be a way to simplify this further perhaps? I could copy out the two common steps in the body of `"get an attribute by name"` and `"get valid an attribute by name"` into another concept?

Are there better names for the concept?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 15, 2021, 7:33 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FjonathanKingston%2Fdom%2F543336cbb36a6a2aa93a883f38048b604cff9f6c%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20663)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%23663.)._
</details>
