### PR TITLE
Fix the comparing boundary points of `concept-range-bp-set`

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -7803,14 +7803,14 @@ steps:
    <dt>If these steps were invoked as "set the start"
    <dd>
     <ol>
-     <li>If <var>bp</var> is
-     <a for="boundary point">after</a> the
-     <var>range</var>'s <a for=range>end</a>, or
-     if <var>range</var>'s
+     <li>If <var>range</var>'s
      <a for="live range">root</a> is not equal to
-     <var>node</var>'s <a for=tree>root</a>, set
-     <var>range</var>'s <a for=range>end</a> to
-     <var>bp</var>.
+     <var>node</var>'s <a for=tree>root</a>,
+     or if <var>bp</var> is
+     <a for="boundary point">after</a> the
+     <var>range</var>'s <a for=range>end</a>, set
+     <var>range</var>'s <a for=range>end</a>
+     to <var>bp</var>.
 
      <li>Set <var>range</var>'s
      <a for=range>start</a> to <var>bp</var>.
@@ -7818,12 +7818,12 @@ steps:
    <dt>If these steps were invoked as "set the end"
    <dd>
     <ol>
-     <li>If <var>bp</var> is
-     <a for="boundary point">before</a> the
-     <var>range</var>'s <a for=range>start</a>,
-     or if <var>range</var>'s
+     <li>If <var>range</var>'s
      <a for="live range">root</a> is not equal to
-     <var>node</var>'s <a for=tree>root</a>, set
+     <var>node</var>'s <a for=tree>root</a>,
+     or if <var>bp</var> is
+     <a for="boundary point">before</a> the
+     <var>range</var>'s <a for=range>start</a>, set
      <var>range</var>'s <a for=range>start</a>
      to <var>bp</var>.
 
@@ -10106,7 +10106,8 @@ Yash Handa,
 Yehuda Katz,
 Yoav Weiss,
 Yoichi Osato,
-Yoshinori Sano, and
+Yoshinori Sano,
+Yusuke Abe, and
 Zack Weinberg
 for being awesome!
 


### PR DESCRIPTION
Fixes #924


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/925.html" title="Last updated on Nov 17, 2020, 11:36 PM UTC (44eecc3)">Preview</a> | <a href="https://whatpr.org/dom/925/52f7a52...44eecc3.html" title="Last updated on Nov 17, 2020, 11:36 PM UTC (44eecc3)">Diff</a>