### PR TITLE
Editorial: slotable ➡️ slottable

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5,6 +5,7 @@ Shortname: dom
 Text Macro: TWITTER thedomstandard
 Abstract: DOM defines a platform-neutral model for events, aborting activities, and node trees.
 Translation: ja https://triple-underscore.github.io/DOM4-ja.html
+Translate IDs: slottable slotable
 Ignored Terms: EmptyString, Array, Document
 Indent: 1
 </pre>
@@ -1304,8 +1305,8 @@ for discussion).
    <a for=EventTarget>activation behavior</a>, then set <var>activationTarget</var> to
    <var>target</var>.
 
-   <li><p>Let <var>slotable</var> be <var>target</var>, if <var>target</var> is a <a>slotable</a>
-   and is <a for=slotable>assigned</a>, and null otherwise.
+   <li><p>Let <var>slottable</var> be <var>target</var>, if <var>target</var> is a <a>slottable</a>
+   and is <a for=slottable>assigned</a>, and null otherwise.
 
    <li><p>Let <var>slot-in-closed-tree</var> be false.
 
@@ -1317,20 +1318,20 @@ for discussion).
 
     <ol>
      <li>
-      <p>If <var>slotable</var> is non-null:
+      <p>If <var>slottable</var> is non-null:
 
       <ol>
        <li><p>Assert: <var>parent</var> is a <a for=/>slot</a>.
 
-       <li><p>Set <var>slotable</var> to null.
+       <li><p>Set <var>slottable</var> to null.
 
        <li><p>If <var>parent</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a> whose
        <a for=ShadowRoot>mode</a> is "<code>closed</code>", then set <var>slot-in-closed-tree</var>
        to true.
       </ol>
 
-     <li><p>If <var>parent</var> is a <a>slotable</a> and is <a for=slotable>assigned</a>, then set
-     <var>slotable</var> to <var>parent</var>.
+     <li><p>If <var>parent</var> is a <a>slottable</a> and is <a for=slottable>assigned</a>, then
+     set <var>slottable</var> to <var>parent</var>.
 
      <li><p>Let <var>relatedTarget</var> be the result of <a>retargeting</a> <var>event</var>'s
      <a for=Event>relatedTarget</a> against <var>parent</var>.
@@ -2126,7 +2127,7 @@ otherwise it is the empty string.</p>
 
    <li><p>Otherwise, set <var>element</var>'s <a for=slot>name</a> to <var>value</var>.
 
-   <li><p>Run <a>assign slotables for a tree</a> with <var>element</var>'s <a for=tree>root</a>.
+   <li><p>Run <a>assign slottables for a tree</a> with <var>element</var>'s <a for=tree>root</a>.
   </ol>
 </ol>
 
@@ -2134,19 +2135,19 @@ otherwise it is the empty string.</p>
 <a for=slot>name</a> is the empty string, is sometimes known as the "default slot".</p>
 
 <p>A <a>slot</a> has an associated <dfn export for=slot>assigned nodes</dfn> (a list of
-<a>slotables</a>). Unless stated otherwise it is empty.</p>
+<a>slottables</a>). Unless stated otherwise it is empty.</p>
 
-<h5 id=light-tree-slotables>Slotables</h5>
+<h5 id=light-tree-slotables>Slottables</h5>
 
 <p>{{Element}} and {{Text}} <a for=/>nodes</a> are
-<dfn export id=concept-slotable lt=slotable>slotables</dfn>.</p>
+<dfn export id=concept-slotable lt=slottable>slottables</dfn>.</p>
 
-<p class="note">A <a>slot</a> can be a <a>slotable</a>.
+<p class="note">A <a>slot</a> can be a <a>slottable</a>.
 
-<p>A <a>slotable</a> has an associated <dfn export for=slotable>name</dfn> (a string). Unless stated
-otherwise it is the empty string.</p>
+<p>A <a>slottable</a> has an associated <dfn export for=slottable id=slotable-name>name</dfn> (a
+string). Unless stated otherwise it is the empty string.</p>
 
-<p>Use these <a>attribute change steps</a> to update a <a>slotable</a>'s <a for=slotable>name</a>:
+<p>Use these <a>attribute change steps</a> to update a <a>slottable</a>'s <a for=slottable>name</a>:
 
 <ol>
  <li>
@@ -2160,31 +2161,33 @@ otherwise it is the empty string.</p>
    <li><p>If <var>value</var> is the empty string and <var>oldValue</var> is null, then return.
 
    <li><p>If <var>value</var> is null or the empty string, then set <var>element</var>'s
