### PR TITLE
Fix a small but important error in composedPath()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -633,7 +633,7 @@ steps:
    <li><p>If <var>path</var>[<var>index</var>]'s <a for=Event/path>root-of-closed-tree</a> is true,
    then increase <var>currentHiddenLevel</var> by 1.
 
-   <li><p>If <var>currentHiddenLevel</var> is less than <var>maxHiddenLevel</var>, then
+   <li><p>If <var>currentHiddenLevel</var> is less than or equal to <var>maxHiddenLevel</var>, then
    <a for=list>prepend</a> <var>path</var>[<var>index</var>]'s <a for=Event/path>item</a> to
    <var>composedPath</var>.
 
@@ -9991,6 +9991,7 @@ Doug Schepers,
 Edgar Chen,
 Elisée Maurer,
 Elliott Sprehn,
+Emilio Cobos Álvarez,
 Eric Bidelman,
 Erik Arvidsson,
 Gary Kacmarcik,


### PR DESCRIPTION
The comparison needs to be 'less than or equal', otherwise you don't prepend the items from the same level as the target.

Trivially, in a 'no shadow DOM' situation, all the items in the path before the current target wouldn't be in the path without this patch, which is wrong.

This is tested already by event-composed-path.html in WPT.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/727.html" title="Last updated on Dec 29, 2018, 6:42 PM UTC (157b3af)">Preview</a> | <a href="https://whatpr.org/dom/727/ee24b02...157b3af.html" title="Last updated on Dec 29, 2018, 6:42 PM UTC (157b3af)">Diff</a>