### PR TITLE
Use a single exception for name validation (follow up)

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -249,7 +249,7 @@ added.
 
 <p>To <dfn export>validate</dfn> a <var>qualifiedName</var>, <a>throw</a> an
 "{{InvalidCharacterError!!exception}}" {{DOMException}} if <var>qualifiedName</var> does not match
-the <code><a type>Name</a></code> or <code><a type>QName</a></code> production.
+the <code><a type>QName</a></code> production.
 
 To <dfn export>validate and extract</dfn> a <var>namespace</var> and <var>qualifiedName</var>,
 run these steps:
@@ -5021,15 +5021,13 @@ for the <a>context object</a>.
   <var>qualifiedName</var> or null. Its <a for=Element>local name</a> will be everything after
   "<code>:</code>" (U+003E) in <var>qualifiedName</var> or <var>qualifiedName</var>.
 
-  <p>If <var>localName</var> does not match the <code><a type>Name</a></code> production an
+  <p>If <var>qualifiedName</var> does not match the <code><a type>QName</a></code> production an
   "{{InvalidCharacterError!!exception}}" {{DOMException}} will be thrown.
 
   <p>If one of the following conditions is true a "{{NamespaceError!!exception}}" {{DOMException}}
   will be thrown:
 
   <ul>
-   <li><var>localName</var> does not match the
-   <code><a type>QName</a></code> production.
    <li><a for=Element>Namespace prefix</a>
    is not null and <var>namespace</var> is the empty string.
    <li><a for=Element>Namespace prefix</a>


### PR DESCRIPTION
This addresses two cases overlooked by 61f40b0763e1:

* The QName production is a strict subset of the Name production.  To avoid confusion, drop "or Name" from the definition of "validate a qualifiedName".
* The non-normative "for web developers" text for `createElementNS` was not updated by the original commit.

Fixes: #671


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 15, 2021, 7:33 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcscott%2Fdom%2F7ad34f3e5673f2dede87b55d79ba7ddbb742ff27%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20675)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%23675.)._
</details>
