### PR TITLE
Catch errors while upgrading customized built-in elements

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6045,8 +6045,23 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
    <a for=Element><code>is</code> value</a> set to <var>is</var>, and <a for=Node>node document</a> set to
    <var>document</var>.
 
-   <li><p>If the <var>synchronous custom elements flag</var> is set,
-   <a lt="upgrade an element">upgrade</a> <var>element</var> using <var>definition</var>.
+   <li>
+    <p>If the <var>synchronous custom elements flag</var> is set, then run this step while
+    catching any exceptions:
+
+    <ol>
+     <li><p><a lt="upgrade an element">Upgrade</a> <var>element</var> using <var>definition</var>.
+    </ol>
+
+    <p>If this step threw an exception, then:</p>
+
+    <ol>
+     <li><p><a>Report the exception</a>.
+
+     <li><p>Set <var>result</var>'s <a for=Element>custom element state</a> to
+     "<code>failed</code>".
+    </ol>
+   </li>
 
    <li><p>Otherwise, <a>enqueue a custom element upgrade reaction</a> given <var>result</var> and
    <var>definition</var>.


### PR DESCRIPTION
Closes https://github.com/whatwg/html/issues/5084. /cc @tkent-google @bzbarsky and also @mfreed7 since he's been working on custom element bugs in Chromium recently.

This needs tests; maybe one of you all would be able to adapt the code in https://github.com/whatwg/html/issues/5084 into such tests? Be sure to test the question as to whether the element retains its identity or not.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/797.html" title="Last updated on Dec 2, 2019, 8:33 PM UTC (c1b5bd4)">Preview</a> | <a href="https://whatpr.org/dom/797/49f009a...c1b5bd4.html" title="Last updated on Dec 2, 2019, 8:33 PM UTC (c1b5bd4)">Diff</a>