### PR TITLE
Editorial: make type of {added,removed}Nodes consistent

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2555,7 +2555,7 @@ within a <var>parent</var>, run these steps:
 
  <li><p>Let <var>previousSibling</var> be <var>child</var>'s <a>previous sibling</a>.
 
- <li><p>Let <var>removedNodes</var> be the empty list.
+ <li><p>Let <var>removedNodes</var> be the empty set.
 
  <li>
   <p>If <var>child</var>'s <a for=tree>parent</a> is non-null, then:
@@ -2589,7 +2589,7 @@ within a <var>parent</var>, run these steps:
 <ol>
  <li><p>Let <var>removedNodes</var> be <var>parent</var>'s <a>children</a>.
 
- <li><p>Let <var>addedNodes</var> be the empty list.
+ <li><p>Let <var>addedNodes</var> be the empty set.
 
  <li><p>If <var>node</var> is {{DocumentFragment}} <a>node</a>, then set <var>addedNodes</var> to
  <var>node</var>'s <a>children</a>.


### PR DESCRIPTION
In [**replace all**](https://dom.spec.whatwg.org/#concept-node-replace-all), `addedNodes` is either a _list_ (step 2) or a _set_ (step 3).

In [**replace**](https://dom.spec.whatwg.org/#concept-node-replace), `removedNodes` has only one element and can be safely changed to a _set_ to match type of `removedNodes` in [**replace all**](https://dom.spec.whatwg.org/#concept-node-replace-all) and [**insert**](https://dom.spec.whatwg.org/#concept-node-insert).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/823.html" title="Last updated on Jan 22, 2020, 3:05 PM UTC (8f1c413)">Preview</a> | <a href="https://whatpr.org/dom/823/86e53d5...8f1c413.html" title="Last updated on Jan 22, 2020, 3:05 PM UTC (8f1c413)">Diff</a>