### PR TITLE
Fix event path iteration

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1315,22 +1315,28 @@ for discussion).
    <var>clearTargetsStruct</var>'s <a for=Event/path>touch target list</a> is a <a for=/>node</a>
    and its <a for=tree>root</a> is a <a for=/>shadow root</a>, and false otherwise.
 
-   <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/CAPTURING_PHASE}}.
-
    <li><p>If <var>activationTarget</var> is non-null and <var>activationTarget</var> has
    <a for=EventTarget>legacy-pre-activation behavior</a>, then run <var>activationTarget</var>'s
    <a for=EventTarget>legacy-pre-activation behavior</a>.
 
    <li>
-    <p>For each <var>struct</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
+    <p><a for=list>For each</a> <var>struct</var> in <var>event</var>'s <a for=Event>path</a>, in
+    reverse order:
 
     <ol>
-     <li><p>If <var>struct</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a> with
-     <var>struct</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
+     <li><p>If <var>struct</var>'s <a for=Event/path>target</a> is non-null, then set
+     <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
+
+     <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
+     {{Event/CAPTURING_PHASE}}.
+
+     <li><p><a>Invoke</a> with <var>struct</var>, <var>event</var>, "<code>capturing</code>", and
+     <var>legacyOutputDidListenersThrowFlag</var> if given.
     </ol>
 
    <li>
-    <p>For each <var>struct</var> in <var>event</var>'s <a for=Event>path</a>, in order:
+    <p>If <var>event</var>'s {{Event/bubbles}} attribute is true, then <a for=list>for each</a>
+    <var>struct</var> in <var>event</var>'s <a for=Event>path</a>:
 
     <ol>
      <li><p>If <var>struct</var>'s <a for=Event/path>target</a> is non-null, then set
@@ -1339,10 +1345,8 @@ for discussion).
      <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
      {{Event/BUBBLING_PHASE}}.
 
-     <li><p>If either <var>event</var>'s {{Event/eventPhase}} attribute is {{Event/BUBBLING_PHASE}}
-     and <var>event</var>'s {{Event/bubbles}} attribute is true or <var>event</var>'s
-     {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> with
-     <var>struct</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
+     <li><p><a>Invoke</a> with <var>struct</var>, <var>event</var>, "<code>bubbling</code>", and
+     <var>legacyOutputDidListenersThrowFlag</var> if given.
     </ol>
   </ol>
 
@@ -1406,7 +1410,8 @@ for discussion).
 </ol>
 
 <p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn>, given a <var>struct</var>,
-<var>event</var>, and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
+<var>event</var>, <var>phase</var>, and an optional <var>legacyOutputDidListenersThrowFlag</var>,
+run these steps:
 
 <ol>
  <li><p>Set <var>event</var>'s <a for=Event>target</a> to the <a for=Event/path>target</a> of the
@@ -1432,7 +1437,7 @@ for discussion).
   run. Note that removal still has an effect due to the <a for="event listener">removed</a> field.
 
  <li><p>Let <var>found</var> be the result of running <a>inner invoke</a> with <var>event</var>,
- <var>listeners</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
+ <var>listeners</var>, <var>phase</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
 
  <li>
   <p>If <var>found</var> is false and <var>event</var>'s {{Event/isTrusted}} attribute is true,
@@ -1456,7 +1461,7 @@ for discussion).
       <tr><td>"<code>transitionend</code>"<td>"<code>webkitTransitionEnd</code>"
     </table>
 
-   <li><p><a>Inner invoke</a> with <var>event</var>, <var>listeners</var>, and
+   <li><p><a>Inner invoke</a> with <var>event</var>, <var>listeners</var>, <var>phase</var>, and
    <var>legacyOutputDidListenersThrowFlag</var> if given.
 
    <li><p>Set <var>event</var>'s {{Event/type}} attribute value to <var>originalEventType</var>.
@@ -1464,7 +1469,7 @@ for discussion).
 </ol>
 
 <p>To <dfn noexport id=concept-event-listener-inner-invoke>inner invoke</dfn>, given an
-<var>event</var>, <var>listeners</var>, and an optional
+<var>event</var>, <var>listeners</var>, <var>phase</var>, and an optional
 <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
 
 <ol>
