### PR TITLE
Add is-available-to-element-internals

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6741,7 +6741,8 @@ invoked, must run these steps:
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
  {{ShadowRootInit/delegatesFocus}}.
 
- <li><p>If <a>this</a> is <a for=Element>custom</a>, set <var>shadow</var>'s
+ <li><p>If <a>this</a>'s <a for=Element>custom element state</a> is "<code>precustomized</code>"
+ or "<code>custom</code>", set <var>shadow</var>'s
  <a for=ShadowRoot>available to element internals</a> property to true. Otherwise, set it to
  false.
 

--- a/dom.bs
+++ b/dom.bs
@@ -6741,10 +6741,9 @@ invoked, must run these steps:
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
  {{ShadowRootInit/delegatesFocus}}.
 
- <li><p>If <a>this</a>'s <a for=Element>custom element state</a> is "<code>precustomized</code>"
- or "<code>custom</code>", set <var>shadow</var>'s
- <a for=ShadowRoot>available to element internals</a> property to true. Otherwise, set it to
- false.
+ <li><p>If <a>this</a>'s <a for=Element>custom element state</a> is "<code>precustomized</code>" or 
+ "<code>custom</code>", then set <var>shadow</var>'s 
+ <a for=ShadowRoot>available to element internals</a> to true.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -5714,7 +5714,7 @@ or "<code>closed</code>").</p>
 <p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>delegates focus</dfn>.
 It is initially set to false.</p>
 
-<p><a for=/>Shadow roots</a> have an associated 
+<p><a for=/>Shadow roots</a> have an associated
 <dfn export for=ShadowRoot>available to element internals</dfn>. It is initially set to false.</p>
 
 <p><a for=/>Shadow roots</a>'s associated <a for=DocumentFragment>host</a> is never null.</p>
@@ -6741,8 +6741,8 @@ invoked, must run these steps:
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
  {{ShadowRootInit/delegatesFocus}}.
 
- <li><p>If <a>this</a>'s <a for=Element>custom element state</a> is "<code>precustomized</code>" or 
- "<code>custom</code>", then set <var>shadow</var>'s 
+ <li><p>If <a>this</a>'s <a for=Element>custom element state</a> is "<code>precustomized</code>" or
+ "<code>custom</code>", then set <var>shadow</var>'s
  <a for=ShadowRoot>available to element internals</a> to true.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.

--- a/dom.bs
+++ b/dom.bs
@@ -6741,10 +6741,9 @@ invoked, must run these steps:
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
  {{ShadowRootInit/delegatesFocus}}.
 
- <li><p>If <a>this</a> is <a for=Element>custom</a>, and if <a>this</a>'s <a for=Element>custom
- element state</a> is not "precustomized" or "custom", set <var>shadow</var>'s
- <a for=ShadowRoot>available to element internals</a> property to false. Otherwise, set it to
- true.
+ <li><p>If <a>this</a> is <a for=Element>custom</a>, set <var>shadow</var>'s
+ <a for=ShadowRoot>available to element internals</a> property to true. Otherwise, set it to
+ false.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -5714,8 +5714,8 @@ or "<code>closed</code>").</p>
 <p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>delegates focus</dfn>.
 It is initially set to false.</p>
 
-<p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>available to element internals</dfn>.
-It is initially set to false.</p>
+<p><a for=/>Shadow roots</a> have an associated 
+<dfn export for=ShadowRoot>available to element internals</dfn>. It is initially set to false.</p>
 
 <p><a for=/>Shadow roots</a>'s associated <a for=DocumentFragment>host</a> is never null.</p>
 <!-- If we ever change this, e.g., add a ShadowRoot object constructor, that would have serious

--- a/dom.bs
+++ b/dom.bs
@@ -5714,6 +5714,9 @@ or "<code>closed</code>").</p>
 <p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>delegates focus</dfn>.
 It is initially set to false.</p>
 
+<p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>available to element internals</dfn>.
+It is initially set to false.</p>
+
 <p><a for=/>Shadow roots</a>'s associated <a for=DocumentFragment>host</a> is never null.</p>
 <!-- If we ever change this, e.g., add a ShadowRoot object constructor, that would have serious
      consequences for innerHTML. -->
@@ -6737,6 +6740,11 @@ invoked, must run these steps:
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
  {{ShadowRootInit/delegatesFocus}}.
+
+ <li><p>If <a>this</a> is <a for=Element>custom</a>, and if <a>this</a>'s <a for=Element>custom
+ element state</a> is not "precustomized" or "custom", set <var>shadow</var>'s
+ <a for=ShadowRoot>available to element internals</a> property to false. Otherwise, set it to
+ true.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 


### PR DESCRIPTION
Add `"is available to element internals"` flag, for use with the accompanying [HTML PR](https://github.com/whatwg/html/pull/5912) which restricts access to `ElementInternals.shadowRoot` for shadow roots which were pre-existing before a custom element upgrade/construction. See the discussion on [Issue 871](https://github.com/w3c/webcomponents/issues/871#issuecomment-692383222) for more context.

- [X] At least two implementers are interested (and none opposed):
   * Chromium - me.
   * WebKit: see [this comment](https://github.com/w3c/webcomponents/issues/871#issuecomment-692383222).
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/25554
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://crbug.com/1042130
   * Firefox: …
   * Safari: …


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/893.html" title="Last updated on Oct 5, 2020, 4:20 PM UTC (8625fe7)">Preview</a> | <a href="https://whatpr.org/dom/893/12beda2...8625fe7.html" title="Last updated on Oct 5, 2020, 4:20 PM UTC (8625fe7)">Diff</a>