-   <a for=slotable>name</a> to the empty string.
+   <a for=slottable>name</a> to the empty string.
 
-   <li><p>Otherwise, set <var>element</var>'s <a for=slotable>name</a> to <var>value</var>.
+   <li><p>Otherwise, set <var>element</var>'s <a for=slottable>name</a> to <var>value</var>.
 
-   <li><p>If <var>element</var> is <a for=slotable>assigned</a>, then run <a>assign slotables</a>
-   for <var>element</var>'s <a for=slotable>assigned slot</a>.
+   <li><p>If <var>element</var> is <a for=slottable>assigned</a>, then run <a>assign slottables</a>
+   for <var>element</var>'s <a for=slottable>assigned slot</a>.
 
    <li><p>Run <a>assign a slot</a> for <var>element</var>.
   </ol>
 </ol>
 
-<p>A <a>slotable</a> has an associated <dfn export for=slotable>assigned slot</dfn> (null or a
-<a>slot</a>). Unless stated otherwise it is null. A <a>slotable</a> is
-<dfn export for=slotable>assigned</dfn> if its <a>assigned slot</a> is non-null.</p>
+<p>A <a>slottable</a> has an associated
+<dfn export for=slottable id=slotable-assigned-slot>assigned slot</dfn> (null or a <a>slot</a>).
+Unless stated otherwise it is null. A <a>slottable</a> is
+<dfn export for=slottable id=slotable-assigned>assigned</dfn> if its <a>assigned slot</a> is
+non-null.</p>
 
-<h5 id=finding-slots-and-slotables>Finding slots and slotables</h5>
+<h5 id=finding-slots-and-slotables>Finding slots and slottables</h5>
 
-<p>To <dfn export lt="find a slot|finding a slot">find a slot</dfn> for a given <a>slotable</a>
-<var>slotable</var> and an optional <i>open flag</i> (unset unless stated otherwise), run these
+<p>To <dfn export lt="find a slot|finding a slot">find a slot</dfn> for a given <a>slottable</a>
+<var>slottable</var> and an optional <i>open flag</i> (unset unless stated otherwise), run these
 steps:</p>
 
 <ol>
- <li><p>If <var>slotable</var>'s <a for=tree>parent</a> is null, then return null.</p></li>
+ <li><p>If <var>slottable</var>'s <a for=tree>parent</a> is null, then return null.</p></li>
 
- <li><p>Let <var>shadow</var> be <var>slotable</var>'s <a for=tree>parent</a>'s
+ <li><p>Let <var>shadow</var> be <var>slottable</var>'s <a for=tree>parent</a>'s
  <a for=Element>shadow root</a>.</p></li>
 
  <li><p>If <var>shadow</var> is null, then return null.</p></li>
@@ -2193,12 +2196,12 @@ steps:</p>
  <em>not</em> "<code>open</code>", then return null.</p></li>
 
  <li><p>Return the first <a>slot</a> in <a>tree order</a> in <var>shadow</var>'s
- <a for=tree>descendants</a> whose <a for=slot>name</a> is <var>slotable</var>'s
- <a for=slotable>name</a>, if any, and null otherwise.</p></li>
+ <a for=tree>descendants</a> whose <a for=slot>name</a> is <var>slottable</var>'s
+ <a for=slottable>name</a>, if any, and null otherwise.</p></li>
 </ol>
 
-<p>To <dfn export lt="find slotables|finding slotables">find slotables</dfn> for a given <a>slot</a>
-<var>slot</var>, run these steps:</p>
+<p>To <dfn export lt="find slottables|finding slottables" id=find-slotables>find slottables</dfn>
+for a given <a>slot</a> <var>slot</var>, run these steps:</p>
 
 <ol>
  <li><p>Let <var>result</var> be an empty list.</p></li>
@@ -2210,14 +2213,14 @@ steps:</p>
  <a for=DocumentFragment>host</a>.</p></li>
 
  <li>
-  <p>For each <a>slotable</a> <a for=tree>child</a> of <var>host</var>, <var>slotable</var>, in
+  <p>For each <a>slottable</a> <a for=tree>child</a> of <var>host</var>, <var>slottable</var>, in
   <a>tree order</a>:</p>
 
   <ol>
    <li><p>Let <var>foundSlot</var> be the result of <a>finding a slot</a> given
-   <var>slotable</var>.</p></li>
+   <var>slottable</var>.</p></li>
 
-   <li><p>If <var>foundSlot</var> is <var>slot</var>, then append <var>slotable</var> to
+   <li><p>If <var>foundSlot</var> is <var>slot</var>, then append <var>slottable</var> to
    <var>result</var>.</p></li>
   </ol>
  </li>