@@ -1480,13 +1485,11 @@ for discussion).
 
    <li><p>Set <var>found</var> to true.
 
-   <li><p>If <var>event</var>'s {{Event/eventPhase}} attribute value is {{Event/CAPTURING_PHASE}}
-   and <var>listener</var>'s <a for="event listener">capture</a> is false, then
-   <a for=iteration>continue</a>.
+   <li><p>If <var>phase</var> is "<code>capturing</code>" and <var>listener</var>'s
+   <a for="event listener">capture</a> is false, then <a for=iteration>continue</a>.
 
-   <li><p>If <var>event</var>'s {{Event/eventPhase}} attribute value is {{Event/BUBBLING_PHASE}} and
-   <var>listener</var>'s <a for="event listener">capture</a> is true, then
-   <a for=iteration>continue</a>.
+   <li><p>If <var>phase</var> is "<code>bubbling</code>" and <var>listener</var>'s
+   <a for="event listener">capture</a> is true, then <a for=iteration>continue</a>.
 
    <li><p>If <var>listener</var>'s <a for="event listener">once</a> is true, then
    <a for=list>remove</a> <var>listener</var> from <var>event</var>'s {{Event/currentTarget}}
@@ -9983,6 +9986,7 @@ Mark Miller,
 Martijn van der Ven,
 Mats Palmgren,
 Mounir Lamouri,
+Michael Stramel,
 Michael™ Smith,
 Mike Champion,
 Mike Taylor,

--- a/dom.bs
+++ b/dom.bs
@@ -1306,14 +1306,14 @@ for discussion).
      <li><p>Set <var>slot-in-closed-tree</var> to false.
     </ol>
 
-   <li><p>Let <var>clearTargetsTuple</var> be the last tuple in <var>event</var>'s
+   <li><p>Let <var>clearTargetsStruct</var> be the last struct in <var>event</var>'s
    <a for=Event>path</a> whose <a for=Event/path>target</a> is non-null.
 
-   <li><p>Let <var>clearTargets</var> be true if <var>clearTargetsTuple</var>'s
-   <a for=Event/path>target</a>, <var>clearTargetsTuple</var>'s <a for=Event/path>relatedTarget</a>,
-   or an {{EventTarget}} object in <var>clearTargetsTuple</var>'s
-   <a for=Event/path>touch target list</a> is a <a for=/>node</a> and its <a for=tree>root</a> is a
-   <a for=/>shadow root</a>, and false otherwise.
+   <li><p>Let <var>clearTargets</var> be true if <var>clearTargetsStruct</var>'s
+   <a for=Event/path>target</a>, <var>clearTargetsStruct</var>'s
+   <a for=Event/path>relatedTarget</a>, or an {{EventTarget}} object in
+   <var>clearTargetsStruct</var>'s <a for=Event/path>touch target list</a> is a <a for=/>node</a>
+   and its <a for=tree>root</a> is a <a for=/>shadow root</a>, and false otherwise.
 
    <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/CAPTURING_PHASE}}.
 
@@ -1322,18 +1322,18 @@ for discussion).
    <a for=EventTarget>legacy-pre-activation behavior</a>.
 
    <li>
-    <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
+    <p>For each <var>struct</var> in <var>event</var>'s <a for=Event>path</a>, in reverse order:
 
     <ol>
-     <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a> with
-     <var>tuple</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
+     <li><p>If <var>struct</var>'s <a for=Event/path>target</a> is null, then <a>invoke</a> with
+     <var>struct</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
     </ol>
 
    <li>
-    <p>For each <var>tuple</var> in <var>event</var>'s <a for=Event>path</a>, in order:
+    <p>For each <var>struct</var> in <var>event</var>'s <a for=Event>path</a>, in order:
 
     <ol>
-     <li><p>If <var>tuple</var>'s <a for=Event/path>target</a> is non-null, then set
+     <li><p>If <var>struct</var>'s <a for=Event/path>target</a> is non-null, then set
      <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
 
      <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
