### PR TITLE
Set current node to sibling when iterating the TreeWalker. Fixes #667.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9443,7 +9443,8 @@ steps:
 
      <li><p>Set <var>sibling</var> to <var>temporary</var>'s <a for=tree>next sibling</a>.
 
-     <li><p>If <var>sibling</var> is non-null, then <a for=iteration>break</a>.
+     <li><p>If <var>sibling</var> is non-null, then set <var>node</var> to <var>sibling</var> and
+     <a for=iteration>break</a>.
 
      <li><p>Set <var>temporary</var> to <var>temporary</var>'s <a for=tree>parent</a>.
     </ol>


### PR DESCRIPTION
This PR fixes #667 where a sibling node is never returned from the nextNode() method of TreeWalker, resulting in an infinite loop.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/747.html" title="Last updated on Apr 5, 2019, 9:33 AM UTC (124d06d)">Preview</a> | <a href="https://whatpr.org/dom/747/7a8406b...124d06d.html" title="Last updated on Apr 5, 2019, 9:33 AM UTC (124d06d)">Diff</a>