@@ -2226,7 +2229,7 @@ steps:</p>
 </ol>
 
 <p>To
-<dfn export lt="find flattened slotables|finding flattened slotables">find flattened slotables</dfn>
+<dfn export lt="find flattened slottables|finding flattened slottables" id=find-flattened-slotables>find flattened slottables</dfn>
 for a given <a>slot</a> <var>slot</var>, run these steps:</p>
 
 <ol>
@@ -2235,14 +2238,14 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
  <li><p>If <var>slot</var>'s <a for=tree>root</a> is not a <a for=/>shadow root</a>, then return
  <var>result</var>.</p></li>
 
- <li><p>Let <var>slotables</var> be the result of <a>finding slotables</a> given
+ <li><p>Let <var>slottables</var> be the result of <a>finding slottables</a> given
  <var>slot</var>.</p></li>
 
- <li><p>If <var>slotables</var> is the empty list, then append each <a>slotable</a>
- <a for=tree>child</a> of <var>slot</var>, in <a>tree order</a>, to <var>slotables</var>.</p></li>
+ <li><p>If <var>slottables</var> is the empty list, then append each <a>slottable</a>
+ <a for=tree>child</a> of <var>slot</var>, in <a>tree order</a>, to <var>slottables</var>.</p></li>
 
  <li>
-  <p>For each <var>node</var> in <var>slotables</var>:
+  <p>For each <var>node</var> in <var>slottables</var>:
 
   <ol>
    <li>
@@ -2250,10 +2253,10 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
     then:
 
     <ol>
-     <li><p>Let <var>temporaryResult</var> be the result of <a>finding flattened slotables</a> given
+     <li><p>Let <var>temporaryResult</var> be the result of <a>finding flattened slottables</a> given
      <var>node</var>.</p></li>
 
-     <li><p>Append each <a>slotable</a> in <var>temporaryResult</var>, in order, to
+     <li><p>Append each <a>slottable</a> in <var>temporaryResult</var>, in order, to
      <var>result</var>.</p></li>
     </ol>
 
@@ -2264,33 +2267,34 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
  <li><p>Return <var>result</var>.</p></li>
 </ol>
 
-<h5 id=assigning-slotables-and-slots>Assigning slotables and slots</h5>
+<h5 id=assigning-slotables-and-slots>Assigning slottables and slots</h5>
 
-<p>To <dfn noexport>assign slotables</dfn> for a <a>slot</a> <var>slot</var>, run these steps:
+<p>To <dfn noexport id=assign-slotables>assign slottables</dfn> for a <a>slot</a> <var>slot</var>,
+run these steps:
 
 <ol>
- <li><p>Let <var>slotables</var> be the result of <a>finding slotables</a> for <var>slot</var>.
+ <li><p>Let <var>slottables</var> be the result of <a>finding slottables</a> for <var>slot</var>.
 
- <li><p>If <var>slotables</var> and <var>slot</var>'s <a for=slot>assigned nodes</a> are not
+ <li><p>If <var>slottables</var> and <var>slot</var>'s <a for=slot>assigned nodes</a> are not
  identical, then run <a>signal a slot change</a> for <var>slot</var>.
 
- <li><p>Set <var>slot</var>'s <a for=slot>assigned nodes</a> to <var>slotables</var>.
+ <li><p>Set <var>slot</var>'s <a for=slot>assigned nodes</a> to <var>slottables</var>.
 
- <li><p>For each <var>slotable</var> in <var>slotables</var>, set <var>slotable</var>'s
+ <li><p>For each <var>slottable</var> in <var>slottables</var>, set <var>slottable</var>'s
  <a>assigned slot</a> to <var>slot</var>.
 </ol>
 
-<p>To <dfn noexport>assign slotables for a tree</dfn>, given a <a for=/>node</a>
-<var>root</var>, run <a>assign slotables</a> for each <a>slot</a> <var>slot</var> in
-<var>root</var>'s <a for=tree>inclusive descendants</a>, in <a>tree order</a>.
+<p>To <dfn noexport id=assign-slotables-for-a-tree>assign slottables for a tree</dfn>, given a
+<a for=/>node</a> <var>root</var>, run <a>assign slottables</a> for each <a>slot</a> <var>slot</var>
+in <var>root</var>'s <a for=tree>inclusive descendants</a>, in <a>tree order</a>.
 
