### PR TITLE
Ground primitives in agents

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2208,8 +2208,8 @@ steps:
 
 <h5 id=signaling-slot-change>Signaling slot change</h5>
 
-<p>Each <a>similar-origin window agent</a> has <dfn noexport>signal slots</dfn> (a <a for=/>set</a>
-of <a>slots</a>). Unless stated otherwise it is empty. [[!HTML]]
+<p>Each <a>similar-origin window agent</a> has <dfn noexport id=signal-slot-list>signal slots</dfn>
+(a <a for=/>set</a> of <a>slots</a>), which is initially empty. [[!HTML]]
 
 <p>To <dfn noexport>signal a slot change</dfn>, for a <a>slot</a> <var>slot</var>, run these steps:
 
@@ -3193,8 +3193,9 @@ invoked, must run these steps:
 <dfn noexport>mutation observer compound microtask queued flag</dfn>, which is initially unset.
 [[!HTML]]
 
-<p>Each <a>similar-origin window agent</a> also has <dfn noexport>mutation observers</dfn> (a
-<a for=/>set</a> of zero or more {{MutationObserver}} objects), which is initially empty.
+<p>Each <a>similar-origin window agent</a> also has
+<dfn noexport id=mutation-observer-list>mutation observers</dfn> (a <a for=/>set</a> of zero or more
+{{MutationObserver}} objects), which is initially empty.
 
 <p>To <dfn export>queue a mutation observer compound microtask</dfn>, run these steps:
 
@@ -3212,18 +3213,16 @@ invoked, must run these steps:
 <ol>
  <li><p>Unset <a>mutation observer compound microtask queued flag</a>.
 
- <li><p>Let <var>agent</var> be the <a>surrounding agent</a>.
-
- <li><p>Let <var>notifySet</var> be a <a for=list>clone</a> of <var>agent</var>'s
+ <li><p>Let <var>notifySet</var> be a <a for=set>clone</a> of the <a>surrounding agent</a>'s
  <a>mutation observers</a>.
 
- <li><p>Let <var>signalSet</var> be a <a for=set>clone</a> of <var>agent</var>'s
+ <li><p>Let <var>signalSet</var> be a <a for=set>clone</a> of the <a>surrounding agent</a>'s
  <a>signal slots</a>.
 
- <li><p><a for=list>Empty</a> <var>agent</var>'s <a>signal slots</a>.
+ <li><p><a for=set>Empty</a> the <a>surrounding agent</a>'s <a>signal slots</a>.
 
  <li>
-  <p><a for=list>For each</a> <var>mo</var> of <var>notifySet</var>,
+  <p><a for=set>For each</a> <var>mo</var> of <var>notifySet</var>,
   <a>execute a compound microtask subtask</a> to run these steps: [[!HTML]]
 
   <ol>

--- a/dom.bs
+++ b/dom.bs
@@ -3223,7 +3223,7 @@ invoked, must run these steps:
  <li><p><a for=list>Empty</a> <var>agent</var>'s <a>signal slots</a>.
 
  <li>
-  <p><a for=list>For each</a> <var>mo</var> of <var>notifyList</var>,
+  <p><a for=list>For each</a> <var>mo</var> of <var>notifySet</var>,
   <a>execute a compound microtask subtask</a> to run these steps: [[!HTML]]
 
   <ol>

--- a/dom.bs
+++ b/dom.bs
@@ -32,7 +32,7 @@ urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
  text: Construct; url: sec-construct; type: abstract-op
  type: dfn
   text: Realm; url: realm
-  text: current Realm Record; url: current-realm
+  text: surrounding agent; url: surrounding-agent
 urlPrefix: https://w3c.github.io/hr-time/#; spec: HR-TIME
  type:typedef; urlPrefix: dom-; text: DOMHighResTimeStamp
  type:dfn; text: time origin; url: dfn-time-origin
@@ -2208,17 +2208,14 @@ steps:
 
 <h5 id=signaling-slot-change>Signaling slot change</h5>
 
-<p>Each <a>similar-origin window agent</a> has a <dfn export>signal slot list</dfn> (a list of
-<a>slots</a>). Unless stated otherwise it is empty. [[!HTML]]
+<p>Each <a>similar-origin window agent</a> has <dfn noexport>signal slots</dfn> (a <a for=/>set</a>
+of <a>slots</a>). Unless stated otherwise it is empty. [[!HTML]]
 
 <p>To <dfn noexport>signal a slot change</dfn>, for a <a>slot</a> <var>slot</var>, run these steps:
 
 <ol>
