### PR TITLE
Use a single exception for name validation (follow-up)

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -219,7 +219,7 @@ added.
 
 <p>To <dfn export>validate</dfn> a <var>qualifiedName</var>, <a>throw</a> an
 "{{InvalidCharacterError!!exception}}" {{DOMException}} if <var>qualifiedName</var> does not match
-the <code><a type>Name</a></code> or <code><a type>QName</a></code> production.
+the <code><a type>QName</a></code> production.
 
 To <dfn export>validate and extract</dfn> a <var>namespace</var> and <var>qualifiedName</var>,
 run these steps:
@@ -5049,15 +5049,13 @@ for <a>this</a>.
   <var>qualifiedName</var> or null. Its <a for=Element>local name</a> will be everything after
   "<code>:</code>" (U+003E) in <var>qualifiedName</var> or <var>qualifiedName</var>.
 
-  <p>If <var>localName</var> does not match the <code><a type>Name</a></code> production an
+  <p>If <var>qualifiedName</var> does not match the <code><a type>QName</a></code> production an
   "{{InvalidCharacterError!!exception}}" {{DOMException}} will be thrown.
 
   <p>If one of the following conditions is true a "{{NamespaceError!!exception}}" {{DOMException}}
   will be thrown:
 
   <ul>
-   <li><var>localName</var> does not match the
-   <code><a type>QName</a></code> production.
    <li><a for=Element>Namespace prefix</a>
    is not null and <var>namespace</var> is the empty string.
    <li><a for=Element>Namespace prefix</a>
@@ -9992,6 +9990,7 @@ Brandon Payton,
 Brandon Slade,
 Brandon Wallace,
 Brian Kardell,
+C. Scott Ananian,
 Cameron McCormack,
 Chris Dumez,
 Chris Paris,

--- a/dom.bs
+++ b/dom.bs
@@ -1,4 +1,3 @@
-TEST
 <pre class=metadata>
 Group: WHATWG
 H1: DOM

--- a/dom.bs
+++ b/dom.bs
@@ -1,3 +1,4 @@
+TEST
 <pre class=metadata>
 Group: WHATWG
 H1: DOM


### PR DESCRIPTION
Once you have thrown for all QName cases, you can no longer throw for Name cases. Tested as part of #423.

Also cleanup createElementNS() domintro.

Fixes #671 and closes #675.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 27, 2021, 5:19 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Fdom%2F37d704849195682c1c680849f3e9ce6abbb4c0da%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20945)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%23945.)._
</details>
