### PR TITLE
Create an abstraction for Element's textContent getter

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4127,22 +4127,26 @@ following, switching on <a>context object</a>:
  <dd>Null.
 </dl>
 
+<p>To <dfn export>string replace all</dfn> with a string <var>string</var> within a
+<a for=/>node</a> <var>parent</var>, run these steps:
+
+<ol>
+ <li><p>Let <var>node</var> be null.
+
+ <li><p>If the given value is not the empty string, then set <var>node</var> to a new {{Text}}
+ <a for=/>node</a> whose <a for=CharacterData>data</a> is the given value and
+ <a for=Node>node document</a> is <var>parent</var>'s <a for=Node>node document</a>.
+
+ <li><p><a for=Node>Replace all</a> with <var>node</var> within <var>parent</var>.
+</ol>
+
 <p>The {{Node/textContent}} attribute's setter must, if the given value is null, act as if it was
 the empty string instead, and then do as described below, switching on <a>context object</a>:
 
 <dl class=switch>
  <dt>{{DocumentFragment}}
  <dt>{{Element}}
- <dd>
-  <ol>
-   <li><p>Let <var>node</var> be null.
-
-   <li><p>If the given value is not the empty string, set <var>node</var> to a new {{Text}}
-   <a>node</a> whose <a for=CharacterData>data</a> is the given value and
-   <a for=Node>node document</a> is <a>context object</a>'s <a for=Node>node document</a>.
-
-   <li><p><a for=Node>Replace all</a> with <var>node</var> within the <a>context object</a>.
-  </ol>
+ <dd><p><a>String replace all</a> with the given value within the <a>context object</a>.
 
  <dt>{{Attr}}
  <dd><p><a>Set an existing attribute value</a> with <a>context object</a> and new value.

--- a/dom.bs
+++ b/dom.bs
@@ -4113,11 +4113,7 @@ following, switching on <a>context object</a>:
 <dl class=switch>
  <dt>{{DocumentFragment}}
  <dt>{{Element}}
- <dd>The <a for=string>concatenation</a> of <a for=CharacterData>data</a> of all
- the {{Text}} <a>node</a>
- <a>descendants</a> of the
- <a>context object</a>, in
- <a>tree order</a>.
+ <dd>The <a>descendant text content</a> of the <a>context object</a>.
 
  <dt>{{Attr}}
  <dd><a>Context object</a>'s <a for=Attr>value</a>.
@@ -7347,12 +7343,18 @@ if any, and its <a>contiguous exclusive <code>Text</code> nodes</a>, and <var>no
 <a for=tree>next sibling</a> <a>exclusive <code>Text</code> node</a>, if any, and its
 <a>contiguous exclusive <code>Text</code> nodes</a>, avoiding any duplicates.
 
-<p>The <dfn export id=concept-child-text-content>child text content</dfn> of a <a>node</a>
+<p>The <dfn export id=concept-child-text-content>child text content</dfn> of a <a for=/>node</a>
 <var>node</var> is the <a for=string>concatenation</a> of the <a for=CharacterData>data</a> of all
-the {{Text}} node <a>children</a> of <var>node</var>, in <a>tree order</a>.
+the {{Text}} <a for=/>node</a> <a>children</a> of <var>node</var>, in <a>tree order</a>.
 
 <p>This and <a lt="other applicable specifications">other specifications</a> may define
-<dfn export id=concept-node-text-change-ext>child text content change steps</dfn> for <a for=/>nodes</a>.
+<dfn export id=concept-node-text-change-ext>child text content change steps</dfn> for
+<a for=/>nodes</a>.
+
+<p>The <dfn export id=concept-descendant-text-content>descendant text content</dfn> of a
+<a for=/>node</a> <var>node</var> is the <a for=string>concatenation</a> of the
+<a for=CharacterData>data</a> of all the {{Text}} <a for=/>node</a> <a>descendants</a> of
+<var>node</var>, in <a>tree order</a>.
 
 <hr>
 

--- a/dom.bs
+++ b/dom.bs
@@ -4133,8 +4133,8 @@ following, switching on <a>context object</a>:
 <ol>
  <li><p>Let <var>node</var> be null.
 
- <li><p>If the given value is not the empty string, then set <var>node</var> to a new {{Text}}
- <a for=/>node</a> whose <a for=CharacterData>data</a> is the given value and
+ <li><p>If <var>string</var> is not the empty string, then set <var>node</var> to a new {{Text}}
+ <a for=/>node</a> whose <a for=CharacterData>data</a> is <var>string</var> and
  <a for=Node>node document</a> is <var>parent</var>'s <a for=Node>node document</a>.
 
  <li><p><a for=Node>Replace all</a> with <var>node</var> within <var>parent</var>.


### PR DESCRIPTION
This is needed for defining HTML's output element. See https://github.com/whatwg/html/issues/4163 for context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/743.html" title="Last updated on Mar 26, 2019, 12:54 PM UTC (20be836)">Preview</a> | <a href="https://whatpr.org/dom/743/9943801...20be836.html" title="Last updated on Mar 26, 2019, 12:54 PM UTC (20be836)">Diff</a>