### PR TITLE
Correct step in matches()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6796,23 +6796,20 @@ method, when invoked, must run these steps:
  <li>Return null.
 </ol>
 
-The <dfn method for=Element><code>matches(<var>selectors</var>)</code></dfn> and
-<dfn method for=Element><code>webkitMatchesSelector(<var>selectors</var>)</code></dfn> methods, when
-invoked, must run these steps:
+<p>The <dfn method for=Element><code>matches(<var>selectors</var>)</code></dfn> and
+<dfn method for=Element><code>webkitMatchesSelector(<var>selectors</var>)</code></dfn> method steps
+are:
 
 <ol>
- <li>Let <var>s</var> be the result of
- <a>parse a selector</a> from <var>selectors</var>.
+ <li><p>Let <var>s</var> be the result of <a>parse a selector</a> from <var>selectors</var>.
  [[!SELECTORS4]]
 
- <li>If <var>s</var> is failure, <a>throw</a> a
- "{{SyntaxError!!exception}}" {{DOMException}}.
+ <li><p>If <var>s</var> is failure, then <a>throw</a> a "{{SyntaxError!!exception}}"
+ {{DOMException}}.
 
- <li>Return true if the result of
- <a>match a selector against an element</a>, using
- <var>s</var>, <var>element</var>, and
- <a>:scope element</a> <a>this</a>,
- returns success, and false otherwise. [[!SELECTORS4]]
+ <li><p>If the result of <a>match a selector against an element</a>, using <var>s</var>,
+ <a>this</a>, and <a>:scope element</a> <a>this</a>, returns success, then return true; otherwise,
+ return false. [[!SELECTORS4]]
 </ol>
 
 <hr>
@@ -10000,6 +9997,7 @@ Chris Dumez,
 Chris Paris,
 Chris Rebert,
 Cyrille Tuzi,
+Dan Burzo,
 Daniel Glazman,
 Darin Fisher,
 David Bruant,


### PR DESCRIPTION
It needs to pass this rather than an undefined variable. Also clean up the algorithm a bit.

Fixes #921.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/923.html" title="Last updated on Jan 19, 2021, 11:20 AM UTC (fd6673c)">Preview</a> | <a href="https://whatpr.org/dom/923/8f3ee85...fd6673c.html" title="Last updated on Jan 19, 2021, 11:20 AM UTC (fd6673c)">Diff</a>