### PR TITLE
Editorial: use Infra list syntax in mutations

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2427,10 +2427,8 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
    its <a for=range>end offset</a> by <var>count</var>.
   </ol>
 
- <li>Let <var>nodes</var> be <var>node</var>'s
- <a>children</a> if <var>node</var> is
- a {{DocumentFragment}} <a>node</a>, and a
- list containing solely <var>node</var> otherwise.
+ <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a>, if <var>node</var> is a
+ {{DocumentFragment}} <a>node</a>, « <var>node</var> » otherwise.
 
  <li>If <var>node</var> is a {{DocumentFragment}}
  <a>node</a>,
@@ -2602,7 +2600,7 @@ within a <var>parent</var>, run these steps:
   <p>If <var>child</var>'s <a for=tree>parent</a> is not null, then:
 
   <ol>
-   <li><p>Set <var>removedNodes</var> to a list solely containing <var>child</var>.
+   <li><p>Set <var>removedNodes</var> to « <var>child</var> ».
 
    <li><p><a for=/>Remove</a> <var>child</var> from its <var>parent</var> with the
    <i>suppress observers flag</i> set.
@@ -2610,8 +2608,8 @@ within a <var>parent</var>, run these steps:
 
   <p class="note no-backref">The above can only be false if <var>child</var> is <var>node</var>.
 
- <li>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a
- {{DocumentFragment}} <a>node</a>, and a list containing solely <var>node</var> otherwise.
+ <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a
+ {{DocumentFragment}} <a>node</a>, « <var>node</var> » otherwise.
  <!-- This needs to come before insert as that removes the children of a
       DocumentFragment node. -->
 
@@ -2637,11 +2635,12 @@ To <dfn export for=Node id=concept-node-replace-all>replace all</dfn> with a
  <li>Let <var>removedNodes</var> be <var>parent</var>'s
  <a>children</a>.
 
- <li>Let <var>addedNodes</var> be the empty list if <var>node</var> is
- null, <var>node</var>'s <a>children</a> if
- <var>node</var> is a {{DocumentFragment}}
- <a>node</a>, and a list containing <var>node</var>
- otherwise.
+ <li><p>Let <var>addedNodes</var> be the empty list.
+
+ <li><p>If <var>node</var> is {{DocumentFragment}} <a>node</a>, then set <var>addedNodes</var> to
+ <var>node</var>'s <a>children</a>.
+
+ <li><p>Otherwise, if <var>node</var> is non-null, set <var>addedNodes</var> to « <var>node</var> ».
 
  <li><a for=/>Remove</a> all
  <var>parent</var>'s <a>children</a>, in

--- a/dom.bs
+++ b/dom.bs
@@ -2428,7 +2428,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   </ol>
 
  <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a>, if <var>node</var> is a
- {{DocumentFragment}} <a>node</a>, « <var>node</var> » otherwise.
+ {{DocumentFragment}} <a>node</a>; otherwise « <var>node</var> ».
 
  <li>If <var>node</var> is a {{DocumentFragment}}
  <a>node</a>,
@@ -2609,7 +2609,7 @@ within a <var>parent</var>, run these steps:
   <p class="note no-backref">The above can only be false if <var>child</var> is <var>node</var>.
 
  <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a> if <var>node</var> is a
- {{DocumentFragment}} <a>node</a>, « <var>node</var> » otherwise.
+ {{DocumentFragment}} <a>node</a>; otherwise « <var>node</var> ».
  <!-- This needs to come before insert as that removes the children of a
       DocumentFragment node. -->
 


### PR DESCRIPTION
As pointed out at https://github.com/whatwg/dom/pull/695#pullrequestreview-233547961 it would be nice if this were more consistent.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/762.html" title="Last updated on May 20, 2019, 2:38 PM UTC (09c786e)">Preview</a> | <a href="https://whatpr.org/dom/762/daa525d...09c786e.html" title="Last updated on May 20, 2019, 2:38 PM UTC (09c786e)">Diff</a>