### PR TITLE
Adoption and DocumentFragment, part two

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5329,8 +5329,8 @@ method steps are:
 algorithm is passed <var>node</var> and <var>oldDocument</var>, as indicated in the <a>adopt</a>
 algorithm.
 
-<p>To <dfn export id=concept-node-adopt>adopt</dfn> a <var>node</var> into a <var>document</var>, run
-these steps:
+<p>To <dfn export id=concept-node-adopt>adopt</dfn> a <var>node</var> into a <var>document</var>,
+with an optional <var>forceDocumentFragmentAdoption</var> (default false):
 
 <ol>
  <li><p>Let <var>oldDocument</var> be <var>node</var>'s <a for=Node>node document</a>.
@@ -5347,6 +5347,16 @@ these steps:
     <a>shadow-including inclusive descendants</a>:
 
     <ol>
+     <li>
+      <p>If <var>forceDocumentFragmentAdoption</var> is false, <var>inclusiveDescendant</var> is a
+      {{DocumentFragment}} <a for=/>node</a>, <var>inclusiveDescendant</var> is <var>node</var>, and
+      <var>node</var>'s <a for=DocumentFragment>host</a> is non-null, then
+      <a for=iteration>continue</a>.
+
+      <p class=note>This is only reasonable as long as all <a>adopt</a> callers remove the children
+      of <var>node</var>. HTML's <{template}> element passes true for
+      <var>forceDocumentFragmentAdoption</var>.
+
      <li><p>Set <var>inclusiveDescendant</var>'s <a for=Node>node document</a> to <var>document</var>.
 
      <li><p>If <var>inclusiveDescendant</var> is an <a for=/>element</a>, then set the
@@ -5374,6 +5384,12 @@ these steps:
 
  <li><p>If <var>node</var> is a <a for=/>shadow root</a>, then <a>throw</a> a
  "{{HierarchyRequestError!!exception}}" {{DOMException}}.
+
+ <li>
+  <p>If <var>node</var> is a {{DocumentFragment}} <a for=/>node</a> and its
+  <a for=DocumentFragment>host</a> is non-null, then return <var>node</var>.
+
+  <p class=note>Unfortunately this does not throw for web compatibility.
 
  <li><p><a>Adopt</a> <var>node</var> into <a>this</a>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -2509,6 +2509,8 @@ of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run the
  <li><p>If <var>referenceChild</var> is <var>node</var>, then set <var>referenceChild</var> to
  <var>node</var>'s <a for=tree>next sibling</a>.
 
+ <li><p><a>Adopt</a> <var>node</var> into <var>parent</var>'s <a for=Node>node document</a>.
+
  <li><p><a for=/>Insert</a> <var>node</var> into <var>parent</var> before <var>referenceChild</var>.
 
  <li><p>Return <var>node</var>.
@@ -2574,8 +2576,6 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   <p>For each <var>node</var> in <var>nodes</var>, in <a>tree order</a>:
 
   <ol>
-   <li><p><a>Adopt</a> <var>node</var> into <var>parent</var>'s <a for=Node>node document</a>.
-
    <li><p>If <var>child</var> is null, then <a for=set>append</a> <var>node</var> to
    <var>parent</var>'s <a for=tree>children</a>.
 
@@ -2689,6 +2689,8 @@ within a <var>parent</var>, run these steps:
 
  <li><p>Let <var>previousSibling</var> be <var>child</var>'s <a>previous sibling</a>.
 
+ <li><p><a>Adopt</a> <var>node</var> into <var>parent</var>'s <a for=Node>node document</a>.
+
  <li><p>Let <var>removedNodes</var> be the empty set.
 
  <li>
@@ -2721,6 +2723,9 @@ within a <var>parent</var>, run these steps:
 within a <var>parent</var>, run these steps:
 
 <ol>
+ <li><p>If <var>node</var> is non-null, then <a>adopt</a> <var>node</var> into <var>parent</var>'s
+ <a for=Node>node document</a>.
+
  <li><p>Let <var>removedNodes</var> be <var>parent</var>'s <a for=tree>children</a>.
 
  <li><p>Let <var>addedNodes</var> be the empty set.
@@ -5369,9 +5374,6 @@ these steps:
 
  <li><p>If <var>node</var> is a <a for=/>shadow root</a>, then <a>throw</a> a
  "{{HierarchyRequestError!!exception}}" {{DOMException}}.
-
- <li><p>If <var>node</var> is a {{DocumentFragment}} <a for=/>node</a> whose
- <a for=DocumentFragment>host</a> is non-null, then return.
 
  <li><p><a>Adopt</a> <var>node</var> into <a>this</a>.
 


### PR DESCRIPTION
This reverts commit c825ceaf3cb77943f487f85533d8be79bccd2fe3 and adds a new solution for `DocumentFragment` adoption on top. See #813 and #814 for context. 

HTML: https://github.com/whatwg/html/pull/5413

Tests: https://github.com/web-platform-tests/wpt/pull/22504

jsdom: https://github.com/jsdom/jsdom/pull/2925


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/819.html" title="Last updated on Oct 18, 2022, 9:21 AM UTC (7afc950)">Preview</a> | <a href="https://whatpr.org/dom/819/bf5f6c2...7afc950.html" title="Last updated on Oct 18, 2022, 9:21 AM UTC (7afc950)">Diff</a>