### PR TITLE
Need to catch exceptions to report them

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3297,7 +3297,7 @@ run these steps:
 
    <li><p>If <var>records</var> <a for=queue>is not empty</a>, then <a spec=webidl>invoke</a>
    <var>mo</var>'s <a for=MutationObserver>callback</a> with « <var>records</var>, <var>mo</var> »,
-   and <var>mo</var>. If this throws an exception, then <a>report the exception</a>.
+   and <var>mo</var>. If this throws an exception, catch it, and <a>report the exception</a>.
   </ol>
 
  <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a>


### PR DESCRIPTION
Now that the default semantics are to throw, we need to be more explicit about catching.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/889.html" title="Last updated on Sep 8, 2020, 3:01 PM UTC (3b1370a)">Preview</a> | <a href="https://whatpr.org/dom/889/8f20138...3b1370a.html" title="Last updated on Sep 8, 2020, 3:01 PM UTC (3b1370a)">Diff</a>