### PR TITLE
Add declarative Shadow DOM features

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5727,6 +5727,9 @@ or "<code>closed</code>").</p>
 <p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>delegates focus</dfn>.
 It is initially set to false.</p>
 
+<p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>is declarative shadow root</dfn>.
+It is initially set to false.</p>
+
 <p><a for=/>Shadow roots</a>'s associated <a for=DocumentFragment>host</a> is never null.</p>
 <!-- If we ever change this, e.g., add a ShadowRoot object constructor, that would have serious
      consequences for innerHTML. -->
@@ -6750,6 +6753,8 @@ invoked, must run these steps:
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
  {{ShadowRootInit/delegatesFocus}}.
+
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>is declarative shadow root</a> to false.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 
@@ -10133,6 +10138,7 @@ Manish Tripathi,
 Marcos Caceres,
 Mark Miller,
 Martijn van der Ven,
+Mason Freed,  <!-- mfreed7 on GitHub -->
 Mats Palmgren,
 Mounir Lamouri,
 Michael Stramel,

--- a/dom.bs
+++ b/dom.bs
@@ -4232,8 +4232,8 @@ elements. SVG ought to do the same for its <{script}> elements, but does not cal
 at the moment.
 
 <p>To <dfn export id=concept-node-clone lt="clone a node" local-lt="clone">clone</dfn> a
-<var>node</var>, with an optional <var>document</var> and <i>clone children flag</i>, run these
-steps:
+<var>node</var>, with an optional <var>document</var>, <i>clone children flag</i>, and
+<i>clone shadows flag</i>, run these steps:
 <!-- This algorithm is used by dom-Node-cloneNode, dom-Document-importNode,
 dom-Range-extractContents, dom-Range-cloneContents -->
 
@@ -4307,6 +4307,22 @@ dom-Range-extractContents, dom-Range-cloneContents -->
  <a>children</a> of <var>node</var> and append them to <var>copy</var>, with
  <var>document</var> as specified and the <i>clone children flag</i> being set.
 
+ <li>If the <i>clone shadows flag</i> is set, run these steps:
+
+ <ol>
+   <li><p>Run <a>attach a shadow root</a> with <var>shadow host</var> equal to <var>copy</var>,
+ <var>mode</var> equal to <var>node</var>'s <a for=/>shadow root</a>'s <a for=ShadowRoot>mode</a>, and <var>delegates focus</var>
+ equal to <var>node</var>'s <a for=/>shadow root</a>'s <a>delegates focus</a>.</p></li>
+
+   <li><p>If <var>node</var>'s <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> is true, then
+   set <var>copy</var>'s <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> property to true.</p></li>
+
+   <li>If the <i>clone children flag</i> is set, <a lt="clone a node">clone</a> all the
+   <a>children</a> of <var>node</var>'s <a for=/>shadow root</a> and append them to <var>copy</var>'s <a for=/>shadow root</a>, with
+   <var>document</var> as specified and the <i>clone children flag</i> being set. 
+
+ </ol>
+
  <li>Return <var>copy</var>.
 </ol>
 
@@ -4317,9 +4333,17 @@ invoked, must run these steps:
  <li><p>If <a>this</a> is a <a for=/>shadow root</a>, then <a>throw</a> a
  "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>Return a <a lt="clone a node">clone</a> of <a>this</a>, with the
- <i>clone children flag</i> set if <var>deep</var> is true.
+ <li><p>Let <i>shouldCloneShadows</i> be true if <a>this</a> is a <a for=Element>shadow host</a>
+ whose <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> property is true,
+ and false otherwise.
+
+ <li><p>Let <i>clonedNode</i> equal a <a lt="clone a node">clone</a> of <a>this</a>, with the
+ <i>clone children flag</i> set if <var>deep</var> is true, and <i>clone shadows flag</i> set to
+ <i>shouldCloneShadows</i>.
+
 </ol>
+
+
 
 A <a>node</a> <var>A</var>
 <dfn export for=Node id=concept-node-equals>equals</dfn> a <a>node</a>
