### PR TITLE
Editorial: attachShadow() takes a required dictionary

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5879,7 +5879,7 @@ interface Element : Node {
   [CEReactions] Attr? setAttributeNodeNS(Attr attr);
   [CEReactions] Attr removeAttributeNode(Attr attr);
 
-  ShadowRoot attachShadow(optional ShadowRootInit init = {});
+  ShadowRoot attachShadow(ShadowRootInit init);
   readonly attribute ShadowRoot? shadowRoot;
 
   Element? closest(DOMString selectors);


### PR DESCRIPTION
Either way is correct IDL, but this seems better for the reader (and changes less if you ignore the prior commit).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/775.html" title="Last updated on Aug 9, 2019, 8:02 AM UTC (1a941ed)">Preview</a> | <a href="https://whatpr.org/dom/775/c15e65f...1a941ed.html" title="Last updated on Aug 9, 2019, 8:02 AM UTC (1a941ed)">Diff</a>