@@ -1342,7 +1342,7 @@ for discussion).
      <li><p>If either <var>event</var>'s {{Event/eventPhase}} attribute is {{Event/BUBBLING_PHASE}}
      and <var>event</var>'s {{Event/bubbles}} attribute is true or <var>event</var>'s
      {{Event/eventPhase}} attribute is {{Event/AT_TARGET}}, then <a>invoke</a> with
-     <var>tuple</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
+     <var>struct</var>, <var>event</var>, and <var>legacyOutputDidListenersThrowFlag</var> if given.
     </ol>
   </ol>
 
@@ -1405,23 +1405,23 @@ for discussion).
  <a for=Event/path>slot-in-closed-tree</a> is <var>slot-in-closed-tree</var>.
 </ol>
 
-<p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn>, given a <var>tuple</var>,
+<p>To <dfn noexport id=concept-event-listener-invoke>invoke</dfn>, given a <var>struct</var>,
 <var>event</var>, and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
 
 <ol>
  <li><p>Set <var>event</var>'s <a for=Event>target</a> to the <a for=Event/path>target</a> of the
- last tuple in <var>event</var>'s <a for=Event>path</a>, that is either <var>tuple</var> or
- preceding <var>tuple</var>, whose <a for=Event/path>target</a> is non-null.
+ last struct in <var>event</var>'s <a for=Event>path</a>, that is either <var>struct</var> or
+ preceding <var>struct</var>, whose <a for=Event/path>target</a> is non-null.
 
- <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to <var>tuple</var>'s
+ <li><p>Set <var>event</var>'s <a for=Event>relatedTarget</a> to <var>struct</var>'s
  <a for=Event/path>relatedTarget</a>.
 
- <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to <var>tuple</var>'s
+ <li><p>Set <var>event</var>'s <a for=Event>touch target list</a> to <var>struct</var>'s
  <a for=Event/path>touch target list</a>.
 
  <li><p>If <var>event</var>'s <a>stop propagation flag</a> is set, then return.
 
- <li><p>Initialize <var>event</var>'s {{Event/currentTarget}} attribute to <var>tuple</var>'s
+ <li><p>Initialize <var>event</var>'s {{Event/currentTarget}} attribute to <var>struct</var>'s
  <a for=Event/path>item</a>.
 
  <li>
@@ -1505,7 +1505,7 @@ for discussion).
     <ol>
      <li><p>Set <var>currentEvent</var> to <var>global</var>'s <a for=Window>current event</a>.
 
-     <li><p>If <var>tuple</var>'s <a for=Event/path>item-in-shadow-tree</a> is false, then set
+     <li><p>If <var>struct</var>'s <a for=Event/path>item-in-shadow-tree</a> is false, then set
      <var>global</var>'s <a for=Window>current event</a> to <var>event</var>.
     </ol>
 
@@ -5685,8 +5685,9 @@ or "<code>closed</code>").</p>
 
 <p>A <a for=/>shadow root</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
 null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow root</a> is the
-<a for=tree>root</a> of <var>event</var>'s <a for=Event>path</a>'s first tuple's <b>item</b>, and
-<a for=/>shadow root</a>'s <a for=DocumentFragment>host</a> otherwise.
+<a for=tree>root</a> of <var>event</var>'s <a for=Event>path</a>'s first struct's
+<a for=Event/path>item</a>, and <a for=/>shadow root</a>'s <a for=DocumentFragment>host</a>
+otherwise.
 
 <p>The <dfn attribute for=ShadowRoot><code>mode</code></dfn> attribute's getter must return the
 <a>context object</a>'s <a for=ShadowRoot>mode</a>.</p>


### PR DESCRIPTION
Instead of shoehorning all target handling into the bubbling iteration, this separates "capturing" iteration from "bubbling" iteration and the Event object's phase is set to target as appropriate in both.

This also invokes the event listeners in a more natural order.

Tests: ...

Fixes #685.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/686.html" title="Last updated on Mar 1, 2019, 10:49 AM UTC (7aaff50)">Preview</a> | <a href="https://whatpr.org/dom/686/42d2485...7aaff50.html" title="Last updated on Mar 1, 2019, 10:49 AM UTC (7aaff50)">Diff</a>