### PR TITLE
Use undefined union for Window.event

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -776,7 +776,7 @@ incapable of setting {{Event/composed}}. It has to be supported for legacy conte
 
 <pre class=idl>
 partial interface Window {
-  [Replaceable] readonly attribute any event; // legacy
+  [Replaceable] readonly attribute (Event or undefined) event; // legacy
 };
 </pre>
 


### PR DESCRIPTION
<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed): N/A
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at: N/A
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/935.html" title="Last updated on Dec 21, 2020, 2:31 PM UTC (6538936)">Preview</a> | <a href="https://whatpr.org/dom/935/83037a1...6538936.html" title="Last updated on Dec 21, 2020, 2:31 PM UTC (6538936)">Diff</a>