- <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> to which <var>slot</var>'s
- <a>relevant Realm</a> belongs.
-
- <li><p>If <var>slot</var> is not in <var>agent</var>'s <a>signal slot list</a>, then
- <a for=list>append</a> <var>slot</var> to <var>agent</var>'s <a>signal slot list</a>.
+ <li><p><a for=set>Append</a> <var>slot</var> to <var>slot</var>'s <a>relevant agent</a>'s
+ <a>signal slots</a>.
 
  <li><p><a>Queue a mutation observer compound microtask</a>.
 </ol>
@@ -3196,8 +3193,8 @@ invoked, must run these steps:
 <dfn noexport>mutation observer compound microtask queued flag</dfn>, which is initially unset.
 [[!HTML]]
 
-<p>Each <a>similar-origin window agent</a> also has a <dfn noexport>mutation observer list</dfn> (a
-<a for=/>list</a> of zero or more {{MutationObserver}} objects), which is initially empty.
+<p>Each <a>similar-origin window agent</a> also has <dfn noexport>mutation observers</dfn> (a
+<a for=/>set</a> of zero or more {{MutationObserver}} objects), which is initially empty.
 
 <p>To <dfn export>queue a mutation observer compound microtask</dfn>, run these steps:
 
@@ -3215,16 +3212,15 @@ invoked, must run these steps:
 <ol>
  <li><p>Unset <a>mutation observer compound microtask queued flag</a>.
 
- <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> <a>current Realm Record</a>
- belongs to.
+ <li><p>Let <var>agent</var> be the <a>surrounding agent</a>.
 
- <li><p>Let <var>notifyList</var> be a <a for=list>clone</a> of <var>agent</var>'s
- <a>mutation observer list</a>.
+ <li><p>Let <var>notifySet</var> be a <a for=list>clone</a> of <var>agent</var>'s
+ <a>mutation observers</a>.
 
- <li><p>Let <var>signalList</var> be a <a for=list>clone</a> of <var>agent</var>'s
- <a>signal slot list</a>.
+ <li><p>Let <var>signalSet</var> be a <a for=set>clone</a> of <var>agent</var>'s
+ <a>signal slots</a>.
 
- <li><p><a for=list>Empty</a> <var>agent</var>'s <a>signal slot list</a>.
+ <li><p><a for=list>Empty</a> <var>agent</var>'s <a>signal slots</a>.
 
  <li>
   <p><a for=list>For each</a> <var>mo</var> of <var>notifyList</var>,
@@ -3246,7 +3242,7 @@ invoked, must run these steps:
    and <var>mo</var>. If this throws an exception, then <a>report the exception</a>.
   </ol>
 
- <li><p><a for=list>For each</a> <var>slot</var> of <var>signalList</var>, <a>fire an event</a>
+ <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a>
  named <code>slotchange</code>, with its {{Event/bubbles}} attribute set to true, at
  <var>slot</var>.
 </ol>
@@ -3388,10 +3384,8 @@ constructor, when invoked, must run these steps:
  <li><p>Let <var>mo</var> be a new {{MutationObserver}} object whose
  <a for=MutationObserver>callback</a> is <var>callback</var>.
 
- <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> <var>mo</var>'s
- <a>relevant Realm</a> belongs to.
-
- <li><p><a for=list>Append</a> <var>mo</var> to <var>agent</var>'s <a>mutation observer list</a>.
+ <li><p><a for=set>Append</a> <var>mo</var> to <var>mo</var>'s <a>relevant agent</a>'s
+ <a>mutation observers</a>.
 
  <li><p>Return <var>mo</var>.
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -30,7 +30,9 @@ type: interface
   text: WebGLContextEvent
 urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMASCRIPT
  text: Construct; url: sec-construct; type: abstract-op
- text: Realm; url: realm; type: dfn
+ type: dfn
+  text: Realm; url: realm
+  text: current Realm Record; url: current-realm
 urlPrefix: https://w3c.github.io/hr-time/#; spec: HR-TIME
  type:typedef; urlPrefix: dom-; text: DOMHighResTimeStamp
  type:dfn; text: time origin; url: dfn-time-origin
@@ -3213,8 +3215,8 @@ invoked, must run these steps:
 <ol>
  <li><p>Unset <a>mutation observer compound microtask queued flag</a>.
 
- <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> <a>current Realm</a> belongs
- to.
+ <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> <a>current Realm Record</a>
+ belongs to.
 
  <li><p>Let <var>notifyList</var> be a <a for=list>clone</a> of <var>agent</var>'s
  <a>mutation observer list</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -2206,16 +2206,17 @@ steps:
 
 <h5 id=signaling-slot-change>Signaling slot change</h5>
 
