### PR TITLE
Align with Web IDL extended attribute changes

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -451,7 +451,7 @@ interface Event {
   readonly attribute boolean defaultPrevented;
   readonly attribute boolean composed;
 
-  [Unforgeable] readonly attribute boolean isTrusted;
+  [LegacyUnforgeable] readonly attribute boolean isTrusted;
   readonly attribute DOMHighResTimeStamp timeStamp;
 
   void initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false); // historical
@@ -5464,7 +5464,7 @@ with that <a>document</a>.
 [Exposed=Window]
 interface DOMImplementation {
   [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
-  [NewObject] XMLDocument createDocument(DOMString? namespace, [TreatNullAs=EmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
+  [NewObject] XMLDocument createDocument(DOMString? namespace, [LegacyNullToEmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
   [NewObject] Document createHTMLDocument(optional DOMString title);
 
   boolean hasFeature(); // useless; always returns true
@@ -7068,7 +7068,7 @@ string <var>value</var>, run these steps:
 <pre class=idl>
 [Exposed=Window]
 interface CharacterData : Node {
-  attribute [TreatNullAs=EmptyString] DOMString data;
+  attribute [LegacyNullToEmptyString] DOMString data;
   readonly attribute unsigned long length;
   DOMString substringData(unsigned long offset, unsigned long count);
   void appendData(DOMString data);


### PR DESCRIPTION
[TreatNullAs=EmptyString] → [LegacyNullToEmptyString] and [Unforgeable] →
[LegacyUnforgeable]. Follows https://github.com/heycam/webidl/pull/870.

This should be merged after that, plus a day or so for the linking database to pick up the new name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/856.html" title="Last updated on Apr 8, 2020, 9:42 PM UTC (c4fb6e5)">Preview</a> | <a href="https://whatpr.org/dom/856/61834f7...c4fb6e5.html" title="Last updated on Apr 8, 2020, 9:42 PM UTC (c4fb6e5)">Diff</a>