### PR TITLE
Add a note about duplicate event listeners for removeEventListener

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1216,6 +1216,9 @@ method, when invoked, must run these steps:
  with the <a>context object</a> and that <a>event listener</a>.
 </ol>
 
+<p class="note">The event listener list will not contain duplicate event listeners matching
+<var>type</var>, <var>callback</var>, and <var>capture</var> because the <a>add an event listener</a> concept does not add duplicates.
+
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when
 invoked, must run these steps:
 

--- a/dom.bs
+++ b/dom.bs
@@ -1217,7 +1217,7 @@ method, when invoked, must run these steps:
 </ol>
 
 <p class="note">The event listener list will not contain duplicate event listeners matching
-<var>type</var>, <var>callback</var>, and <var>capture</var> because the <a>add an event listener</a> concept does not add duplicates.
+<var>type</var>, <var>callback</var>, and <var>capture</var> because <a>add an event listener</a> does not add duplicates.
 
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when
 invoked, must run these steps:

--- a/dom.bs
+++ b/dom.bs
@@ -1216,7 +1216,7 @@ method, when invoked, must run these steps:
  with the <a>context object</a> and that <a>event listener</a>.
 </ol>
 
-<p class="note">The event listener list will not contain duplicate event listeners matching
+<p class="note">The event listener list will not contain multiple event listeners matching
 <var>type</var>, <var>callback</var>, and <var>capture</var> because <a>add an event listener</a> does not add duplicates.
 
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when

--- a/dom.bs
+++ b/dom.bs
@@ -1216,8 +1216,9 @@ method, when invoked, must run these steps:
  with the <a>context object</a> and that <a>event listener</a>.
 </ol>
 
-<p class="note">The event listener list will not contain multiple event listeners matching
-<var>type</var>, <var>callback</var>, and <var>capture</var> because <a>add an event listener</a> does not add duplicates.
+<p class=note>The event listener list will not contain multiple event listeners with equal
+<var>type</var>, <var>callback</var>, and <var>capture</var>, as <a>add an event listener</a>
+prevents that.
 
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when
 invoked, must run these steps:
@@ -10038,6 +10039,7 @@ Kirill Topolyan,
 Koji Ishii,
 Lachlan Hunt,
 Lauren Wood,
+Luke Zielinski,
 Magne Andersson,
 Majid Valipour,
 Malte Ubl,


### PR DESCRIPTION
First crack at first spec change.

Addresses https://github.com/whatwg/dom/issues/664


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/722.html" title="Last updated on Dec 10, 2018, 9:44 AM GMT (6c15c49)">Preview</a> | <a href="https://whatpr.org/dom/722/23ec642...6c15c49.html" title="Last updated on Dec 10, 2018, 9:44 AM GMT (6c15c49)">Diff</a>