### PR TITLE
Non-bubbling event should run non-capture listeners

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1405,15 +1405,21 @@ for discussion).
     </ol>
 
    <li>
-    <p>If <var>event</var>'s {{Event/bubbles}} attribute is true, then <a for=list>for each</a>
-    <var>struct</var> in <var>event</var>'s <a for=Event>path</a>:
+    <p><a for=list>For each</a> <var>struct</var> in <var>event</var>'s <a for=Event>path</a>:
 
     <ol>
      <li><p>If <var>struct</var>'s <a for=Event/path>target</a> is non-null, then set
      <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/AT_TARGET}}.
 
-     <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
-     {{Event/BUBBLING_PHASE}}.
+     <li>
+      <p>Otherwise:
+
+      <ol>
+       <li><p>If <var>event</var>'s {{Event/bubbles}} attribute is false, then
+       <a for=iteration>continue</a>.
+
+       <li><p>Set <var>event</var>'s {{Event/eventPhase}} attribute to {{Event/BUBBLING_PHASE}}.
+      </ol>
 
      <li><p><a>Invoke</a> with <var>struct</var>, <var>event</var>, "<code>bubbling</code>", and
      <var>legacyOutputDidListenersThrowFlag</var> if given.


### PR DESCRIPTION
This fixes a regression from #686.

Tests: various tests were failing because of this. https://github.com/web-platform-tests/wpt/pull/16307 aligns the remaining failing test with the new model.

Fixes #742.