@@ -6906,7 +6930,9 @@ for <a>this</a>.
 <p>The
 <dfn method for=Element><code>getInnerHTML(<var>options</var>)</code></dfn>
 method, when invoked, must return the result of running
-<a href="https://www.w3.org/TR/html5/single-page.html#html-fragment-serialisation-algorithm">fragment serialization algorithm</a>, given <a>this</a> as <var>the node</var> and <var>options.includeShadowRoots</var> as <var>include shadow roots</var>.
+<a href="https://www.w3.org/TR/html5/single-page.html#html-fragment-serialisation-algorithm">fragment
+serialization algorithm</a>, given <a>this</a> as <var>node</var> and <i>options.includeShadowRoots</i>
+as <i>include shadow roots</i>.
 
 <p>The
 <dfn method for=Element><code>insertAdjacentElement(<var>where</var>, <var>element</var>)</code></dfn>

--- a/dom.bs
+++ b/dom.bs
@@ -4335,7 +4335,8 @@ invoked, must run these steps:
 
  <li><p>Return a <a lt="clone a node">clone</a> of <a>this</a>, with the
  <i>clone children flag</i> set if <var>deep</var> is true, and the
- <i>clone shadows flag</i> set if <a>this</a> is a {{DocumentFragment}}.
+ <i>clone shadows flag</i> set if <a>this</a> is a {{DocumentFragment}} whose
+ <a for=DocumentFragment>host</a> is an HTML <{template}> element.
 
 </ol>
 

--- a/dom.bs
+++ b/dom.bs
@@ -5867,6 +5867,8 @@ interface Element : Node {
   HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
   HTMLCollection getElementsByClassName(DOMString classNames);
 
+  DOMString getInnerHTML(GetInnerHTMLOptions options);
+
   [CEReactions] Element? insertAdjacentElement(DOMString where, Element element); // historical
   void insertAdjacentText(DOMString where, DOMString data); // historical
 };
