### PR TITLE
Use "NotSupportedError" when trying to attachShadow() twice

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6768,7 +6768,7 @@ invoked, must run these steps:
  "<code>span</code>", then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
  <li><p>If <a>context object</a> is a <a for=Element>shadow host</a>, then <a>throw</a> an
- "{{InvalidStateError!!exception}}" {{DOMException}}.
+ "{{NotSupportedError!!exception}}" {{DOMException}}.
 
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>
  is <a>context object</a>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is


### PR DESCRIPTION
Discussed in #760. This makes the various cases less distinguishable,
which is desirable. With this change, all three cases behave the same
between:

- A custom element with disabled-shadow
- A custom element with a shadow tree
- A built-in element on the blocklist

Tests: https://github.com/web-platform-tests/wpt/pull/16853


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/761.html" title="Last updated on May 15, 2019, 7:09 PM UTC (7bcdca6)">Preview</a> | <a href="https://whatpr.org/dom/761/e4e0ea8...7bcdca6.html" title="Last updated on May 15, 2019, 7:09 PM UTC (7bcdca6)">Diff</a>