### PR TITLE
Add Imperative Slot API

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2222,7 +2222,8 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
    <li><p>Let <var>result</var> be an empty list.</p></li>
 
    <li><p>For each <a>slottable</a> in <var>slot</var>'s <a>manually assigned nodes</a>,
-   if <a>slottable</a>'s <a for=tree>parent</a> is <var>host</var>, add <a>slottable</a> to array.</p></li>
+   if <a>slottable</a>'s <a for=tree>parent</a> is <var>host</var>, add <a>slottable</a>
+   to <var>result</var>.</p></li>
   </ol>
  </li>
 

--- a/dom.bs
+++ b/dom.bs
@@ -2228,9 +2228,8 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
 
    <li><p><a for=set>For each</a> <a>slottable</a> <var>slottable</var> of <var>slot</var>'s
    <a>manually assigned nodes</a>, if <var>slottable</var>'s <a for=tree>parent</a> is
-   <var>host</var>, <a for=list>append</a> <var>slottable</var> to <var>result</var>.</p></li>
+   <var>host</var>, <a for=list>append</a> <var>slottable</var> to <var>result</var>.
   </ol>
- </li>
 
  <li>
   <p>Otherwise, for each <a>slottable</a> <a for=tree>child</a> <var>slottable</var> of
@@ -5756,7 +5755,7 @@ It is initially set to false.</p>
      consequences for innerHTML. -->
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>slot assignment</dfn>
-("<code>manual</code>" or "<code>named</code>").</p>
+("<code>manual</code>" or "<code>named</code>").
 
 <p>A <a for=/>shadow root</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
 null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow root</a> is the

--- a/dom.bs
+++ b/dom.bs
@@ -2683,6 +2683,9 @@ indicated in the <a for=/>remove</a> algorithm below.
 
  <li><p><a for=set>Remove</a> <var>node</var> from its <var>parent</var>'s <a for=tree>children</a>.
 
+ <li><p>If <var>node</var> is an {{HTMLSlotElement}}, set <var>node</var>'s <a>manually assigned nodes</a>
+ to an empty set.
+
  <li><p>If <var>node</var> is <a for=slottable>assigned</a>, then run <a>assign slottables</a> for
  <var>node</var>'s <a>assigned slot</a>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -2177,8 +2177,10 @@ non-null.</p>
 
 <p>A <a>slottable</a> has an associated
 <dfn export for=slottable id=slottable-manual-slot-assignment>manual slot assignment</dfn> (null
-or a <a>slot</a>). Unless stated otherwise, it is null. The <a>manual slot assignment</a> is
-a weak reference to the slot, such that it can be garbage collected if not referenced elsewhere.</p>
+or a <a>slot</a>). Unless stated otherwise, it is null.</p>
+
+<p class=note>The <a>manual slot assignment</a> can be implemented using a weak reference
+to the <a>slot</a>, because this variable is not directly accessible from script.</p>
 
 <h5 id=finding-slots-and-slotables>Finding slots and slottables</h5>
 

--- a/dom.bs
+++ b/dom.bs
@@ -2473,7 +2473,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
    <a for=tree>children</a> before <var>child</var>'s <a for=tree>index</a>.
 
    <li><p>If <var>parent</var> is a <a for=Element>shadow host</a> whose <a for=/>shadow root</a>'s
-   <a for=ShadowRoot>slot assignment</a> is "<code>name</code>" and <var>node</var> is a
+   <a for=ShadowRoot>slot assignment</a> is "<code>named</code>" and <var>node</var> is a
    <a>slottable</a>, then <a>assign a slot</a> for <var>node</var>.
 
    <li><p>If <var>parent</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a>, and
@@ -5738,7 +5738,7 @@ interface ShadowRoot : DocumentFragment {
 };
 
 enum ShadowRootMode { "open", "closed" };
-enum SlotAssignmentMode { "manual", "name" };
+enum SlotAssignmentMode { "manual", "named" };
 </pre>
 
 <p>{{ShadowRoot}} <a for=/>nodes</a> are simply known as