-<p>Each <a>unit of related similar-origin browsing contexts</a> has a
-<dfn export>signal slot list</dfn> (a list of <a>slots</a>). Unless stated otherwise it is empty.
-[[!HTML]]
+<p>Each <a>similar-origin window agent</a> has a <dfn export>signal slot list</dfn> (a list of
+<a>slots</a>). Unless stated otherwise it is empty. [[!HTML]]
 
 <p>To <dfn noexport>signal a slot change</dfn>, for a <a>slot</a> <var>slot</var>, run these steps:
 
 <ol>
- <li><p>If <var>slot</var> is not in <a>unit of related similar-origin browsing contexts</a>'
- <a>signal slot list</a>, append <var>slot</var> to
- <a>unit of related similar-origin browsing contexts</a>' <a>signal slot list</a>.
+ <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> to which <var>slot</var>'s
+ <a>relevant Realm</a> belongs.
+
+ <li><p>If <var>slot</var> is not in <var>agent</var>'s <a>signal slot list</a>, then
+ <a for=list>append</a> <var>slot</var> to <var>agent</var>'s <a>signal slot list</a>.
 
  <li><p><a>Queue a mutation observer compound microtask</a>.
 </ol>
@@ -3189,13 +3190,12 @@ invoked, must run these steps:
 
 <h3 id=mutation-observers>Mutation observers</h3>
 
-<p>Each <a>unit of related similar-origin browsing contexts</a> has a
+<p>Each <a>similar-origin window agent</a> has a
 <dfn noexport>mutation observer compound microtask queued flag</dfn>, which is initially unset.
 [[!HTML]]
 
-<p>Each <a>unit of related similar-origin browsing contexts</a> also has a
-<dfn noexport>mutation observer list</dfn> (a <a for=/>list</a> of zero or more {{MutationObserver}}
-objects), which is initially empty.
+<p>Each <a>similar-origin window agent</a> also has a <dfn noexport>mutation observer list</dfn> (a
+<a for=/>list</a> of zero or more {{MutationObserver}} objects), which is initially empty.
 
 <p>To <dfn export>queue a mutation observer compound microtask</dfn>, run these steps:
 
@@ -3213,14 +3213,16 @@ objects), which is initially empty.
 <ol>
  <li><p>Unset <a>mutation observer compound microtask queued flag</a>.
 
- <li><p>Let <var>notifyList</var> be a <a for=list>clone</a> of
- <a>unit of related similar-origin browsing contexts</a>' <a>mutation observer list</a>.
+ <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> <a>current Realm</a> belongs
+ to.
 
- <li><p>Let <var>signalList</var> be a <a for=list>clone</a> of
- <a>unit of related similar-origin browsing contexts</a>' <a>signal slot list</a>.
+ <li><p>Let <var>notifyList</var> be a <a for=list>clone</a> of <var>agent</var>'s
+ <a>mutation observer list</a>.
 
- <li><p><a for=list>Empty</a> <a>unit of related similar-origin browsing contexts</a>'
+ <li><p>Let <var>signalList</var> be a <a for=list>clone</a> of <var>agent</var>'s
  <a>signal slot list</a>.
+
+ <li><p><a for=list>Empty</a> <var>agent</var>'s <a>signal slot list</a>.
 
  <li>
   <p><a for=list>For each</a> <var>mo</var> of <var>notifyList</var>,
@@ -3384,8 +3386,10 @@ constructor, when invoked, must run these steps:
  <li><p>Let <var>mo</var> be a new {{MutationObserver}} object whose
  <a for=MutationObserver>callback</a> is <var>callback</var>.
 
- <li><p><a for=list>Append</a> <var>mo</var> to
- <a>unit of related similar-origin browsing contexts</a>' <a>mutation observer list</a>.
+ <li><p>Let <var>agent</var> be the <a>similar-origin window agent</a> <var>mo</var>'s
+ <a>relevant Realm</a> belongs to.
+
+ <li><p><a for=list>Append</a> <var>mo</var> to <var>agent</var>'s <a>mutation observer list</a>.
 
  <li><p>Return <var>mo</var>.
 </ol>


### PR DESCRIPTION
Using "unit of related similar-origin browsing contexts" never made much sense as a browsing context could always hold several cross-site documents.

Helps with https://github.com/whatwg/html/issues/4198.

Fixes #88.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/717.html" title="Last updated on Jan 16, 2019, 12:34 PM UTC (66d734c)">Preview</a> | <a href="https://whatpr.org/dom/717/15e2f41...66d734c.html" title="Last updated on Jan 16, 2019, 12:34 PM UTC (66d734c)">Diff</a>