### PR TITLE
Avoid enqueuing tree mutation record when there is no mutation

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2416,7 +2416,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
    <li><p><a for=/>Remove</a> its <a>children</a> with the <i>suppress observers flag</i> set.
 
    <li>
-    <p><a>queue a tree mutation record</a> for <var>node</var> with « », <var>nodes</var>, null, and
+    <p><a>Queue a tree mutation record</a> for <var>node</var> with « », <var>nodes</var>, null, and
     null.
 
     <p class="note no-backref">This step intentionally does not pay attention to the

--- a/dom.bs
+++ b/dom.bs
@@ -2604,7 +2604,7 @@ within a <var>parent</var>, run these steps:
  <li><p>If <var>node</var> is non-null, then <a for=/>insert</a> <var>node</var> into
  <var>parent</var> before null with the <i>suppress observers flag</i> set.
 
- <li><p>If either <var>addedNodes</var> or <var>removedNodes</var> <a for=list>is not empty</a>,
+ <li><p>If either <var>addedNodes</var> or <var>removedNodes</var> <a for=set>is not empty</a>,
  then <a>queue a tree mutation record</a> for <var>parent</var> with <var>addedNodes</var>,
  <var>removedNodes</var>, null, and null.
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -3588,12 +3588,15 @@ run these steps:
 
 <p>To <dfn noexport>queue a tree mutation record</dfn> for <var>target</var> with
 <var>addedNodes</var>, <var>removedNodes</var>, <var>previousSibling</var>, and
-<var>nextSibling</var>, <a>queue a mutation record</a> of "<code>childList</code>" for
-<var>target</var> with null, null, null, <var>addedNodes</var>, <var>removedNodes</var>,
-<var>previousSibling</var>, and <var>nextSibling</var>.
+<var>nextSibling</var>, run these steps:
 
-<p class="note no-backref">Either <var>addedNodes</var> or <var>removedNodes</var>
-<a for=list>is not empty</a>.
+<ol>
+ <li><p>Assert: either <var>addedNodes</var> or <var>removedNodes</var> <a for=set>is not empty</a>.
+
+ <li><p><a>Queue a mutation record</a> of "<code>childList</code>" for <var>target</var> with
+ null, null, null, <var>addedNodes</var>, <var>removedNodes</var>, <var>previousSibling</var>,
+ and <var>nextSibling</var>.
+</ol>
 
 
 <h4 id=interface-mutationrecord>Interface {{MutationRecord}}</h4>

--- a/dom.bs
+++ b/dom.bs
@@ -2604,7 +2604,8 @@ within a <var>parent</var>, run these steps:
  <li><p>If <var>node</var> is non-null, then <a for=/>insert</a> <var>node</var> into
  <var>parent</var> before null with the <i>suppress observers flag</i> set.
 
- <li><p><a>Queue a tree mutation record</a> for <var>parent</var> with <var>addedNodes</var>,
+ <li><p>If either <var>addedNodes</var> or <var>removedNodes</var> <a for=list>is not empty</a>,
+ then <a>queue a tree mutation record</a> for <var>parent</var> with <var>addedNodes</var>,
  <var>removedNodes</var>, null, and null.
 </ol>
 
@@ -3590,6 +3591,9 @@ run these steps:
 <var>nextSibling</var>, <a>queue a mutation record</a> of "<code>childList</code>" for
 <var>target</var> with null, null, null, <var>addedNodes</var>, <var>removedNodes</var>,
 <var>previousSibling</var>, and <var>nextSibling</var>.
+
+<p class="note no-backref">Either <var>addedNodes</var> or <var>removedNodes</var>
+<a for=list>is not empty</a>.
 
 
 <h4 id=interface-mutationrecord>Interface {{MutationRecord}}</h4>


### PR DESCRIPTION
Fixes #796.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/822.html" title="Last updated on Jan 22, 2020, 3:23 PM UTC (de10bc3)">Preview</a> | <a href="https://whatpr.org/dom/822/55379a7...de10bc3.html" title="Last updated on Jan 22, 2020, 3:23 PM UTC (de10bc3)">Diff</a>