### PR TITLE
Insertion of empty DocumentFragment is a no-op

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2404,8 +2404,26 @@ algorithm below.
 before a <var>child</var>, with an optional <i>suppress observers flag</i>, run these steps:
 
 <ol>
- <li><p>Let <var>count</var> be the number of <a>children</a> of <var>node</var> if it is a
- {{DocumentFragment}} <a>node</a>, and one otherwise.
+ <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a>, if <var>node</var> is a
+ {{DocumentFragment}} <a>node</a>; otherwise « <var>node</var> ».
+
+ <li><p>Let <var>count</var> be <var>nodes</var>'s <a for=set>size</a>.
+
+ <li><p>If <var>count</var> is 0, then return.
+
+ <li>
+  <p>If <var>node</var> is a {{DocumentFragment}} <a>node</a>, then:
+
+  <ol>
+   <li><p><a for=/>Remove</a> its <a>children</a> with the <i>suppress observers flag</i> set.
+
+   <li>
+    <p><a>queue a tree mutation record</a> for <var>node</var> with « », <var>nodes</var>, null, and
+    null.
+
+    <p class="note no-backref">This step intentionally does not pay attention to the
+    <i>suppress observers flag</i>.
+  </ol>
 
  <li>
   <p>If <var>child</var> is non-null, then:
@@ -2419,20 +2437,6 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
    <a for=range>end offset</a> is greater than <var>child</var>'s <a for=tree>index</a>, increase
    its <a for=range>end offset</a> by <var>count</var>.
   </ol>
-
- <li><p>Let <var>nodes</var> be <var>node</var>'s <a>children</a>, if <var>node</var> is a
- {{DocumentFragment}} <a>node</a>; otherwise « <var>node</var> ».
-
- <li><p>If <var>node</var> is a {{DocumentFragment}} <a>node</a>, then <a for=/>remove</a> its
- <a>children</a> with the <i>suppress observers flag</i> set.
-
- <li>
-  <p>If <var>node</var> is a {{DocumentFragment}} <a for=/>node</a>, then
-  <a>queue a tree mutation record</a> for <var>node</var> with « », <var>nodes</var>, null, and
-  null.
-
-  <p class="note no-backref">This step intentionally does not pay attention to the
-  <i>suppress observers flag</i>.
 
  <li><p>Let <var>previousSibling</var> be <var>child</var>'s <a>previous sibling</a> or
  <var>parent</var>'s <a>last child</a> if <var>child</var> is null.


### PR DESCRIPTION
Also clean up the language around DocumentFragment nodes in this algorithm a bit.

Tests: https://github.com/web-platform-tests/wpt/pull/20659.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/806.html" title="Last updated on Dec 6, 2019, 3:46 PM UTC (6d21b71)">Preview</a> | <a href="https://whatpr.org/dom/806/37d8475...6d21b71.html" title="Last updated on Dec 6, 2019, 3:46 PM UTC (6d21b71)">Diff</a>