### PR TITLE
Editorial: use IDL to simplify create an element

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6035,20 +6035,10 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <li><p>Set <var>result</var> to the result of <a>constructing</a> <var>C</var>, with no
      arguments.
 
-     <li>
-      <p>If <var>result</var> does not implement the {{HTMLElement}} interface, then <a>throw</a> a
-      <code>TypeError</code>.
+     <li><p>Assert: <var>result</var>'s <a for=Element>custom element state</a> and
+     <a for=Element>custom element definition</a> are initialized.
 
-      <div class=note>
-       <p>This is meant to be a brand check to ensure that the object was allocated by the HTML
-       element constructor. See <a href="https://github.com/heycam/webidl/issues/97">webidl #97</a>
-       about making this more precise.
-
-       <p>If this check passes, then <var>result</var> will already have its
-       <a for=Element>custom element state</a> and <a for=Element>custom element definition</a>
-       initialized.
-      </div>
-     </li>
+     <li><p>Assert: <var>result</var>'s <a for=Element>namespace</a> is the <a>HTML namespace</a>.
 
      <li><p>If <var>result</var>'s <a for=Element>attribute list</a> <a for=list>is not empty</a>,
      then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
@@ -6061,17 +6051,6 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 
      <li><p>If <var>result</var>'s <a for=Node>node document</a> is not <var>document</var>, then
      <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
-
-     <li>
-      <p>If <var>result</var>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
-      then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
-
-      <p class="note">As of the time of this writing, every element that implements the
-      {{HTMLElement}} interface is also in the <a>HTML namespace</a>, so this check is currently
-      redundant with the above brand check. However, this is not guaranteed to be true forever in
-      the face of potential specification changes, such as converging certain SVG and HTML
-      interfaces.
-     </li>
 
      <li><p>If <var>result</var>'s <a for=Element>local name</a> is not equal to
      <var>localName</var>, then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.

--- a/dom.bs
+++ b/dom.bs
@@ -6038,7 +6038,11 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <li><p>Assert: <var>result</var>'s <a for=Element>custom element state</a> and
      <a for=Element>custom element definition</a> are initialized.
 
-     <li><p>Assert: <var>result</var>'s <a for=Element>namespace</a> is the <a>HTML namespace</a>.
+     <li>
+      <p>Assert: <var>result</var>'s <a for=Element>namespace</a> is the <a>HTML namespace</a>.
+
+      <p class=note>IDL enforces that <var>result</var> is an {{HTMLElement}} object, which all use
+      the <a>HTML namespace</a>.
 
      <li><p>If <var>result</var>'s <a for=Element>attribute list</a> <a for=list>is not empty</a>,
      then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.


### PR DESCRIPTION
Per https://github.com/whatwg/html/pull/4525 a custom element constructor is required to be an HTMLElement.

Also, rather than assume another specification will make foreign namespace objects implement HTMLElement, let's instead assert that does not happen as we cannot test it.