### PR TITLE
Editorial: Restore necessary comma

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -278,7 +278,7 @@ function imgFetched(ev) {
 <a>Event listeners</a> can be removed
 by utilizing the
 {{EventTarget/removeEventListener()}}
-method passing the same arguments.
+method, passing the same arguments.
 
 Alternatively, <a>event listeners</a> can be removed by passing an {{AbortSignal}} to
 {{EventTarget/addEventListener()}} and calling {{AbortController/abort()}} on the controller


### PR DESCRIPTION
A comma got dropped in https://github.com/whatwg/dom/commit/83037a1 but the sentence it’s in isn’t grammatical without it, so this change restores it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/954.html" title="Last updated on Feb 28, 2021, 1:32 AM UTC (a2ae3c9)">Preview</a> | <a href="https://whatpr.org/dom/954/c80cbf5...a2ae3c9.html" title="Last updated on Feb 28, 2021, 1:32 AM UTC (a2ae3c9)">Diff</a>