@@ -5874,6 +5876,10 @@ interface Element : Node {
 dictionary ShadowRootInit {
   required ShadowRootMode mode;
   boolean delegatesFocus = false;
+};
+
+dictionary GetInnerHTMLOptions {
+  boolean includeShadowRoots = true;
 };
 </pre>
 
@@ -6883,8 +6889,13 @@ for <a>this</a>.
 </dl>
 
 <p>The
+<dfn method for=Element><code>getInnerHTML(<var>options</var>)</code></dfn>
+method, when invoked, must return the result of running
+<a href="https://www.w3.org/TR/html5/single-page.html#html-fragment-serialisation-algorithm">fragment serialization algorithm</a>, given <a>this</a> as <var>the node</var> and <var>options.includeShadowRoots</var> as <var>include shadow roots</var>.
+
+<p>The
 <dfn method for=Element><code>insertAdjacentElement(<var>where</var>, <var>element</var>)</code></dfn>
-method, when invoked, must return the result of running <a>insert adjacent</a>, give <a>this</a>,
+method, when invoked, must return the result of running <a>insert adjacent</a>, given <a>this</a>,
 <var>where</var>, and <var>element</var>.
 
 <p>The

--- a/dom.bs
+++ b/dom.bs
@@ -4333,9 +4333,9 @@ invoked, must run these steps:
  <li><p>If <a>this</a> is a <a for=/>shadow root</a>, then <a>throw</a> a
  "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>Let <i>clonedNode</i> equal a <a lt="clone a node">clone</a> of <a>this</a>, with the
- <i>clone children flag</i> set if <var>deep</var> is true, and the <i>clone shadows flag</i>
- set if <a>this</a> is a {{DocumentFragment}}.
+ <li><p>Return a <a lt="clone a node">clone</a> of <a>this</a>, with the
+ <i>clone children flag</i> set if <var>deep</var> is true, and the
+ <i>clone shadows flag</i> set if <a>this</a> is a {{DocumentFragment}}.
 
 </ol>
 

--- a/dom.bs
+++ b/dom.bs
@@ -6782,7 +6782,7 @@ steps:
  <a for=ShadowRoot>is declarative shadow root</a> property is true, then <a for=/>remove</a> all of
  <a for=/>shadow root</a>'s <a>children</a>, in <a>tree order</a>. Return <var>shadow host</var>'s <a for=/>shadow root</a>.
 
- <p class="note">This means that if multiple <a href="https://html.spec.whatwg.org/#concept-declarative-shadow-root">declarative shadow root</a>s are contained within a single shadow host,
+ <p class="note">This means that if multiple declarative shadow roots are contained within a single shadow host,
  only the last one will remain.
 
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>

--- a/dom.bs
+++ b/dom.bs
@@ -4307,7 +4307,7 @@ dom-Range-extractContents, dom-Range-cloneContents -->
  <a>children</a> of <var>node</var> and append them to <var>copy</var>, with
  <var>document</var> as specified and the <i>clone children flag</i> being set.
 
- <li>If the <i>clone shadows flag</i> is set, run these steps:
+ <li>If <var>node</var> is a <a for=Element>shadow host</a> and the <i>clone shadows flag</i> is set, run these steps:
 
  <ol>
    <li><p>Run <a>attach a shadow root</a> with <var>shadow host</var> equal to <var>copy</var>,
@@ -4333,13 +4333,9 @@ invoked, must run these steps:
  <li><p>If <a>this</a> is a <a for=/>shadow root</a>, then <a>throw</a> a
  "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>If <a>this</a> has a non-null <a for=DocumentFragment>host</a>, but <a>this</a> is not
- a <a for=Element>shadow host</a>, then set <i>shouldCloneShadows</i> to true. Otherwise, set
- it to false.
-
  <li><p>Let <i>clonedNode</i> equal a <a lt="clone a node">clone</a> of <a>this</a>, with the
- <i>clone children flag</i> set if <var>deep</var> is true, and <i>clone shadows flag</i> set to
- <i>shouldCloneShadows</i>.
+ <i>clone children flag</i> set if <var>deep</var> is true, and the <i>clone shadows flag</i>
+ set if <a>this</a> is a {{DocumentFragment}}.
 
 </ol>
 

--- a/dom.bs
+++ b/dom.bs
@@ -5899,6 +5899,7 @@ dictionary ShadowRootInit {
 
 dictionary GetInnerHTMLOptions {
   boolean includeShadowRoots = true;
+  sequence&lt;ShadowRoot> closedRoots;
 };
 </pre>
 
@@ -6735,7 +6736,7 @@ invoked, must run these steps:
 steps:
 
 <ol>
- <li><p>Let <var>shadow</var> be <var>shadow host</var>'s <a for=Element>shadow root</a>.
+ <li><p>Let <var>shadow</var> be <a>this</a>'s <a for=Element>shadow root</a>.
 
  <li><p>If <var>shadow</var> is null or its <a for=ShadowRoot>mode</a> is "<code>closed</code>",
  then return null.</p></li>
@@ -6747,10 +6748,10 @@ steps:
 <var>shadow host</var>, <var>mode</var>, and <var>delegates focus</var>, run these steps:</p>
 
 <ol>
- <li><p>If <a>this</a>'s <a for=Element>namespace</a> is <em>not</em> the <a>HTML namespace</a>,
+ <li><p>If <var>shadow host</var>'s <a for=Element>namespace</a> is <em>not</em> the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>If <a>this</a>'s <a for=Element>local name</a> is <em>not</em> a
+ <li><p>If <var>shadow host</var>'s <a for=Element>local name</a> is <em>not</em> a
 
   <ul class=brief>
    <li>a <a>valid custom element name</a>
@@ -6778,13 +6779,13 @@ steps:
  </li>
 
  <li>
-  <p>If <a>this</a>'s <a for=Element>local name</a> is a <a>valid custom element name</a>, or
-  <a>this</a>'s <a for=Element><code>is</code> value</a> is not null, then:
+  <p>If <var>shadow host</var>'s <a for=Element>local name</a> is a <a>valid custom element name</a>, or
+  <var>shadow host</var>'s <a for=Element><code>is</code> value</a> is not null, then:
 
   <ol>
    <li><p>Let <var>definition</var> be the result of
    <a lt="look up a custom element definition">looking up a custom element definition</a> given
-   <a>this</a>'s <a for=Node>node document</a>, its <a for=Element>namespace</a>, its
+   <var>shadow host</var>'s <a for=Node>node document</a>, its <a for=Element>namespace</a>, its
    <a for=Element>local name</a>, and its <a for=Element><code>is</code> value</a>.
 
    <li><p>If <var>definition</var> is not null and <var>definition</var>'s
@@ -6793,26 +6794,27 @@ steps:
   </ol>
  </li>
 
- <li><p>If <a>this</a> has a non-null <a for=/>shadow root</a> whose
- <a for=ShadowRoot>is declarative shadow root</a> property is false, then <a>throw</a> an
- "{{NotSupportedError!!exception}}" {{DOMException}}.
+ <li><p>If <var>shadow host</var> has a non-null <a for=/>shadow root</a>, then:
+   <ol>
+     <li><p>If <var>shadow host</var>'s <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative
+     shadow root</a> property is false, then <a>throw</a> an "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>If <a>this</a> has a non-null <a for=/>shadow root</a> whose
- <a for=ShadowRoot>is declarative shadow root</a> property is true, then <a for=/>remove</a> all of
- <a for=/>shadow root</a>'s <a>children</a>, in <a>tree order</a>. Return <var>shadow host</var>'s <a for=/>shadow root</a>.
+     <li><p>Otherwise, <a for=/>remove</a> all of <a for=/>shadow root</a>'s <a>children</a>, in
+     <a>tree order</a>. Return <var>shadow host</var>'s <a for=/>shadow root</a>.
 
- <p class="note">This means that if multiple declarative shadow roots are contained within a single shadow host,
- only the last one will remain.
+     <p class="note">This means that if multiple declarative shadow roots are contained within a single shadow host,
+     only the last one will remain.
+   </ol>
 
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>
- is <a>this</a>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is <var>shadow host</var>,
+ is <var>shadow host</var>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is <var>shadow host</var>,
  and <a for=ShadowRoot>mode</a> is <var>mode</var>.
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>delegates focus</var>.
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>is declarative shadow root</a> property to false.
 
- <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
+ <li><p>Set <var>shadow host</var>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 </ol>
 
 <hr>
@@ -6925,7 +6927,8 @@ for <a>this</a>.
 <p>The
 <dfn method for=Element><code>getInnerHTML(<var>options</var>)</code></dfn>
 method, when invoked, must return the result of running <a>HTML fragment serialization algorithm</a>,
-given <a>this</a> as <var>node</var> and <i>options.includeShadowRoots</i> as <i>include shadow roots</i>.
+given <a>this</a> as <var>node</var>, <i>options.includeShadowRoots</i> as <i>include shadow roots</i>,
+and <i>options.closedRoots</i> as <i>closed shadow roots</i>.
 
 <p>The
 <dfn method for=Element><code>insertAdjacentElement(<var>where</var>, <var>element</var>)</code></dfn>

--- a/dom.bs
+++ b/dom.bs
@@ -6782,6 +6782,9 @@ steps:
  <a for=ShadowRoot>is declarative shadow root</a> property is true, then <a for=/>remove</a> all of
  <a for=/>shadow root</a>'s <a>children</a>, in <a>tree order</a>. Return <var>shadow host</var>'s <a for=/>shadow root</a>.
 
+ <p class="note">This means that if multiple <a href="https://html.spec.whatwg.org/#concept-declarative-shadow-root">declarative shadow root</a>s are contained within a single shadow host,
+ only the last one will remain.
+
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>
  is <a>this</a>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is <var>shadow host</var>,
  and <a for=ShadowRoot>mode</a> is <var>mode</var>.

--- a/dom.bs
+++ b/dom.bs
@@ -6703,11 +6703,35 @@ when invoked, must run these steps:
 invoked, must run these steps:
 
 <ol>
- <li><p>If <a>this</a>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
+
+ <li><p>Run <a>attach a shadow root</a> with <var>shadow host</var> equal to <a>this</a>,
+   <var>mode</var> equal to <var>init</var>'s {{ShadowRootInit/mode}}, and <var>delegates focus</var>
+   equal to <var>init</var>'s {{ShadowRootInit/delegatesFocus}}.</p></li>
+
+ <li><p>Return <a>this</a>'s <a for=Element>shadow root</a>.</p></li>
+
+</ol>
+
+<p>The <dfn attribute for=Element><code>shadowRoot</code></dfn> attribute's getter must run these
+steps:
+
+<ol>
+ <li><p>Let <var>shadow</var> be <var>shadow host</var>'s <a for=Element>shadow root</a>.
+
+ <li><p>If <var>shadow</var> is null or its <a for=ShadowRoot>mode</a> is "<code>closed</code>",
+ then return null.</p></li>
+
+ <li><p>Return <var>shadow</var>.
+</ol>
+
+<p>To <dfn id=concept-attach-a-shadow-root>attach a shadow root</dfn>, given a
+<var>shadow host</var>, <var>mode</var>, and <var>delegates focus</var>, run these steps:</p>
+
+<ol>
+ <li><p>If <a>this</a>'s <a for=Element>namespace</a> is <em>not</em> the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li>
-  <p>If <a>this</a>'s <a for=Element>local name</a> is not one of the following:
+ <li><p>If <a>this</a>'s <a for=Element>local name</a> is <em>not</em> a
 
   <ul class=brief>
    <li>a <a>valid custom element name</a>
@@ -6750,35 +6774,23 @@ invoked, must run these steps:
   </ol>
  </li>
 
- <li><p>If <a>this</a> is a <a for=Element>shadow host</a> whose <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> property is false, then <a>throw</a> an
+ <li><p>If <a>this</a> has a non-null <a for=/>shadow root</a> whose
+ <a for=ShadowRoot>is declarative shadow root</a> property is false, then <a>throw</a> an
  "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>If <a>this</a> is a <a for=Element>shadow host</a> whose <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> property is true, then <a for=/>remove</a> all of <a for=/>shadow root</a>'s <a>children</a>, in <a>tree order</a>. Return <a>this</a>'s <a for=/>shadow root</a>.
+ <li><p>If <a>this</a> has a non-null <a for=/>shadow root</a> whose
+ <a for=ShadowRoot>is declarative shadow root</a> property is true, then <a for=/>remove</a> all of
+ <a for=/>shadow root</a>'s <a>children</a>, in <a>tree order</a>. Return <var>shadow host</var>'s <a for=/>shadow root</a>.
 
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>
- is <a>this</a>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is <a>this</a>,
- and <a for=ShadowRoot>mode</a> is <var>init</var>'s {{ShadowRootInit/mode}}.
+ is <a>this</a>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is <var>shadow host</var>,
+ and <a for=ShadowRoot>mode</a> is <var>mode</var>.
 
- <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
- {{ShadowRootInit/delegatesFocus}}.
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>delegates focus</var>.
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>is declarative shadow root</a> property to false.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
-
- <li><p>Return <var>shadow</var>.
-</ol>
-
-<p>The <dfn attribute for=Element><code>shadowRoot</code></dfn> attribute's getter must run these
-steps:
-
-<ol>
- <li><p>Let <var>shadow</var> be <a>this</a>'s <a for=Element>shadow root</a>.
-
- <li><p>If <var>shadow</var> is null or its <a for=ShadowRoot>mode</a> is "<code>closed</code>",
- then return null.</p></li>
-
- <li><p>Return <var>shadow</var>.
 </ol>
 
 <hr>

--- a/dom.bs
+++ b/dom.bs
@@ -4319,7 +4319,7 @@ dom-Range-extractContents, dom-Range-cloneContents -->
 
    <li>If the <i>clone children flag</i> is set, <a lt="clone a node">clone</a> all the
    <a>children</a> of <var>node</var>'s <a for=/>shadow root</a> and append them to <var>copy</var>'s <a for=/>shadow root</a>, with
-   <var>document</var> as specified and the <i>clone children flag</i> being set. 
+   <var>document</var> as specified, the <i>clone children flag</i> being set, and the <i>clone shadows flag</i> being set.
 
  </ol>
 
@@ -4333,17 +4333,15 @@ invoked, must run these steps:
  <li><p>If <a>this</a> is a <a for=/>shadow root</a>, then <a>throw</a> a
  "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>Let <i>shouldCloneShadows</i> be true if <a>this</a> is a <a for=Element>shadow host</a>
- whose <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> property is true,
- and false otherwise.
+ <li><p>If <a>this</a> has a non-null <a for=DocumentFragment>host</a>, but <a>this</a> is not
+ a <a for=Element>shadow host</a>, then set <i>shouldCloneShadows</i> to true. Otherwise, set
+ it to false.
 
  <li><p>Let <i>clonedNode</i> equal a <a lt="clone a node">clone</a> of <a>this</a>, with the
  <i>clone children flag</i> set if <var>deep</var> is true, and <i>clone shadows flag</i> set to
  <i>shouldCloneShadows</i>.
 
 </ol>
-
-
 
 A <a>node</a> <var>A</var>
 <dfn export for=Node id=concept-node-equals>equals</dfn> a <a>node</a>

--- a/dom.bs
+++ b/dom.bs
@@ -6744,8 +6744,10 @@ invoked, must run these steps:
   </ol>
  </li>
 
- <li><p>If <a>this</a> is a <a for=Element>shadow host</a>, then <a>throw</a> an
+ <li><p>If <a>this</a> is a <a for=Element>shadow host</a> whose <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> property is false, then <a>throw</a> an
  "{{NotSupportedError!!exception}}" {{DOMException}}.
+
+ <li><p>If <a>this</a> is a <a for=Element>shadow host</a> whose <a for=/>shadow root</a>'s <a for=ShadowRoot>is declarative shadow root</a> property is true, then <a for=/>remove</a> all of <a for=/>shadow root</a>'s <a>children</a>, in <a>tree order</a>. Return <a>this</a>'s <a for=/>shadow root</a>.
 
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>
  is <a>this</a>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is <a>this</a>,
@@ -6754,7 +6756,7 @@ invoked, must run these steps:
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
  {{ShadowRootInit/delegatesFocus}}.
 
- <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>is declarative shadow root</a> to false.
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>is declarative shadow root</a> property to false.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -6924,10 +6924,8 @@ for <a>this</a>.
 
 <p>The
 <dfn method for=Element><code>getInnerHTML(<var>options</var>)</code></dfn>
-method, when invoked, must return the result of running
-<a href="https://www.w3.org/TR/html5/single-page.html#html-fragment-serialisation-algorithm">fragment
-serialization algorithm</a>, given <a>this</a> as <var>node</var> and <i>options.includeShadowRoots</i>
-as <i>include shadow roots</i>.
+method, when invoked, must return the result of running <a>HTML fragment serialization algorithm</a>,
+given <a>this</a> as <var>node</var> and <i>options.includeShadowRoots</i> as <i>include shadow roots</i>.
 
 <p>The
 <dfn method for=Element><code>insertAdjacentElement(<var>where</var>, <var>element</var>)</code></dfn>


### PR DESCRIPTION
The explainer for this feature is here: https://github.com/mfreed7/declarative-shadow-dom/blob/master/README.md
The issue discussion is here: https://github.com/whatwg/dom/issues/831
There is a corresponding Pull Request for the HTML spec that goes along with this PR.

- [ ] At least two implementers are interested (and none opposed):
   * I'm working to get this implemented in Chromium, tracking bug [here](https://crbug.com/1042130).
   * Other implementers have at least not been negative on the [discussion thread](https://github.com/whatwg/dom/issues/831). Not explicitly positive (yet).

- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * In WPT: https://wpt.fyi/results/shadow-dom/declarative?label=master&label=experimental&aligned&q=declarative
   * More tests are being implemented, but the basics are there.

- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1042130
   * Firefox: None yet
   * Safari: None yet


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/858.html" title="Last updated on Jun 11, 2020, 9:43 PM UTC (191a88c)">Preview</a> | <a href="https://whatpr.org/dom/858/94679a2...191a88c.html" title="Last updated on Jun 11, 2020, 9:43 PM UTC (191a88c)">Diff</a>