-<p>To <dfn noexport>assign a slot</dfn>, given a <a>slotable</a> <var>slotable</var>, run these
+<p>To <dfn noexport>assign a slot</dfn>, given a <a>slottable</a> <var>slottable</var>, run these
 steps:
 
 <ol>
- <li><p>Let <var>slot</var> be the result of <a>finding a slot</a> with <var>slotable</var>.
+ <li><p>Let <var>slot</var> be the result of <a>finding a slot</a> with <var>slottable</var>.
 
- <li><p>If <var>slot</var> is non-null, then run <a>assign slotables</a> for <var>slot</var>.
+ <li><p>If <var>slot</var> is non-null, then run <a>assign slottables</a> for <var>slot</var>.
 </ol>
 
 <h5 id=signaling-slot-change>Signaling slot change</h5>
@@ -2447,13 +2451,13 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
    <a for=tree>children</a> before <var>child</var>'s <a for=tree>index</a>.
 
    <li><p>If <var>parent</var> is a <a for=Element>shadow host</a> and <var>node</var> is a
-   <a>slotable</a>, then <a>assign a slot</a> for <var>node</var>.
+   <a>slottable</a>, then <a>assign a slot</a> for <var>node</var>.
 
    <li><p>If <var>parent</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a>, and
    <var>parent</var> is a <a>slot</a> whose <a for=slot>assigned nodes</a> is the empty list,
    then run <a>signal a slot change</a> for <var>parent</var>.
 
-   <li><p>Run <a>assign slotables for a tree</a> with <var>node</var>'s <a for=tree>root</a>.
+   <li><p>Run <a>assign slottables for a tree</a> with <var>node</var>'s <a for=tree>root</a>.
 
    <li>
     <p>For each <a>shadow-including inclusive descendant</a> <var>inclusiveDescendant</var> of
@@ -2663,7 +2667,7 @@ indicated in the <a for=/>remove</a> algorithm below.
 
  <li><p><a for=set>Remove</a> <var>node</var> from its <var>parent</var>'s <a for=tree>children</a>.
 
- <li><p>If <var>node</var> is <a for=slotable>assigned</a>, then run <a>assign slotables</a> for
+ <li><p>If <var>node</var> is <a for=slottable>assigned</a>, then run <a>assign slottables</a> for
  <var>node</var>'s <a>assigned slot</a>.
 
  <li><p>If <var>parent</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a>, and
@@ -2674,9 +2678,9 @@ indicated in the <a for=/>remove</a> algorithm below.
   <p>If <var>node</var> has an <a>inclusive descendant</a> that is a <a>slot</a>, then:
 
   <ol>
-   <li><p>Run <a>assign slotables for a tree</a> with <var>parent</var>'s <a for=tree>root</a>.
+   <li><p>Run <a>assign slottables for a tree</a> with <var>parent</var>'s <a for=tree>root</a>.
 
-   <li><p>Run <a>assign slotables for a tree</a> with <var>node</var>.
+   <li><p>Run <a>assign slottables for a tree</a> with <var>node</var>.
   </ol>
 
  <li><p>Run the <a>removing steps</a> with <var>node</var> and <var>parent</var>.
@@ -3043,18 +3047,19 @@ steps:
 </ol>
 
 
-<h4 id=mixin-slotable>Mixin {{Slotable}}</h4>
+<h4 id=mixin-slotable>Mixin {{Slottable}}</h4>
 
 <pre class=idl>
-interface mixin Slotable {
+interface mixin Slottable {
   readonly attribute HTMLSlotElement? assignedSlot;
 };
-Element includes Slotable;
-Text includes Slotable;
+Element includes Slottable;
+Text includes Slottable;
 </pre>
 
-<p>The <dfn attribute for=Slotable><code>assignedSlot</code></dfn> attribute's getter must return
-the result of <a>find a slot</a> given <a>this</a> and with the <i>open flag</i> set.</p>
+<p>The <dfn attribute for=Slottable id=dom-slotable-assignedslot><code>assignedSlot</code></dfn>
+attribute's getter must return the result of <a>find a slot</a> given <a>this</a> and with the
+<i>open flag</i> set.</p>
 
 
 <h4 id=old-style-collections>Old-style collections: {{NodeList}} and {{HTMLCollection}}</h4>


### PR DESCRIPTION
While preserving IDs. Closes #844.

(This also requires a corresponding change to HTML.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/845.html" title="Last updated on Mar 11, 2020, 9:08 AM UTC (3026fbe)">Preview</a> | <a href="https://whatpr.org/dom/845/b4e91f5...3026fbe.html" title="Last updated on Mar 11, 2020, 9:08 AM UTC (3026fbe)">Diff</a>