### PR TITLE
Make the DOMTokenList creation steps use "get an attribute value"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9525,8 +9525,8 @@ are to return the result of running <a>get an attribute value</a> given the asso
  <li><p>Let <var>localName</var> be associated attribute's <a for=Attr>local name</a>.
 
  <li><p>Let <var>value</var> be the result of
- <a lt="get an attribute by namespace and local name">getting an attribute</a> given null,
- <var>localName</var>, and <var>element</var>.
+ <a lt="get an attribute value">getting an attribute value</a> given <var>element</var> and
+ <var>localName</var>.
 
  <li><p>Run the <a>attribute change steps</a> for <var>element</var>, <var>localName</var>,
  <var>value</var>, <var>value</var>, and null.
@@ -10026,6 +10026,7 @@ Timo Tijhof,
 Tobie Langel,
 Tom Pixley,
 Travis Leithead,
+Trevor Rowbotham,
 <i>triple-underscore</i>,<!--GitHub-->
 Veli Şenol,
 Vidur Apparao,


### PR DESCRIPTION
This makes it so that if the `DOMTokenList`'s associated element has an attribute that is the associated attribute's local name, at creation time, it will use the "get an attribute value" steps, which will always return a string. Previously, the this used the "get an attribute by namespace and local name" steps, which would return an `Attr` node if the associated element had an attribute that is the associated attribute's local name. Fixes #666.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/673.html" title="Last updated on Aug 1, 2018, 12:31 AM GMT (2ff522f)">Preview</a> | <a href="https://whatpr.org/dom/673/32efc48...2ff522f.html" title="Last updated on Aug 1, 2018, 12:31 AM GMT (2ff522f)">Diff</a>