### PR TITLE
Clarification on valid shadow element's local name

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6694,11 +6694,11 @@ when invoked, must run these steps:
 invoked, must run these steps:
 
 <ol>
- <li><p>If <a>this</a>'s <a for=Element>namespace</a> is <em>not</em> the <a>HTML namespace</a>,
+ <li><p>If <a>this</a>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
  <li>
-  <p>If <a>this</a>'s <a for=Element>local name</a> is <em>not</em> one of the following:
+  <p>If <a>this</a>'s <a for=Element>local name</a> is not one of the following:
 
   <ul class=brief>
    <li>a <a>valid custom element name</a>

--- a/dom.bs
+++ b/dom.bs
@@ -4759,7 +4759,7 @@ for a <a>node</a> <var>root</var> is the
 
   <p>The comparisons for the <a for=Element>classes</a> must be done in an
   <a>ASCII case-insensitive</a> manner if <var>root</var>'s <a for=Node>node document</a>'s
-  <a for=Document>mode</a> is "<code>quirks</code>", and in a <a>case-sensitive</a> manner
+  <a for=Document>mode</a> is "<code>quirks</code>", and in an <a for=string>identical to</a> manner
   otherwise.
 </ol>
 
@@ -6700,10 +6700,9 @@ invoked, must run these steps:
  <li>
   <p>If <a>this</a>'s <a for=Element>local name</a> is <em>not</em> one of the following:
 
-  <ul>
-   <li><p>a <a>valid custom element name</a></p></li>
-   <li>
-   "<code>article</code>",
+  <ul class=brief>
+   <li>a <a>valid custom element name</a>
+   <li>"<code>article</code>",
    "<code>aside</code>",
    "<code>blockquote</code>",
    "<code>body</code>",

--- a/dom.bs
+++ b/dom.bs
@@ -6697,26 +6697,34 @@ invoked, must run these steps:
  <li><p>If <a>this</a>'s <a for=Element>namespace</a> is <em>not</em> the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>If <a>this</a>'s <a for=Element>local name</a> is <em>not</em> a
-<a>valid custom element name</a>,
- "<code>article</code>",
- "<code>aside</code>",
- "<code>blockquote</code>",
- "<code>body</code>",
- "<code>div</code>",
- "<code>footer</code>",
- "<code>h1</code>",
- "<code>h2</code>",
- "<code>h3</code>",
- "<code>h4</code>",
- "<code>h5</code>",
- "<code>h6</code>",
- "<code>header</code>",
- "<code>main</code>",
- "<code>nav</code>",
- "<code>p</code>",
- "<code>section</code>", or
- "<code>span</code>", then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
+ <li>
+  <p>If <a>this</a>'s <a for=Element>local name</a> is <em>not</em> one of the following:
+
+  <ul>
+   <li><p>a <a>valid custom element name</a></p></li>
+   <li>
+   "<code>article</code>",
+   "<code>aside</code>",
+   "<code>blockquote</code>",
+   "<code>body</code>",
+   "<code>div</code>",
+   "<code>footer</code>",
+   "<code>h1</code>",
+   "<code>h2</code>",
+   "<code>h3</code>",
+   "<code>h4</code>",
+   "<code>h5</code>",
+   "<code>h6</code>",
+   "<code>header</code>",
+   "<code>main</code>",
+   "<code>nav</code>",
+   "<code>p</code>",
+   "<code>section</code>", or
+   "<code>span</code>"
+  </ul>
+
+  <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
+ </li>
 
  <li>
   <p>If <a>this</a>'s <a for=Element>local name</a> is a <a>valid custom element name</a>, or
@@ -10184,6 +10192,7 @@ Veli Şenol,
 Vidur Apparao,
 Warren He,
 Xidorn Quan,
+Yash Handa,
 Yehuda Katz,
 Yoav Weiss,
 Yoichi Osato,


### PR DESCRIPTION
As discussed in #745, I made the required changes for clarification on the shadow element's local name.
It follows the formate specified in https://github.com/whatwg/dom/issues/745#issuecomment-639329890 by @annevk.

A side note:
There was an error during the `make` process, on both unedited and edited versions of dom.bs

```txt
Error running preprocessor, returned code: 1.
LINK ERROR: No 'dfn' refs found for 'case-sensitive' that are marked for export.
&lt;a data-link-type="dfn" data-lt="case-sensitive">case-sensitive&lt;/a>
 ✘  Did not generate, due to fatal errors
make: *** [Makefile:5: remote] Error 22
```

Due to which I couldn't verify my changes, so please let me know if something is off : )


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/869.html" title="Last updated on Jun 8, 2020, 8:18 AM UTC (67bf9a6)">Preview</a> | <a href="https://whatpr.org/dom/869/f3f46b8...67bf9a6.html" title="Last updated on Jun 8, 2020, 8:18 AM UTC (67bf9a6)">Diff</a>