### PR TITLE
Avoid enqueuing "disconnectedCallback" on detached custom elements

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2681,8 +2681,10 @@ indicated in the <a for=/>remove</a> algorithm below.
 
  <li><p>Run the <a>removing steps</a> with <var>node</var> and <var>parent</var>.
 
+ <li><p>Let <var>isParentConnected</var> be <var>parent</var>'s <a>connected</a>.
+
  <li>
-  <p>If <var>node</var> is <a for=Element>custom</a>, then
+  <p>If <var>node</var> is <a for=Element>custom</a> and <var>isParentConnected</var> is true, then
   <a>enqueue a custom element callback reaction</a> with <var>node</var>, callback name
   "<code>disconnectedCallback</code>", and an empty argument list.
 
@@ -2696,9 +2698,9 @@ indicated in the <a for=/>remove</a> algorithm below.
   <ol>
    <li><p>Run the <a>removing steps</a> with <var>descendant</var>.
 
-   <li><p>If <var>descendant</var> is <a for=Element>custom</a>, then
-   <a>enqueue a custom element callback reaction</a> with <var>descendant</var>, callback name
-   "<code>disconnectedCallback</code>", and an empty argument list.
+   <li><p>If <var>descendant</var> is <a for=Element>custom</a> and <var>isParentConnected</var>
+   is true, then <a>enqueue a custom element callback reaction</a> with <var>descendant</var>,
+   callback name "<code>disconnectedCallback</code>", and an empty argument list.
   </ol>
  </li>
 


### PR DESCRIPTION
Fixes #773.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/827.html" title="Last updated on Feb 3, 2020, 12:43 AM UTC (09213bf)">Preview</a> | <a href="https://whatpr.org/dom/827/e15774f...09213bf.html" title="Last updated on Feb 3, 2020, 12:43 AM UTC (09213bf)">Diff</a>