### PR TITLE
fix: Use `HTMLDocument` where applicable

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -21,6 +21,8 @@ urlPrefix: https://www.w3.org/TR/xml-names/#NT-
 url: https://w3c.github.io/DOM-Parsing/#dfn-createcontextualfragment-fragment
  type: method; text: createContextualFragment(); for: Range
 type: interface
+ url: https://html.spec.whatwg.org/multipage/dom.html#htmldocument
+  text: HTMLDocument
  url: https://w3c.github.io/touch-events/#idl-def-touchevent
   text: TouchEvent
  url: https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion

--- a/dom.bs
+++ b/dom.bs
@@ -86,9 +86,10 @@ This specification standardizes the DOM. It does so as follows:
 
 <p>This specification depends on the Infra Standard. [[!INFRA]]
 
-<p>Some of the terms used in this specification are defined in <cite>Encoding</cite>,
+<p>Some of the terms used in this specification are defined in <cite>Encoding</cite>, <cite>HTML</cite>,
 <cite>Selectors</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and <cite>Namespaces in XML</cite>.
 [[!ENCODING]]
+[[!HTML]]
 [[!SELECTORS4]]
 [[!WEBIDL]]
 [[!XML]]
@@ -5537,7 +5538,7 @@ with that <a>document</a>.
 interface DOMImplementation {
   [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
   [NewObject] XMLDocument createDocument(DOMString? namespace, [TreatNullAs=EmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
-  [NewObject] Document createHTMLDocument(optional DOMString title);
+  [NewObject] HTMLDocument createHTMLDocument(optional DOMString title);
 
   boolean hasFeature(); // useless; always returns true
 };
@@ -5573,7 +5574,7 @@ interface DOMImplementation {
  <dt><code><var>doc</var> = <var>document</var> . {{Document/implementation}} . <a method for=DOMImplementation lt=createHTMLDocument()>createHTMLDocument([<var>title</var>])</a></code>
 
  <dd>
-  Returns a <a>document</a>, with a basic
+  Returns an {{HTMLDocument}}, with a basic
   <a>tree</a> already constructed including a
   <{title}> element, unless the <var>title</var>
   argument is omitted.
@@ -5640,7 +5641,7 @@ The
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>Let <var>doc</var> be a new <a>document</a> that is an <a>HTML document</a>.
+ <li><p>Let <var>doc</var> be a new {{HTMLDocument}}.
 
  <li><p>Set <var>doc</var>'s <a for=Document>content type</a> to "<code>text/html</code>".
 

--- a/dom.bs
+++ b/dom.bs
@@ -5559,7 +5559,7 @@ interface DOMImplementation {
  <dt><code><var>doc</var> = <var>document</var> . {{Document/implementation}} . <a method for=DOMImplementation lt=createDocument()>createDocument(<var>namespace</var>, <var>qualifiedName</var> [, <var>doctype</var> = null])</a></code>
 
  <dd>
-  Returns an {{XMLDocument}}, with a
+  Returns an {{XMLDocument}} object, with a
   <a>document element</a> whose
   <a for=Element>local name</a> is
   <var>qualifiedName</var> and whose
@@ -5574,7 +5574,7 @@ interface DOMImplementation {
  <dt><code><var>doc</var> = <var>document</var> . {{Document/implementation}} . <a method for=DOMImplementation lt=createHTMLDocument()>createHTMLDocument([<var>title</var>])</a></code>
 
  <dd>
-  Returns an {{HTMLDocument}}, with a basic
+  Returns an {{HTMLDocument}} object, with a basic
   <a>tree</a> already constructed including a
   <{title}> element, unless the <var>title</var>
   argument is omitted.
@@ -5604,7 +5604,7 @@ method, when invoked, must run these steps:
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>Let <var>document</var> be a new {{XMLDocument}}.
+ <li><p>Let <var>document</var> be a new {{XMLDocument}} object.
 
  <li><p>Let <var>element</var> be null.
 
@@ -5641,7 +5641,7 @@ The
 method, when invoked, must run these steps:
 
 <ol>
- <li><p>Let <var>doc</var> be a new {{HTMLDocument}}.
+ <li><p>Let <var>doc</var> be a new {{HTMLDocument}} object.
 
  <li><p>Set <var>doc</var>'s <a for=Document>content type</a> to "<code>text/html</code>".
 
@@ -10170,6 +10170,7 @@ Elliott Sprehn,
 Emilio Cobos Álvarez,
 Eric Bidelman,
 Erik Arvidsson,
+<i>ExE Boss</i>,
 Gary Kacmarcik,
 Gavin Nicol,
 Giorgio Liscio,


### PR DESCRIPTION
See&nbsp;issues:&nbsp;<https://github.com/whatwg/html/issues/4792>, <https://github.com/whatwg/dom/issues/221> and&nbsp;<https://github.com/whatwg/dom/issues/278>

Depends&nbsp;on&nbsp;<https://github.com/whatwg/html/pull/5104>

This&nbsp;is&nbsp;already&nbsp;implemented in&nbsp;all&nbsp;major&nbsp;browsers (**Firefox**, **Chrome** and&nbsp;**Safari**).

---

review?(@annevk, @domenic)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 9, 2019, 11:05 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Fdom%2F37d847525782a2a6692aba5fb9ad0e9c419a13ff%2Fdom.bs&force=1&md-status=LS-COMMIT&md-h1=DOM%20%3Csmall%3E(%3Ca%20href%3D%22https%3A%2F%2Fgithub.com%2Fwhatwg%2Fdom%2Fpull%2F799%22%3EPR%20%23799%3C%2Fa%3E)%3C%2Fsmall%3E&md-warning=Commit%2037d8475%20https%3A%2F%2Fgithub.com%2FEB-Forks%2Fwhatwg-dom%2Fcommit%2F37d847525782a2a6692aba5fb9ad0e9c419a13ff%20replaced%20by%20https%3A%2F%2Fdom.spec.whatwg.org%2F&md-title=DOM%20Standard%20(Pull%20Request%20Snapshot%20%23799)&md-Text-Macro=SNAPSHOT-LINK%20%3Ca%20href%3D%22https%3A%2F%2Fdom.spec.whatwg.org%2F%22%20id%3D%22commit-snapshot-link%22%3EGo%20to%20the%20living%20standard%3C%2Fa%3E)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%23799.)._
</details>
