### PR TITLE
Expand title of spec

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
 Group: WHATWG
-H1: DOM
+H1: Document Object Model (DOM)
 Shortname: dom
 Text Macro: TWITTER thedomstandard
 Abstract: DOM defines a platform-neutral model for events, aborting activities, and node trees.


### PR DESCRIPTION
Honestly, the reason for this patch is that "DOM" looks *really* short in MDN's spec tables, especially on e.g. <https://developer.mozilla.org/en-US/docs/Web/API/DOMError>.

(Yes, I realize that changing the title tag in the spec won't directly alter what's shown on MDN, but I assume they prefer that the names in their JSON file to be *official* names, and this seems like the best way to get one of those.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/774.html" title="Last updated on Jul 14, 2019, 8:35 PM UTC (7c6696a)">Preview</a> | <a href="https://whatpr.org/dom/774/b5eac4d...7c6696a.html" title="Last updated on Jul 14, 2019, 8:35 PM UTC (7c6696a)">Diff</a>