### PR TITLE
Editorial: add missing comma in "add an event listener" definition

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1146,7 +1146,7 @@ must return a new {{EventTarget}}.
 if this would be useful for your programs. For now, all author-created {{EventTarget}}s do not
 participate in a tree structure.</p>
 
-<p>To <dfn export>add an event listener</dfn> given an {{EventTarget}} object <var>eventTarget</var>
+<p>To <dfn export>add an event listener</dfn>, given an {{EventTarget}} object <var>eventTarget</var>
 and an <a>event listener</a> <var>listener</var>, run these steps:
 
 <ol>

--- a/dom.bs
+++ b/dom.bs
@@ -1146,8 +1146,8 @@ must return a new {{EventTarget}}.
 if this would be useful for your programs. For now, all author-created {{EventTarget}}s do not
 participate in a tree structure.</p>
 
-<p>To <dfn export>add an event listener</dfn>, given an {{EventTarget}} object <var>eventTarget</var>
-and an <a>event listener</a> <var>listener</var>, run these steps:
+<p>To <dfn export>add an event listener</dfn>, given an {{EventTarget}} object
+<var>eventTarget</var> and an <a>event listener</a> <var>listener</var>, run these steps:
 
 <ol>
  <li><p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object, its

--- a/dom.bs
+++ b/dom.bs
@@ -10007,9 +10007,9 @@ what it is today.
 <p>With that, many thanks to
 Adam Klein,
 Adrian Bateman,
-Aleksey Shvayka,
 Alex Komoroske,
 Alex Russell,
+Alexey Shvayka,
 Anthony Ramine,
 Arkadiusz Michalski,
 Arnaud Le Hors,


### PR DESCRIPTION
Fixes #788.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/820.html" title="Last updated on Jan 16, 2020, 2:04 PM UTC (2b7b081)">Preview</a> | <a href="https://whatpr.org/dom/820/55379a7...2b7b081.html" title="Last updated on Jan 16, 2020, 2:04 PM UTC (2b7b081)">Diff</a>