### PR TITLE
Remove document.origin

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4747,7 +4747,6 @@ interface Document : Node {
   [SameObject] readonly attribute DOMImplementation implementation;
   readonly attribute USVString URL;
   readonly attribute USVString documentURI;
-  readonly attribute USVString origin;
   readonly attribute DOMString compatMode;
   readonly attribute DOMString characterSet;
   readonly attribute DOMString charset; // historical alias of .characterSet
@@ -4854,9 +4853,6 @@ null if <var>event</var>'s {{Event/type}} attribute value is "<code>load</code>"
  <dt><code><var>document</var> . {{Document/documentURI}}</code>
  <dd>Returns <var>document</var>'s <a for=Document>URL</a>.
 
- <dt><code><var>document</var> . {{Document/origin}}</code>
- <dd>Returns <var>document</var>'s <a for=Document>origin</a>.
-
  <dt><code><var>document</var> . {{Document/compatMode}}</code>
  <dd>
   Returns the string "<code>BackCompat</code>" if <var>document</var>'s
@@ -4886,10 +4882,6 @@ The
 The <dfn attribute for=Document><code>URL</code></dfn> attribute's getter and
 <dfn attribute for=Document><code>documentURI</code></dfn> attribute's getter must return the
 <a for=Document>URL</a>, <a lt="URL serializer" spec=url>serialized</a>.
-
-The <dfn attribute for=Document><code>origin</code></dfn> attribute's getter must return the
-<a lt="serialization of an origin">serialization</a> of <a>context object</a>'s
-<a for=Document>origin</a>.
 
 The <dfn attribute for=Document><code>compatMode</code></dfn> attribute's getter must
 return "<code>BackCompat</code>" if <a>context object</a>'s <a for=Document>mode</a> is


### PR DESCRIPTION
Use self.origin instead. (The document's origin internal concept is kept for now. Maybe at some point we can only use that of the relevant global object, but not now.)

Tests: ...

Closes #410.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/815.html" title="Last updated on Jan 2, 2020, 8:09 AM UTC (7e2469c)">Preview</a> | <a href="https://whatpr.org/dom/815/0913dac...7e2469c.html" title="Last updated on Jan 2, 2020, 8:09 AM UTC (7e2469c)">Diff</a>