### PR TITLE
Export concept of collapsed

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -7632,7 +7632,7 @@ interface AbstractRange {
 <dfn export id=concept-range-end-offset for=range>end offset</dfn> is its <a for=range>end</a>'s
 <a for="boundary point">offset</a>.
 
-<p>A <a>range</a> is <dfn for=range>collapsed</dfn> if its <a for=range>start node</a> is its
+<p>A <a>range</a> is <dfn for=range export>collapsed</dfn> if its <a for=range>start node</a> is its
 <a for=range>end node</a> and its <a for=range>start offset</a> is its <a for=range>end offset</a>.
 
 <dl class=domintro>


### PR DESCRIPTION
The Selection API makes extensive reference to the "collapsed" concept. It's currently explicitly linked through an absolute URL. Alternatively, it might be nice to export it in such a way that it can be used via [=range/collapsed=] - for whatever  reason, that form is not being exposed to BikeShed/Shepherd's data.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/764.html" title="Last updated on Jun 4, 2019, 6:58 AM UTC (74343da)">Preview</a> | <a href="https://whatpr.org/dom/764/0f0d1b6...74343da.html" title="Last updated on Jun 4, 2019, 6:58 AM UTC (74343da)">Diff</a>