### PR TITLE
Editorial: fix typo

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1844,7 +1844,7 @@ service worker.
 {{AbortController}} object, but an API observing the {{AbortSignal}} object can chose to ignore
 them. For instance, if the operation has already completed.
 
-<p>To <dfn export for=AbortSignal>signal abort</dfn>, given a {{AbortSignal}} object
+<p>To <dfn export for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object
 <var>signal</var>, run these steps:
 
 <ol>


### PR DESCRIPTION
Hi, I was reading through the [AbortSignal](https://dom.spec.whatwg.org/#interface-AbortSignal) specs and found this typo. So here is my first contribution to WHATWG ☺️

Cheers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/962.html" title="Last updated on Mar 14, 2021, 8:19 PM UTC (c40bad9)">Preview</a> | <a href="https://whatpr.org/dom/962/aa384af...c40bad9.html" title="Last updated on Mar 14, 2021, 8:19 PM UTC (c40bad9)">Diff</a>