@@ -5758,7 +5758,7 @@ It is initially set to false.</p>
      consequences for innerHTML. -->
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>slot assignment</dfn>
-("<code>manual</code>" or "<code>name</code>").</p>
+("<code>manual</code>" or "<code>named</code>").</p>
 
 <p>A <a for=/>shadow root</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
 null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow root</a> is the
@@ -5903,7 +5903,7 @@ interface Element : Node {
 dictionary ShadowRootInit {
   required ShadowRootMode mode;
   boolean delegatesFocus = false;
-  SlotAssignmentMode slotAssignment = "name";
+  SlotAssignmentMode slotAssignment = "named";
 };
 </pre>
 

--- a/dom.bs
+++ b/dom.bs
@@ -2175,12 +2175,11 @@ Unless stated otherwise it is null. A <a>slottable</a> is
 <dfn export for=slottable id=slotable-assigned>assigned</dfn> if its <a>assigned slot</a> is
 non-null.</p>
 
-<p>A <a>slottable</a> has an associated
-<dfn export for=slottable id=slottable-manual-slot-assignment>manual slot assignment</dfn> (null
-or a <a>slot</a>). Unless stated otherwise, it is null.</p>
+<p>A <a>slottable</a> has an associated <dfn export for=slottable>manual slot assignment</dfn> (null
+or a <a>slot</a>). Unless stated otherwise, it is null.
 
-<p class=note>The <a>manual slot assignment</a> can be implemented using a weak reference
-to the <a>slot</a>, because this variable is not directly accessible from script.</p>
+<p class=note>A <a>slottable</a>'s <a>manual slot assignment</a> can be implemented using a weak
+reference to the <a>slot</a>, because this variable is not directly accessible from script.
 
 <h5 id=finding-slots-and-slotables>Finding slots and slottables</h5>
 
@@ -2199,9 +2198,10 @@ steps:</p>
  <li><p>If the <i>open flag</i> is set and <var>shadow</var>'s <a for=ShadowRoot>mode</a> is
  <em>not</em> "<code>open</code>", then return null.</p></li>
 
- <li><p>If <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>",
- then return the <a>slot</a> in <var>shadow</var>'s <a for=tree>descendants</a> whose <a>manually assigned nodes</a>
- <a for=set>contains</a> <var>slottable</var>, if any, and null otherwise.</p></li>
+ <li><p>If <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>", then
+ return the <a>slot</a> in <var>shadow</var>'s <a for=tree>descendants</a> whose
+ <a>manually assigned nodes</a> <a for=set>contains</a> <var>slottable</var>, if any, and null
+ otherwise.
 
  <li><p>Return the first <a>slot</a> in <a>tree order</a> in <var>shadow</var>'s
  <a for=tree>descendants</a> whose <a for=slot>name</a> is <var>slottable</var>'s
@@ -2214,36 +2214,34 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
 <ol>
  <li><p>Let <var>result</var> be an empty list.</p></li>
 
- <li><p>Let <var>root</var> be <var>slot</var>'s <a for=tree>root</a>.</p></li>
+ <li><p>Let <var>root</var> be <var>slot</var>'s <a for=tree>root</a>.
 
- <li><p>If <var>root</var> is not a <a for=/>shadow root</a>, then return
- <var>result</var>.</p></li>
+ <li><p>If <var>root</var> is not a <a for=/>shadow root</a>, then return <var>result</var>.
 
- <li><p>Let <var>host</var> be <var>root</var>'s <a for=DocumentFragment>host</a>.</p></li>
+ <li><p>Let <var>host</var> be <var>root</var>'s <a for=DocumentFragment>host</a>.
 
  <li>
-  <p>If <var>root</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>",
-  then:</p>
+  <p>If <var>root</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>", then:
 
   <ol>
-   <li><p>Let <var>result</var> be an empty list.</p></li>
+   <li><p>Let <var>result</var> be « ».
 
-   <li><p>For each <a>slottable</a> in <var>slot</var>'s <a>manually assigned nodes</a>,
-   if <a>slottable</a>'s <a for=tree>parent</a> is <var>host</var>, add <a>slottable</a>
-   to <var>result</var>.</p></li>
+   <li><p><a for=set>For each</a> <a>slottable</a> <var>slottable</var> of <var>slot</var>'s
+   <a>manually assigned nodes</a>, if <var>slottable</var>'s <a for=tree>parent</a> is
+   <var>host</var>, <a for=list>append</a> <var>slottable</var> to <var>result</var>.</p></li>
   </ol>
  </li>
 
  <li>
-  <p>Otherwise, for each <a>slottable</a> <a for=tree>child</a> of <var>host</var>, <var>slottable</var>, in
-  <a>tree order</a>:</p>
+  <p>Otherwise, for each <a>slottable</a> <a for=tree>child</a> <var>slottable</var> of
+  <var>host</var>, in <a>tree order</a>:
 
   <ol>
    <li><p>Let <var>foundSlot</var> be the result of <a>finding a slot</a> given
-   <var>slottable</var>.</p></li>
+   <var>slottable</var>.
 
-   <li><p>If <var>foundSlot</var> is <var>slot</var>, then append <var>slottable</var> to
-   <var>result</var>.</p></li>
+   <li><p>If <var>foundSlot</var> is <var>slot</var>, then <a for=list>append</a>
+   <var>slottable</var> to <var>result</var>.
   </ol>
  </li>
 
@@ -5777,8 +5775,8 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 <dfn for=ShadowRoot export><code>onslotchange</code></dfn> <a>event handler</a>, whose
 <a>event handler event type</a> is {{HTMLSlotElement/slotchange}}.
 
-<p>The <dfn attribute for=ShadowRoot><code>slotAssignment</code></dfn> attribute's getter must
-return <a>this</a>'s <a for=ShadowRoot>slot assignment</a>.</p>
+<p>The <dfn attribute for=ShadowRoot><code>slotAssignment</code></dfn> getter steps are to return
+<a>this</a>'s <a for=ShadowRoot>slot assignment</a>.
 
 <hr>
 
@@ -6779,17 +6777,17 @@ invoked, must run these steps:
 
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>
  is <a>this</a>'s <a for=Node>node document</a>, <a for=DocumentFragment>host</a> is <a>this</a>,
- and <a for=ShadowRoot>mode</a> is <var>init</var>'s {{ShadowRootInit/mode}}.
+ and <a for=ShadowRoot>mode</a> is <var>init</var>["{{ShadowRootInit/mode}}"].
 
- <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to <var>init</var>'s
- {{ShadowRootInit/delegatesFocus}}.
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>delegates focus</a> to
+ <var>init</var>["{{ShadowRootInit/delegatesFocus}}"].
 
  <li><p>If <a>this</a>'s <a for=Element>custom element state</a> is "<code>precustomized</code>" or
  "<code>custom</code>", then set <var>shadow</var>'s
  <a for=ShadowRoot>available to element internals</a> to true.
 
- <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> to <var>init</var>'s
- {{ShadowRootInit/slotAssignment}}.
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> to
+ <var>init</var>["{{ShadowRootInit/slotAssignment}}"].
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 

--- a/dom.bs
+++ b/dom.bs
@@ -2175,6 +2175,11 @@ Unless stated otherwise it is null. A <a>slottable</a> is
 <dfn export for=slottable id=slotable-assigned>assigned</dfn> if its <a>assigned slot</a> is
 non-null.</p>
 
+<p>A <a>slottable</a> has an associated
+<dfn export for=slottable id=slottable-manual-slot-assignment>manual slot assignment</dfn> (null
+or a <a>slot</a>). Unless stated otherwise, it is null. The <a>manual slot assignment</a> is
+a weak reference to the slot, such that it can be garbage collected if not referenced elsewhere.</p>
+
 <h5 id=finding-slots-and-slotables>Finding slots and slottables</h5>
 
 <p>To <dfn export lt="find a slot|finding a slot">find a slot</dfn> for a given <a>slottable</a>
@@ -2682,9 +2687,6 @@ indicated in the <a for=/>remove</a> algorithm below.
  <li><p>Let <var>oldNextSibling</var> be <var>node</var>'s <a for=tree>next sibling</a>.
 
  <li><p><a for=set>Remove</a> <var>node</var> from its <var>parent</var>'s <a for=tree>children</a>.
-
- <li><p>If <var>node</var> is an {{HTMLSlotElement}}, set <var>node</var>'s <a>manually assigned nodes</a>
- to an empty set.
 
  <li><p>If <var>node</var> is <a for=slottable>assigned</a>, then run <a>assign slottables</a> for
  <var>node</var>'s <a>assigned slot</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -2192,6 +2192,10 @@ steps:</p>
  <li><p>If the <i>open flag</i> is set and <var>shadow</var>'s <a for=ShadowRoot>mode</a> is
  <em>not</em> "<code>open</code>", then return null.</p></li>
 
+ <li><p>If <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>",
+ then return the <a>slot</a> in <var>shadow</var>'s <a for=tree>descendants</a> whose <a>manually assigned nodes</a>
+ <a for=set>contains</a> <var>slottable</var>, if any, and null otherwise.</p></li>
+
  <li><p>Return the first <a>slot</a> in <a>tree order</a> in <var>shadow</var>'s
  <a for=tree>descendants</a> whose <a for=slot>name</a> is <var>slottable</var>'s
  <a for=slottable>name</a>, if any, and null otherwise.</p></li>
@@ -2203,14 +2207,27 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
 <ol>
  <li><p>Let <var>result</var> be an empty list.</p></li>
 
- <li><p>If <var>slot</var>'s <a for=tree>root</a> is not a <a for=/>shadow root</a>, then return
+ <li><p>Let <var>root</var> be <var>slot</var>'s <a for=tree>root</a>.</p></li>
+
+ <li><p>If <var>root</var> is not a <a for=/>shadow root</a>, then return
  <var>result</var>.</p></li>
 
- <li><p>Let <var>host</var> be <var>slot</var>'s <a for=tree>root</a>'s
- <a for=DocumentFragment>host</a>.</p></li>
+ <li><p>Let <var>host</var> be <var>root</var>'s <a for=DocumentFragment>host</a>.</p></li>
 
  <li>
-  <p>For each <a>slottable</a> <a for=tree>child</a> of <var>host</var>, <var>slottable</var>, in
+  <p>If <var>root</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>",
+  then:</p>
+
+  <ol>
+   <li><p>Let <var>result</var> be an empty list.</p></li>
+
+   <li><p>For each <a>slottable</a> in <var>slot</var>'s <a>manually assigned nodes</a>,
+   if <a>slottable</a>'s <a for=tree>parent</a> is <var>host</var>, add <a>slottable</a> to array.</p></li>
+  </ol>
+ </li>
+
+ <li>
+  <p>Otherwise, for each <a>slottable</a> <a for=tree>child</a> of <var>host</var>, <var>slottable</var>, in
   <a>tree order</a>:</p>
 
   <ol>
@@ -2447,7 +2464,8 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
    <li><p>Otherwise, <a for=set>insert</a> <var>node</var> into <var>parent</var>'s
    <a for=tree>children</a> before <var>child</var>'s <a for=tree>index</a>.
 
-   <li><p>If <var>parent</var> is a <a for=Element>shadow host</a> and <var>node</var> is a
+   <li><p>If <var>parent</var> is a <a for=Element>shadow host</a> whose <a for=/>shadow root</a>'s
+   <a for=ShadowRoot>slot assignment</a> is "<code>name</code>" and <var>node</var> is a
    <a>slottable</a>, then <a>assign a slot</a> for <var>node</var>.
 
    <li><p>If <var>parent</var>'s <a for=tree>root</a> is a <a for=/>shadow root</a>, and
@@ -5706,11 +5724,13 @@ invoked, must return a new {{DocumentFragment}} <a>node</a> whose <a for=Node>no
 [Exposed=Window]
 interface ShadowRoot : DocumentFragment {
   readonly attribute ShadowRootMode mode;
+  readonly attribute SlotAssignmentMode slotAssignment;
   readonly attribute Element host;
   attribute EventHandler onslotchange;
 };
 
 enum ShadowRootMode { "open", "closed" };
+enum SlotAssignmentMode { "manual", "name" };
 </pre>
 
 <p>{{ShadowRoot}} <a for=/>nodes</a> are simply known as
@@ -5729,6 +5749,9 @@ It is initially set to false.</p>
 <!-- If we ever change this, e.g., add a ShadowRoot object constructor, that would have serious
      consequences for innerHTML. -->
 
+<p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>slot assignment</dfn>
+("<code>manual</code>" or "<code>name</code>").</p>
+
 <p>A <a for=/>shadow root</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
 null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow root</a> is the
 <a for=tree>root</a> of <var>event</var>'s <a for=Event>path</a>'s first struct's
@@ -5745,6 +5768,9 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 <a>event handler IDL attribute</a> for the
 <dfn for=ShadowRoot export><code>onslotchange</code></dfn> <a>event handler</a>, whose
 <a>event handler event type</a> is {{HTMLSlotElement/slotchange}}.
+
+<p>The <dfn attribute for=ShadowRoot><code>slotAssignment</code></dfn> attribute's getter must
+return <a>this</a>'s <a for=ShadowRoot>slot assignment</a>.</p>
 
 <hr>
 
@@ -5869,6 +5895,7 @@ interface Element : Node {
 dictionary ShadowRootInit {
   required ShadowRootMode mode;
   boolean delegatesFocus = false;
+  SlotAssignmentMode slotAssignment = "name";
 };
 </pre>
 
@@ -6752,6 +6779,9 @@ invoked, must run these steps:
  <li><p>If <a>this</a>'s <a for=Element>custom element state</a> is "<code>precustomized</code>" or
  "<code>custom</code>", then set <var>shadow</var>'s
  <a for=ShadowRoot>available to element internals</a> to true.
+
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> to <var>init</var>'s
+ {{ShadowRootInit/slotAssignment}}.
 
  <li><p>Set <a>this</a>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 
@@ -10087,6 +10117,7 @@ Manish Tripathi,
 Marcos Caceres,
 Mark Miller,
 Martijn van der Ven,
+Mason Freed,
 Mats Palmgren,
 Mounir Lamouri,
 Michael Stramel,
@@ -10150,6 +10181,7 @@ Yehuda Katz,
 Yoav Weiss,
 Yoichi Osato,
 Yoshinori Sano,
+Yu Han,
 Yusuke Abe, and
 Zack Weinberg
 for being awesome!


### PR DESCRIPTION
### This is a fresh PR, with updates from https://github.com/whatwg/dom/pull/860. I don't have permissions to update that PR, and the master-to-main transition made it difficult anyway.

The explainer for this feature is here: https://github.com/w3c/webcomponents/blob/gh-pages/proposals/Imperative-Shadow-DOM-Distribution-API.md
The issue discussion is here: [3534](https://github.com/whatwg/html/issues/3534)
There is a corresponding [Pull Request](https://github.com/whatwg/html/pull/6561) for the HTML spec that goes along with this PR.

* [ ]  At least two implementers are interested (and none opposed):
  
  * Chromium tracking bug is [here](http://crbug.com/1196842), with the original implementation tracker [here](http://crbug.com/869308).
  * The implementation is based on what was agreed in the last [F2F Meeting](https://github.com/whatwg/html/issues/3534#issuecomment-537802687).
* [x]  [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
  
  * In WPT: https://wpt.fyi/results/shadow-dom/slots-imperative-slot-api.tentative.html?label=master&label=experimental&aligned&q=slots-imperative-slot-api.tentative.html
  * In WPT: https://wpt.fyi/results/shadow-dom/slots-imperative-api-slotchange.tentative.html?label=master&label=experimental&aligned
  * More WPTs to be implemented as part of the [Chromium implementation](http://crbug.com/1196842).
* [x]  [Implementation bugs](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md#handling-pull-requests) are filed:
  
  * Chrome: https://crbug.com/869308
  * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1705141
  * Safari: https://bugs.webkit.org/show_bug.cgi?id=218692


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 15, 2021, 7:24 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwhatpr.org%2Fdom%2F966%2Fa73380f.html&doc2=https%3A%2F%2Fwhatpr.org%2Fdom%2F966.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%23966.)._
</details>
