### PR TITLE
Specify `ParentNode.replaceChildren` implementation.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2896,7 +2896,7 @@ must run these steps:
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
  <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
- <li><a for=Node>Replace all</a> <a>children</a> of <a>this</a> with <var>node</var>.
+ <li><p><a for=Node>Replace all</a> <a>children</a> of <a>this</a> with <var>node</var>.
 </ol>
 
 <p>The <dfn method for=ParentNode><code>querySelector(<var>selectors</var>)</code></dfn> method,

--- a/dom.bs
+++ b/dom.bs
@@ -2793,6 +2793,7 @@ interface mixin ParentNode {
 
   [CEReactions, Unscopable] void prepend((Node or DOMString)... nodes);
   [CEReactions, Unscopable] void append((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] void replaceChildren((Node or DOMString)... nodes);
 
   Element? querySelector(DOMString selectors);
   [NewObject] NodeList querySelectorAll(DOMString selectors);
@@ -2827,6 +2828,15 @@ Element includes ParentNode;
  <dd>
   <p>Inserts <var>nodes</var> after the <a>last child</a> of <var>node</var>, while replacing
   strings in <var>nodes</var> with equivalent {{Text}} <a for=/>nodes</a>.
+
+  <p><a>Throws</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of
+  the <a>node tree</a> are violated.
+  <!-- "NotFoundError" is impossible -->
+
+ <dt><code><var>node</var> . <a method for=ParentNode lt="replaceChildren()">replaceChildren</a>(<var>nodes</var>)</code>
+ <dd>
+  <p><a for=Node>Replace all</a> <a>children</a> of <var>node</var> with <var>nodes</var>,
+  while replacing strings in <var>nodes</var> with equivalent {{Text}} <a for=/>nodes</a>.
 
   <p><a>Throws</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}} if the constraints of
   the <a>node tree</a> are violated.
@@ -2877,6 +2887,16 @@ must run these steps:
  <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
  <li><p><a>Append</a> <var>node</var> to <a>this</a>.
+</ol>
+
+<p>The <dfn method for=ParentNode><code>replaceChildren(<var>nodes</var>)</code></dfn> method, when invoked,
+must run these steps:
+
+<ol>
+ <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
+ <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
+
+ <li><a for=Node>Replace all</a> <a>children</a> of <a>this</a> with <var>node</var>.
 </ol>
 
 <p>The <dfn method for=ParentNode><code>querySelector(<var>selectors</var>)</code></dfn> method,


### PR DESCRIPTION
## Issue
  - whatwg/dom/#478

## Implementation
  - whatwg/dom#835

## WPT Platform Tests
  - https://github.com/web-platform-tests/wpt/pull/21810

## Bug Trackers
   - [🐛Webkit `198578`](https://bugs.webkit.org/show_bug.cgi?id=198578)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/835.html" title="Last updated on Feb 18, 2020, 2:12 AM UTC (51fa48f)">Preview</a> | <a href="https://whatpr.org/dom/835/b4e91f5...51fa48f.html" title="Last updated on Feb 18, 2020, 2:12 AM UTC (51fa48f)">Diff</a>