### PR TITLE
Avoid setting target to the Window object

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1271,8 +1271,9 @@ for discussion).
      <var>touchTarget</var> against <var>parent</var> to <var>touchTargets</var>.
 
      <li>
-      <p>If <var>parent</var> is a <a>node</a> and <var>target</var>'s <a for=tree>root</a> is a
-      <a>shadow-including inclusive ancestor</a> of <var>parent</var>, then:
+      <p>If <var>parent</var> is a {{Window}} object, or <var>parent</var> is a <a>node</a> and
+      <var>target</var>'s <a for=tree>root</a> is a <a>shadow-including inclusive ancestor</a> of
+      <var>parent</var>, then:
 
       <ol>
        <li><p>If <var>isActivationEvent</var> is true, <var>event</var>'s {{Event/bubbles}}


### PR DESCRIPTION
fc165642b437c548a11222c85ddda0094ed40ea5 did not adequately consider the global object.

Fixes #697.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/698.html" title="Last updated on Sep 17, 2018, 9:31 AM GMT (0e3e225)">Preview</a> | <a href="https://whatpr.org/dom/698/42d2485...0e3e225.html" title="Last updated on Sep 17, 2018, 9:31 AM GMT (0e3e225)">Diff</a>