### PR TITLE
Editorial: major change to align with IDL and Infra

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -534,17 +534,16 @@ the empty list.</p>
 initialized to. When an <a>event</a> is created the attribute must be initialized to the empty
 string.
 
-<p>The <dfn attribute for=Event><code>target</code></dfn> attribute's getter, when invoked, must
-return <a>this</a>'s <a for=Event>target</a>.
+<p>The <dfn attribute for=Event><code>target</code></dfn> getter steps are to return <a>this</a>'s
+<a for=Event>target</a>.
 
-<p>The <dfn attribute for=Event><code>srcElement</code></dfn> attribute's getter, when invoked, must
-return <a>this</a>'s <a for=Event>target</a>.
+<p>The <dfn attribute for=Event><code>srcElement</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Event>target</a>.
 
 <p>The <dfn attribute for=Event><code>currentTarget</code></dfn> attribute must return the value it
 was initialized to. When an <a>event</a> is created the attribute must be initialized to null.
 
-<p>The <dfn method for=Event><code>composedPath()</code></dfn> method, when invoked, must run these
-steps:
+<p>The <dfn method for=Event><code>composedPath()</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>composedPath</var> be an empty <a for=/>list</a>.
@@ -680,18 +679,18 @@ initialized to, which must be one of the following:
  <li><dfn export for=Event id=dispatch-flag>dispatch flag</dfn>
 </ul>
 
-<p>The <dfn method for=Event><code>stopPropagation()</code></dfn> method, when invoked, must set
+<p>The <dfn method for=Event><code>stopPropagation()</code></dfn> method steps are to set
 <a>this</a>'s <a>stop propagation flag</a>.</p>
 
-<p>The <dfn attribute for=Event><code>cancelBubble</code></dfn> attribute's getter, when invoked,
-must return true if <a>this</a>'s <a>stop propagation flag</a> is set, and false otherwise.
+<p>The <dfn attribute for=Event><code>cancelBubble</code></dfn> getter steps are to return true if
+<a>this</a>'s <a>stop propagation flag</a> is set; otherwise false.
 
-<p>The {{Event/cancelBubble}} attribute's setter, when invoked, must set <a>this</a>'s
-<a>stop propagation flag</a> if the given value is true, and do nothing otherwise.
+<p>The {{Event/cancelBubble}} setter steps are to set <a>this</a>'s <a>stop propagation flag</a> if
+the given value is true; otherwise do nothing.
 
-<p>The <dfn method for=Event><code>stopImmediatePropagation()</code></dfn> method, when invoked,
-must set <a>this</a>'s <a>stop propagation flag</a> and <a>this</a>'s
-<a>stop immediate propagation flag</a>.</p>
+<p>The <dfn method for=Event><code>stopImmediatePropagation()</code></dfn> method steps are to set
+<a>this</a>'s <a>stop propagation flag</a> and <a>this</a>'s
+<a>stop immediate propagation flag</a>.
 
 <p>The <dfn attribute for=Event><code>bubbles</code></dfn> and
 <dfn attribute for=Event><code>cancelable</code></dfn> attributes must return the values they were
@@ -702,24 +701,24 @@ initialized to.
 <a>in passive listener flag</a> is unset, then set <var>event</var>'s <a>canceled flag</a>, and do
 nothing otherwise.
 
-<p>The <dfn attribute for=Event><code>returnValue</code></dfn> attribute's getter, when invoked,
-must return false if <a>this</a>'s <a>canceled flag</a> is set, and true otherwise.
+<p>The <dfn attribute for=Event><code>returnValue</code></dfn> getter steps are to return false if
+<a>this</a>'s <a>canceled flag</a> is set; otherwise true.
 
-<p>The {{Event/returnValue}} attribute's setter, when invoked, must <a>set the canceled flag</a>
-with <a>this</a> if the given value is false, and do nothing otherwise.
+<p>The {{Event/returnValue}} setter steps are to <a>set the canceled flag</a> with <a>this</a> if
+the given value is false; otherwise do nothing.
 
-<p>The <dfn method for=Event><code>preventDefault()</code></dfn> method, when invoked, must
+<p>The <dfn method for=Event><code>preventDefault()</code></dfn> method steps are to
 <a>set the canceled flag</a> with <a>this</a>.
 
 <p class="note no-backref">There are scenarios where invoking {{Event/preventDefault()}} has no
 effect. User agents are encouraged to log the precise cause in a developer console, to aid
 debugging.
 
-<p>The <dfn attribute for=Event><code>defaultPrevented</code></dfn> attribute's getter, when
-invoked, must return true if <a>this</a>'s <a>canceled flag</a> is set, and false otherwise.</p>
+<p>The <dfn attribute for=Event><code>defaultPrevented</code></dfn> getter steps are to return true
+if <a>this</a>'s <a>canceled flag</a> is set; otherwise false.
 
-<p>The <dfn attribute for=Event><code>composed</code></dfn> attribute's getter, when invoked, must
-return true if <a>this</a>'s <a>composed flag</a> is set, and false otherwise.</p>
+<p>The <dfn attribute for=Event><code>composed</code></dfn> getter steps are to return true if
+<a>this</a>'s <a>composed flag</a> is set; otherwise false.
 
 <hr>
 
@@ -759,7 +758,7 @@ initialized to.
 
 <p>The
 <dfn method for=Event><code>initEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>)</code></dfn>
-method, when invoked, must run these steps:</p>
+method steps are:
 
 <ol>
  <li><p>If <a>this</a>'s <a>dispatch flag</a> is set, then return.
@@ -783,8 +782,8 @@ partial interface Window {
 <p>Each {{Window}} object has an associated <dfn for=Window>current event</dfn> (undefined or an
 {{Event}} object). Unless stated otherwise it is undefined.
 
-<p>The <dfn attribute for=Window><code>event</code></dfn> attribute's getter, when invoked, must
-return <a>this</a>'s <a for=Window>current event</a>.
+<p>The <dfn attribute for=Window><code>event</code></dfn> getter steps are to return <a>this</a>'s
+<a for=Window>current event</a>.
 
 <p class=note>Web developers are strongly encouraged to instead rely on the {{Event}} object passed
 to event listeners, as that will result in more portable code. This attribute is not available in
@@ -1100,8 +1099,8 @@ steps:
  <li><p>Return <var>capture</var>, <var>passive</var>, <var>once</var>, and <var>signal</var>.
 </ol>
 
-<p>The <dfn constructor for=EventTarget><code>EventTarget()</code></dfn> constructor, when invoked,
-must return a new {{EventTarget}}.
+<p>The <dfn constructor for=EventTarget lt=EventTarget()><code>new EventTarget()</code></dfn>
+constructor steps are to do nothing.
 
 <p class="note">Because of the defaults stated elsewhere, the returned {{EventTarget}}'s
 <a>get the parent</a> algorithm will return null, and it will have no <a>activation behavior</a>,
@@ -1149,7 +1148,7 @@ the same code path. [[HTML]]
 
 <p>The
 <dfn method for=EventTarget><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>capture</var>, <var>passive</var>, and <var>once</var> be the result of
@@ -1188,7 +1187,7 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>capture</var> be the result of <a>flattening</a> <var>options</var>.
@@ -1204,8 +1203,8 @@ method, when invoked, must run these steps:
 <var>type</var>, <var>callback</var>, and <var>capture</var>, as <a>add an event listener</a>
 prevents that.
 
-<p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>If <var>event</var>'s <a>dispatch flag</a> is set, or if its <a>initialized flag</a> is not
@@ -2767,9 +2766,9 @@ DocumentFragment includes NonElementParentNode;
 </dl>
 
 <p>The <dfn method for=NonElementParentNode><code>getElementById(<var>elementId</var>)</code></dfn>
-method, when invoked, must return the first <a for="/">element</a>, in <a>tree order</a>, within
-<a>this</a>'s <a>descendants</a>, whose <a for=Element>ID</a> is <var>elementId</var>, and null if
-there is no such <a for="/">element</a> otherwise.
+method steps are to return the first <a for="/">element</a>, in <a>tree order</a>, within
+<a>this</a>'s <a>descendants</a>, whose <a for=Element>ID</a> is <var>elementId</var>; otherwise, if
+there is no such <a for="/">element</a>, null.
 
 
 <h4 id=mixin-documentorshadowroot>Mixin {{DocumentOrShadowRoot}}</h4>
@@ -2879,21 +2878,20 @@ Element includes ParentNode;
   match <var>selectors</var>.
 </dl>
 
-<p>The <dfn attribute for=ParentNode><code>children</code></dfn> attribute's getter must return an
-{{HTMLCollection}} <a>collection</a> rooted at <a>this</a> matching only <a for="/">element</a>
+<p>The <dfn attribute for=ParentNode><code>children</code></dfn> getter steps are to return an
+{{HTMLCollection}} <a>collection</a> rooted at <a>this</a> matching only <a for=/>element</a>
 <a>children</a>.
 
-<p>The <dfn attribute for=ParentNode><code>firstElementChild</code></dfn> attribute's getter must
-return the first <a for=tree>child</a> that is an <a for="/">element</a>, and null otherwise.
+<p>The <dfn attribute for=ParentNode><code>firstElementChild</code></dfn> getter steps are to return
+the first <a for=tree>child</a> that is an <a for="/">element</a>; otherwise null.
 
-<p>The <dfn attribute for=ParentNode><code>lastElementChild</code></dfn> attribute's getter must
-return the last <a for=tree>child</a> that is an <a for="/">element</a>, and null otherwise.
+<p>The <dfn attribute for=ParentNode><code>lastElementChild</code></dfn> getter steps are to return
+the last <a for=tree>child</a> that is an <a for="/">element</a>; otherwise null.
 
-<p>The <dfn attribute for=ParentNode><code>childElementCount</code></dfn> attribute's getter must
-return the number of <a>children</a> of <a>this</a> that are <a for="/">elements</a>.
+<p>The <dfn attribute for=ParentNode><code>childElementCount</code></dfn> getter steps are to return
+the number of <a>children</a> of <a>this</a> that are <a for=/>elements</a>.
 
-<p>The <dfn method for=ParentNode><code>prepend(<var>nodes</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=ParentNode><code>prepend(<var>nodes</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
@@ -2903,8 +2901,7 @@ must run these steps:
  <a for=tree>first child</a>.
 </ol>
 
-<p>The <dfn method for=ParentNode><code>append(<var>nodes</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=ParentNode><code>append(<var>nodes</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
@@ -2913,8 +2910,8 @@ must run these steps:
  <li><p><a>Append</a> <var>node</var> to <a>this</a>.
 </ol>
 
-<p>The <dfn method for=ParentNode><code>replaceChildren(<var>nodes</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=ParentNode><code>replaceChildren(<var>nodes</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
@@ -2926,12 +2923,12 @@ must run these steps:
  <li><p><a for=Node>Replace all</a> with <var>node</var> within <a>this</a>.
 </ol>
 
-<p>The <dfn method for=ParentNode><code>querySelector(<var>selectors</var>)</code></dfn> method,
-when invoked, must return the first result of running <a>scope-match a selectors string</a>
+<p>The <dfn method for=ParentNode><code>querySelector(<var>selectors</var>)</code></dfn> method
+steps are to return the first result of running <a>scope-match a selectors string</a>
 <var>selectors</var> against <a>this</a>, if the result is not an empty list, and null otherwise.
 
-<p>The <dfn method for=ParentNode><code>querySelectorAll(<var>selectors</var>)</code></dfn>
-method, when invoked, must return the <a lt="static collection">static</a> result of running
+<p>The <dfn method for=ParentNode><code>querySelectorAll(<var>selectors</var>)</code></dfn> method
+steps are to return the <a lt="static collection">static</a> result of running
 <a>scope-match a selectors string</a> <var>selectors</var> against <a>this</a>.
 
 
@@ -2964,13 +2961,13 @@ CharacterData includes NonDocumentTypeChildNode;
  is an <a for="/">element</a>, and null otherwise.
 </dl>
 
-<p>The <dfn attribute for=NonDocumentTypeChildNode><code>previousElementSibling</code></dfn>
-attribute's getter must return the first <a>preceding</a> <a for=tree>sibling</a> that is an
-<a for="/">element</a>, and null otherwise.
+<p>The <dfn attribute for=NonDocumentTypeChildNode><code>previousElementSibling</code></dfn> getter
+steps are to return the first <a>preceding</a> <a for=tree>sibling</a> that is an
+<a for=/>element</a>; otherwise null.
 
-<p>The <dfn attribute for=NonDocumentTypeChildNode><code>nextElementSibling</code></dfn> attribute's
-getter must return the first <a>following</a> <a for=tree>sibling</a> that is an
-<a for=/>element</a>, and null otherwise.
+<p>The <dfn attribute for=NonDocumentTypeChildNode><code>nextElementSibling</code></dfn> getter
+steps are to return the first <a>following</a> <a for=tree>sibling</a> that is an
+<a for=/>element</a>; otherwise null.
 
 
 <h4 id=interface-childnode>Mixin {{ChildNode}}</h4>
@@ -3016,8 +3013,7 @@ CharacterData includes ChildNode;
  <dd>Removes <var>node</var>.
 </dl>
 
-<p>The <dfn method for=ChildNode><code>before(<var>nodes</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=ChildNode><code>before(<var>nodes</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>parent</var> be <a>this</a>'s <a for=tree>parent</a>.
@@ -3038,8 +3034,7 @@ must run these steps:
  <var>viablePreviousSibling</var>.
 </ol>
 
-<p>The <dfn method for=ChildNode><code>after(<var>nodes</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=ChildNode><code>after(<var>nodes</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>parent</var> be <a>this</a>'s <a for=tree>parent</a>.
@@ -3056,8 +3051,7 @@ must run these steps:
  <var>viableNextSibling</var>.
 </ol>
 
-<p>The <dfn method for=ChildNode><code>replaceWith(<var>nodes</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=ChildNode><code>replaceWith(<var>nodes</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>parent</var> be <a>this</a>'s <a for=tree>parent</a>.
@@ -3080,8 +3074,7 @@ invoked, must run these steps:
  <var>viableNextSibling</var>.
 </ol>
 
-<p>The <dfn method for=ChildNode><code>remove()</code></dfn> method, when invoked, must run these
-steps:
+<p>The <dfn method for=ChildNode><code>remove()</code></dfn> method steps are:
 
 <ol>
  <li><p>If <a>this</a>'s <a for=tree>parent</a> is null, then return.
@@ -3101,8 +3094,8 @@ Text includes Slottable;
 </pre>
 
 <p>The <dfn attribute for=Slottable id=dom-slotable-assignedslot><code>assignedSlot</code></dfn>
-attribute's getter must return the result of <a>find a slot</a> given <a>this</a> and with the
-<i>open flag</i> set.</p>
+getter steps are to return the result of <a>find a slot</a> given <a>this</a> and with the
+<i>open flag</i> set.
 
 
 <h4 id=old-style-collections>Old-style collections: {{NodeList}} and {{HTMLCollection}}</h4>
@@ -3208,13 +3201,13 @@ it (use <code>sequence&lt;T></code> in IDL instead).
 the number of elements <a for=collection>represented by the collection</a>. If there are no such
 elements, then there are no <a>supported property indices</a>.
 
-<p>The <dfn attribute for=HTMLCollection><code>length</code></dfn> attribute's getter must return
-the number of nodes <a for=collection>represented by the collection</a>.
+<p>The <dfn attribute for=HTMLCollection><code>length</code></dfn> getter steps are to return the
+number of nodes <a for=collection>represented by the collection</a>.
 
-<p>The <dfn method for=HTMLCollection><code>item(<var>index</var>)</code></dfn> method, when
-invoked, must return the <var>index</var><sup>th</sup> <a for="/">element</a> in the
-<a>collection</a>. If there is no <var>index</var><sup>th</sup> <a for="/">element</a> in the
-<a>collection</a>, then the method must return null.
+<p>The <dfn method for=HTMLCollection><code>item(<var>index</var>)</code></dfn> method steps are to
+return the <var>index</var><sup>th</sup> <a for="/">element</a> in the <a>collection</a>. If there
+is no <var>index</var><sup>th</sup> <a for="/">element</a> in the <a>collection</a>, then the method
+must return null.
 
 <p>The <a>supported property names</a> are the values from the list returned by these steps:
 
@@ -3239,8 +3232,7 @@ invoked, must return the <var>index</var><sup>th</sup> <a for="/">element</a> in
  <li><p>Return <var>result</var>.
 </ol>
 
-<p>The <dfn method for=HTMLCollection><code>namedItem(<var>key</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=HTMLCollection><code>namedItem(<var>key</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>key</var> is the empty string, return null.
@@ -3453,22 +3445,19 @@ dictionary MutationObserverInit {
 </dl>
 
 <p>The
-<dfn constructor for=MutationObserver><code>MutationObserver(<var>callback</var>)</code></dfn>
-constructor, when invoked, must run these steps:
+<dfn constructor for=MutationObserver lt=MutationObserver(callback)><code>new MutationObserver(<var>callback</var>)</code></dfn>
+constructor steps are:
 
 <ol>
- <li><p>Let <var>mo</var> be a new {{MutationObserver}} object whose
- <a for=MutationObserver>callback</a> is <var>callback</var>.
+ <li><p>Set <a>this</a>'s <a for=MutationObserver>callback</a> to <var>callback</var>.
 
- <li><p><a for=set>Append</a> <var>mo</var> to <var>mo</var>'s <a>relevant agent</a>'s
+ <li><p><a for=set>Append</a> <a>this</a> to <a>this</a>'s <a>relevant agent</a>'s
  <a>mutation observers</a>.
-
- <li><p>Return <var>mo</var>.
 </ol>
 
 <p>The
 <dfn method for=MutationObserver><code>observe(<var>target</var>, <var>options</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>If either <var>options</var>'s {{MutationObserverInit/attributeOldValue}} or
@@ -3525,8 +3514,7 @@ method, when invoked, must run these steps:
   </ol>
 </ol>
 
-<p>The <dfn method for=MutationObserver><code>disconnect()</code></dfn> method, when invoked, must
-run these steps:
+<p>The <dfn method for=MutationObserver><code>disconnect()</code></dfn> method steps are:
 
 <ol>
  <li><p><a for=list>For each</a> <var>node</var> of <a>this</a>'s
@@ -3537,8 +3525,7 @@ run these steps:
  <li><p><a for=queue>Empty</a> <a>this</a>'s <a for=MutationObserver>record queue</a>.
 </ol>
 
-<p>The <dfn method for=MutationObserver><code>takeRecords()</code></dfn> method, when invoked, must
-run these steps:
+<p>The <dfn method for=MutationObserver><code>takeRecords()</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>records</var> be a <a for=queue>clone</a> of <a>this</a>'s
@@ -3889,8 +3876,8 @@ is used by all <a for=/>nodes</a> ({{Document}}, {{DocumentType}}, {{DocumentFra
   </dl>
 </dl>
 
-The <dfn attribute for=Node>nodeType</dfn> attribute's getter, when invoked, must return
-the first matching statement, switching on <a>this</a>:
+<p>The <dfn attribute for=Node>nodeType</dfn> getter steps are to return the first matching
+statement, switching on <a>this</a>:
 
 <dl class=switch>
  <dt>{{Element}}
@@ -3948,7 +3935,7 @@ The <dfn attribute for=Node>localName</dfn> attribute
 must return the local name that is associated with the node, if it has one,
 and null otherwise.-->
 
-<p>The <dfn attribute for=Node>nodeName</dfn> attribute's getter, when invoked, must return the
+<p>The <dfn attribute for=Node>nodeName</dfn> getter steps are to return the
 first matching statement, switching on <a>this</a>:
 
 <dl class=switch>
@@ -3987,7 +3974,7 @@ first matching statement, switching on <a>this</a>:
  <dd>Returns <var>node</var>'s <a for=Node>node document</a>'s <a>document base URL</a>.
 </dl>
 
-The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must return
+The <dfn attribute for=Node><code>baseURI</code></dfn> getter steps are to return
 <a for=Node>node document</a>'s <a>document base URL</a>, <a lt="URL serializer" spec=url>serialized</a>.
 
 <hr>
@@ -4035,45 +4022,45 @@ The <dfn attribute for=Node><code>baseURI</code></dfn> attribute's getter must r
  <a for=tree>next sibling</a>.
 </dl>
 
-<p>The <dfn attribute for=Node><code>isConnected</code></dfn> attribute's getter must return true,
+<p>The <dfn attribute for=Node><code>isConnected</code></dfn> getter steps are to return true,
 if <a>this</a> is <a>connected</a>, and false otherwise.</p>
 
-<p>The <dfn attribute for=Node><code>ownerDocument</code></dfn> attribute's getter must return null,
+<p>The <dfn attribute for=Node><code>ownerDocument</code></dfn> getter steps are to return null,
 if <a>this</a> is a <a>document</a>, and <a>this</a>'s <a for=Node>node document</a> otherwise.
 
-<p class="note">The <a for=Node>node document</a> of a <a>document</a> is that <a>document</a> itself. All
-<a for=/>nodes</a> have a <a for=Node>node document</a> at all times.
+<p class=note>The <a for=Node>node document</a> of a <a>document</a> is that <a>document</a> itself.
+All <a for=/>nodes</a> have a <a for=Node>node document</a> at all times.
 
-<p>The <dfn method for=Node><code>getRootNode(<var>options</var>)</code></dfn> method, when invoked,
-must return <a>this</a>'s <a>shadow-including root</a> if <var>options</var>'s
-{{GetRootNodeOptions/composed}} is true, and <a>this</a>'s <a for=tree>root</a> otherwise.
+<p>The <dfn method for=Node><code>getRootNode(<var>options</var>)</code></dfn> method steps are to
+return <a>this</a>'s <a>shadow-including root</a> if <var>options</var>'s
+{{GetRootNodeOptions/composed}} is true; otherwise <a>this</a>'s <a for=tree>root</a>.
 
-<p>The <dfn attribute for=Node><code>parentNode</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Node><code>parentNode</code></dfn> getter steps are to return
 <a>this</a>'s <a for=tree>parent</a>.
 
 <p class="note">An {{Attr}} <a>node</a> has no <a for=tree>parent</a>.
 
-<p>The <dfn attribute for=Node><code>parentElement</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Node><code>parentElement</code></dfn> getter steps are to return
 <a>this</a>'s <a>parent element</a>.
 
-<p>The <dfn method for=Node><code>hasChildNodes()</code></dfn> method, when invoked, must return
-true if <a>this</a> has <a>children</a>, and false otherwise.
+<p>The <dfn method for=Node><code>hasChildNodes()</code></dfn> method steps are to return true if
+<a>this</a> has <a>children</a>; otherwise false.
 
-<p>The <dfn attribute for=Node><code>childNodes</code></dfn> attribute's getter must return a
+<p>The <dfn attribute for=Node><code>childNodes</code></dfn> getter steps are to return a
 {{NodeList}} rooted at <a>this</a> matching only <a>children</a>.
 
-<p>The <dfn attribute for=Node><code>firstChild</code> </dfn> attribute's getter must return
+<p>The <dfn attribute for=Node><code>firstChild</code> </dfn> getter steps are to return
 <a>this</a>'s <a for=tree>first child</a>.
 
-<p>The <dfn attribute for=Node><code>lastChild</code></dfn> attribute's getter must return
-<a>this</a>'s <a>last child</a>.
+<p>The <dfn attribute for=Node><code>lastChild</code></dfn> getter steps are to return <a>this</a>'s
+<a>last child</a>.
 
-<p>The <dfn attribute for=Node><code>previousSibling</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Node><code>previousSibling</code></dfn> getter steps are to return
 <a>this</a>'s <a>previous sibling</a>.
 
 <p class="note">An {{Attr}} <a>node</a> has no <a for=tree>siblings</a>.
 
-<p>The <dfn attribute for=Node><code>nextSibling</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Node><code>nextSibling</code></dfn> getter steps are to return
 <a>this</a>'s <a for=tree>next sibling</a>.
 
 <hr>
@@ -4114,7 +4101,7 @@ instead, and then do as described below, depending on <a>this</a>:
  <dd><p>Do nothing.
 </dl>
 
-<p>The <dfn attribute for=Node><code>textContent</code></dfn> attribute's getter must return the
+<p>The <dfn attribute for=Node><code>textContent</code></dfn> getter steps are to return the
 following, switching on <a>this</a>:
 
 <dl class=switch>
@@ -4147,8 +4134,8 @@ following, switching on <a>this</a>:
  <li><p><a for=Node>Replace all</a> with <var>node</var> within <var>parent</var>.
 </ol>
 
-<p>The {{Node/textContent}} attribute's setter must, if the given value is null, act as if it was
-the empty string instead, and then do as described below, switching on <a>this</a>:
+<p>The {{Node/textContent}} setter steps are to, if the given value is null, act as if it was the
+empty string instead, and then do as described below, switching on <a>this</a>:
 
 <dl class=switch>
  <dt>{{DocumentFragment}}
@@ -4177,9 +4164,8 @@ the empty string instead, and then do as described below, switching on <a>this</
  into the first of their <a for=/>nodes</a>.
 </dl>
 
-<p>The <dfn method for=Node><code>normalize()</code></dfn> method, when invoked, must run these
-steps for each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>node</var> of
-<a>this</a>:
+<p>The <dfn method for=Node><code>normalize()</code></dfn> method steps are to run these steps for
+each <a>descendant</a> <a>exclusive <code>Text</code> node</a> <var>node</var> of <a>this</a>:
 
 <ol>
  <li>Let <var>length</var> be <var>node</var>'s <a for=Node>length</a>.
@@ -4330,8 +4316,7 @@ dom-Range-extractContents, dom-Range-cloneContents -->
  <li>Return <var>copy</var>.
 </ol>
 
-<p>The <dfn method for=Node><code>cloneNode(<var>deep</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Node><code>cloneNode(<var>deep</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <a>this</a> is a <a for=/>shadow root</a>, then <a>throw</a> a
@@ -4385,12 +4370,12 @@ A <a>node</a> <var>A</var>
  <a for=tree>index</a>.
 </ul>
 
-<p>The <dfn method for=Node><code>isEqualNode(<var>otherNode</var>)</code></dfn> method, when
-invoked, must return true if <var>otherNode</var> is non-null and <a>this</a> <a for=Node>equals</a>
-<var>otherNode</var>, and false otherwise.
+<p>The <dfn method for=Node><code>isEqualNode(<var>otherNode</var>)</code></dfn> method steps are to
+return true if <var>otherNode</var> is non-null and <a>this</a> <a for=Node>equals</a>
+<var>otherNode</var>; otherwise false.
 
-<p>The <dfn method for=Node><code>isSameNode(<var>otherNode</var>)</code></dfn> method, when
-invoked, must return true if <var>otherNode</var> is <a>this</a>, and false otherwise.
+<p>The <dfn method for=Node><code>isSameNode(<var>otherNode</var>)</code></dfn> method steps are to
+return true if <var>otherNode</var> is <a>this</a>; otherwise false.
 
 </div>
 
@@ -4447,8 +4432,8 @@ returns as mask:
  <li><dfn const for=Node>DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC</dfn> (32, 20 in hexadecimal).
 </ul>
 
-<p>The <dfn method for=Node><code>compareDocumentPosition(<var>other</var>)</code></dfn> method,
-when invoked, must run these steps:
+<p>The <dfn method for=Node><code>compareDocumentPosition(<var>other</var>)</code></dfn> method
+steps are:
 
 <ol>
  <li><p>If <a>this</a> is <var>other</var>, then return zero.
@@ -4519,9 +4504,9 @@ when invoked, must run these steps:
  <li><p>Return {{Node/DOCUMENT_POSITION_FOLLOWING}}.
 </ol>
 
-<p>The <dfn method for=Node><code>contains(<var>other</var>)</code></dfn> method, when invoked, must
-return true if <var>other</var> is an <a>inclusive descendant</a> of <a>this</a>, and false
-otherwise (including when <var>other</var> is null).
+<p>The <dfn method for=Node><code>contains(<var>other</var>)</code></dfn> method steps are to return
+true if <var>other</var> is an <a>inclusive descendant</a> of <a>this</a>; otherwise false
+(including when <var>other</var> is null).
 
 <hr>
 
@@ -4610,8 +4595,7 @@ for an <var>element</var> using <var>namespace</var>, run these steps:
   </ol>
 </dl>
 
-<p>The <dfn method for=Node><code>lookupPrefix(<var>namespace</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Node><code>lookupPrefix(<var>namespace</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>namespace</var> is null or the empty string, then return null.
@@ -4641,8 +4625,8 @@ invoked, must run these steps:
   </dl>
 </ol>
 
-<p>The <dfn method for=Node><code>lookupNamespaceURI(<var>prefix</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Node><code>lookupNamespaceURI(<var>prefix</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>If <var>prefix</var> is the empty string, then set it to null.
@@ -4651,8 +4635,8 @@ invoked, must run these steps:
  <var>prefix</var>.
 </ol>
 
-<p>The <dfn method for=Node><code>isDefaultNamespace(<var>namespace</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Node><code>isDefaultNamespace(<var>namespace</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>If <var>namespace</var> is the empty string, then set it to null.
@@ -4667,18 +4651,18 @@ invoked, must run these steps:
 <hr>
 
 <p>The <dfn method for=Node><code>insertBefore(<var>node</var>, <var>child</var>)</code></dfn>
-method, when invoked, must return the result of <a>pre-inserting</a> <var>node</var> into
-<a>this</a> before <var>child</var>.
+method steps are to return the result of <a>pre-inserting</a> <var>node</var> into <a>this</a>
+before <var>child</var>.
 
-<p>The <dfn method for=Node><code>appendChild(<var>node</var>)</code></dfn> method, when invoked,
-must return the result of <a>appending</a> <var>node</var> to <a>this</a>.
+<p>The <dfn method for=Node><code>appendChild(<var>node</var>)</code></dfn> method steps are to
+return the result of <a>appending</a> <var>node</var> to <a>this</a>.
 
 <p>The <dfn method for=Node><code>replaceChild(<var>node</var>, <var>child</var>)</code></dfn>
-method, when invoked, must return the result of <a>replacing</a> <var>child</var> with
-<var>node</var> within <a>this</a>.
+method steps are to return the result of <a>replacing</a> <var>child</var> with <var>node</var>
+within <a>this</a>.
 
-<p>The <dfn method for=Node><code>removeChild(<var>child</var>)</code></dfn> method, when invoked,
-must return the result of <a>pre-removing</a> <var>child</var> from <a>this</a>.
+<p>The <dfn method for=Node><code>removeChild(<var>child</var>)</code></dfn> method steps are to
+return the result of <a>pre-removing</a> <var>child</var> from <a>this</a>.
 
 <hr><!-- Collections -->
 
@@ -4918,32 +4902,32 @@ null if <var>event</var>'s {{Event/type}} attribute value is "<code>load</code>"
  <a for=Document>content type</a>.
 </dl>
 
-<p>The <dfn constructor for=Document><code>Document()</code></dfn> constructor, when invoked, must
-return a new <a>document</a> whose <a for=Document>origin</a> is the <a for=Document>origin</a> of
+<p>The <dfn constructor for=Document lt=Document()><code>new Document()</code></dfn> constructor
+steps are to set <a>this</a>'s <a for=Document>origin</a> to the <a for=Document>origin</a> of
 <a>current global object</a>'s <a>associated <code>Document</code></a>. [[!HTML]]
 
 <p class="note no-backref">Unlike {{DOMImplementation/createDocument()}}, this constructor does not
 return an {{XMLDocument}} object, but a <a>document</a> ({{Document}} object).
 
-The
-<dfn attribute for=Document><code>implementation</code></dfn> attribute's getter must return the
-{{DOMImplementation}} object that is associated with the <a>document</a>.
+<p>The
+<dfn attribute for=Document><code>implementation</code></dfn> getter steps are to return the
+{{DOMImplementation}} object that is associated with <a>this</a>.
 
-The <dfn attribute for=Document><code>URL</code></dfn> attribute's getter and
-<dfn attribute for=Document><code>documentURI</code></dfn> attribute's getter must return the
+<p>The <dfn attribute for=Document><code>URL</code></dfn> and
+<dfn attribute for=Document><code>documentURI</code></dfn> getter steps are to return <a>this</a>'s
 <a for=Document>URL</a>, <a lt="URL serializer" spec=url>serialized</a>.
 
-The <dfn attribute for=Document><code>compatMode</code></dfn> attribute's getter must
-return "<code>BackCompat</code>" if <a>this</a>'s <a for=Document>mode</a> is
-"<code>quirks</code>", and "<code>CSS1Compat</code>" otherwise.
+<p>The <dfn attribute for=Document><code>compatMode</code></dfn> getter steps are to return
+"<code>BackCompat</code>" if <a>this</a>'s <a for=Document>mode</a> is "<code>quirks</code>";
+otherwise "<code>CSS1Compat</code>".
 
-The <dfn attribute for=Document><code>characterSet</code></dfn> attribute's getter,
-<dfn attribute for=Document><code>charset</code></dfn> attribute's getter, and
-<dfn attribute for=Document><code>inputEncoding</code></dfn> attribute's getter, must return
+<p>The <dfn attribute for=Document><code>characterSet</code></dfn>,
+<dfn attribute for=Document><code>charset</code></dfn>, and
+<dfn attribute for=Document><code>inputEncoding</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Document>encoding</a>'s <a for=encoding>name</a>.
 
-The <dfn attribute for=Document><code>contentType</code></dfn> attribute's getter must return the
-<a for=Document>content type</a>.
+<p>The <dfn attribute for=Document><code>contentType</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Document>content type</a>.
 
 <hr>
 
@@ -5007,15 +4991,15 @@ The <dfn attribute for=Document><code>contentType</code></dfn> attribute's gette
   space-separated list of classes.
 </dl>
 
-The <dfn attribute for=Document><code>doctype</code></dfn> attribute's getter must return the
-<a for=tree>child</a> of the <a>document</a> that is a <a>doctype</a>, and null otherwise.
+<p>The <dfn attribute for=Document><code>doctype</code></dfn> getter steps are to return the
+<a for=tree>child</a> of <a>this</a> that is a <a>doctype</a>; otherwise null.
 
-The <dfn attribute for=Document><code>documentElement</code></dfn> attribute's getter must return
-the <a>document element</a>.
+<p>The <dfn attribute for=Document><code>documentElement</code></dfn> getter steps are to return
+<a>this</a>'s <a>document element</a>.
 
-The <dfn method for=Document><code>getElementsByTagName(<var>qualifiedName</var>)</code></dfn>
-method, when invoked, must return the
-<a>list of elements with qualified name <var>qualifiedName</var></a> for <a>this</a>.
+<p>The <dfn method for=Document><code>getElementsByTagName(<var>qualifiedName</var>)</code></dfn>
+method steps are to return the <a>list of elements with qualified name <var>qualifiedName</var></a>
+for <a>this</a>.
 
 <p class="note no-backref">Thus, in an <a>HTML document</a>,
 <code class=lang-javascript>document.getElementsByTagName("FOO")</code> will match
@@ -5024,15 +5008,14 @@ method, when invoked, must return the
 the <a>HTML namespace</a>, but not <code>&lt;FOO></code> elements
 that are in the <a>HTML namespace</a>.
 
-The
+<p>The
 <dfn method for=Document><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must return the
-<a>list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for
-<a>this</a>.
+method steps are to return the <a>list of elements with namespace <var>namespace</var> and local
+name <var>localName</var></a> for <a>this</a>.
 
-The <dfn method for=Document><code>getElementsByClassName(<var>classNames</var>)</code></dfn>
-method, when invoked, must return the <a>list of elements with class names <var>classNames</var></a>
-for <a>this</a>.
+<p>The <dfn method for=Document><code>getElementsByClassName(<var>classNames</var>)</code></dfn>
+method steps are to return the <a>list of elements with class names <var>classNames</var></a> for
+<a>this</a>.
 
 <div class=example id=example-5ffcda00>
  Given the following XHTML fragment:
@@ -5148,8 +5131,9 @@ stated otherwise.
 and the <a>HTML namespace</a>, the {{HTMLHtmlElement}} interface is used.
 [[!HTML]]
 
-The <dfn method for=Document><code>createElement(<var>localName</var>, <var>options</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The
+<dfn method for=Document><code>createElement(<var>localName</var>, <var>options</var>)</code></dfn>
+method steps are:
 
 <ol>
  <li><p>If <var>localName</var> does not match the <code><a type>Name</a></code> production, then
@@ -5191,26 +5175,25 @@ invoked, must run these steps:
 
 <p>The
 <dfn method for=Document><code>createElementNS(<var>namespace</var>, <var>qualifiedName</var>, <var>options</var>)</code></dfn>
-method, when invoked, must return the result of running the
+method steps are to return the result of running the
 <a>internal <code>createElementNS</code> steps</a>, given <a>this</a>, <var>namespace</var>,
 <var>qualifiedName</var>, and <var>options</var>.
 
 <p class="note">{{Document/createElement()}} and {{Document/createElementNS()}}'s <var>options</var>
 parameter is allowed to be a string for web compatibility.
 
-The <dfn method for=Document><code>createDocumentFragment()</code></dfn> method, when invoked,
-must return a new {{DocumentFragment}} <a>node</a> with its <a for=Node>node document</a> set to
-<a>this</a>.
+<p>The <dfn method for=Document><code>createDocumentFragment()</code></dfn> method steps are to
+return a new {{DocumentFragment}} <a>node</a> whose <a for=Node>node document</a> is <a>this</a>.
 
-The <dfn method for=Document><code>createTextNode(<var>data</var>)</code></dfn> method, when
-invoked, must return a new {{Text}} <a>node</a> with its <a for=CharacterData>data</a> set to
-<var>data</var> and <a for=Node>node document</a> set to <a>this</a>.
+<p>The <dfn method for=Document><code>createTextNode(<var>data</var>)</code></dfn> method steps are
+to return a new {{Text}} <a>node</a> whose <a for=CharacterData>data</a> is <var>data</var> and
+<a for=Node>node document</a> is <a>this</a>.
 
 <p class="note no-backref">No check is performed that <var>data</var> consists of
 characters that match the <code><a type>Char</a></code> production.
 
-<p>The <dfn method for=Document><code>createCDATASection(<var>data</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Document><code>createCDATASection(<var>data</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>If <a>this</a> is an <a>HTML document</a>, then <a>throw</a> a
@@ -5223,17 +5206,17 @@ invoked, must run these steps:
  <var>data</var> and <a for=Node>node document</a> set to <a>this</a>.
 </ol>
 
-The <dfn method for=Document><code>createComment(<var>data</var>)</code></dfn> method, when invoked,
-must return a new {{Comment}} <a>node</a> with its <a for=CharacterData>data</a> set to
-<var>data</var> and <a for=Node>node document</a> set to <a>this</a>.
+<p>The <dfn method for=Document><code>createComment(<var>data</var>)</code></dfn> method steps are
+to return a new {{Comment}} <a>node</a> whose <a for=CharacterData>data</a> is <var>data</var> and
+<a for=Node>node document</a> is <a>this</a>.
 
 <p class="note no-backref">No check is performed that <var>data</var> consists of
 characters that match the <code><a type>Char</a></code> production
 or that it contains two adjacent hyphens or ends with a hyphen.
 
-The
+<p>The
 <dfn method for=Document><code>createProcessingInstruction(<var>target</var>, <var>data</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li>If <var>target</var> does not match the
@@ -5280,8 +5263,8 @@ method, when invoked, must run these steps:
   "{{HierarchyRequestError!!exception}}" {{DOMException}}.
 </dl>
 
-The <dfn method for=Document><code>importNode(<var>node</var>, <var>deep</var>)</code></dfn> method,
-when invoked, must run these steps:
+<p>The <dfn method for=Document><code>importNode(<var>node</var>, <var>deep</var>)</code></dfn>
+method steps are:
 
 <ol>
  <li><p>If <var>node</var> is a <a>document</a> or <a for=/>shadow root</a>, then <a>throw</a> a
@@ -5333,8 +5316,7 @@ these steps:
   </ol>
 </ol>
 
-The <dfn method for=Document><code>adoptNode(<var>node</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=Document><code>adoptNode(<var>node</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>node</var> is a <a>document</a>, then <a>throw</a> a
@@ -5353,8 +5335,8 @@ must run these steps:
 
 <hr>
 
-The <dfn method for=Document><code>createAttribute(<var>localName</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Document><code>createAttribute(<var>localName</var>)</code></dfn> method
+steps are:
 
 <ol>
  <li><p>If <var>localName</var> does not match the <code><a type>Name</a></code> production in XML,
@@ -5367,9 +5349,9 @@ invoked, must run these steps:
  <a for=Node>node document</a> is <a>this</a>.
 </ol>
 
-The
+<p>The
 <dfn method for=Document><code>createAttributeNS(<var>namespace</var>, <var>qualifiedName</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>namespace</var>, <var>prefix</var>, and <var>localName</var> be the result of
@@ -5382,8 +5364,8 @@ method, when invoked, must run these steps:
 
 <hr>
 
-<p>The <dfn method for=Document><code>createEvent(<var>interface</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Document><code>createEvent(<var>interface</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>Let <var>constructor</var> be null.
@@ -5451,8 +5433,8 @@ invoked, must run these steps:
 
 <hr>
 
-<p>The <dfn method for=Document><code>createRange()</code></dfn> method, when invoked, must return a
-new <a>live range</a> with (<a>this</a>, 0) as its <a for=range>start</a> an <a for=range>end</a>.
+<p>The <dfn method for=Document><code>createRange()</code></dfn> method steps are to return a new
+<a>live range</a> with (<a>this</a>, 0) as its <a for=range>start</a> an <a for=range>end</a>.
 
 <p class=note>The {{Range/Range()}} constructor can be used instead.
 
@@ -5460,7 +5442,7 @@ new <a>live range</a> with (<a>this</a>, 0) as its <a for=range>start</a> an <a 
 
 <p>The
 <dfn method for=Document><code>createNodeIterator(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>iterator</var> be a new {{NodeIterator}} object.
@@ -5479,7 +5461,7 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for=Document><code>createTreeWalker(<var>root</var>, <var>whatToShow</var>, <var>filter</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>walker</var> be a new {{TreeWalker}} object.
@@ -5550,9 +5532,9 @@ interface DOMImplementation {
 
 <div class=impl>
 
-The
+<p>The
 <dfn method for=DOMImplementation><code>createDocumentType(<var>qualifiedName</var>, <var>publicId</var>, <var>systemId</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p><a>Validate</a> <var>qualifiedName</var>.
@@ -5569,7 +5551,7 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for=DOMImplementation><code>createDocument(<var>namespace</var>, <var>qualifiedName</var>, <var>doctype</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>document</var> be a new {{XMLDocument}}.
@@ -5604,9 +5586,9 @@ method, when invoked, must run these steps:
  <li><p>Return <var>document</var>.
 </ol>
 
-The
+<p>The
 <dfn method for=DOMImplementation><code>createHTMLDocument(<var>title</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>doc</var> be a new <a>document</a> that is an <a>HTML document</a>.
@@ -5644,8 +5626,8 @@ method, when invoked, must run these steps:
  <li><p>Return <var>doc</var>.
 </ol>
 
-The <dfn method for="DOMImplementation"><code>hasFeature()</code></dfn> method, when
-invoked, must return true.
+<p>The <dfn method for="DOMImplementation"><code>hasFeature()</code></dfn> method steps are to
+return true.
 
 <p class="note no-backref">{{hasFeature()}} originally would report whether the user agent
 claimed to support a given DOM feature, but experience proved it was not nearly as
@@ -5679,13 +5661,13 @@ interface DocumentType : Node {
 explicitly given when a <a>doctype</a> is created, its <a>public ID</a> and <a>system ID</a> are the
 empty string.
 
-<p>The <dfn attribute for=DocumentType><code>name</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=DocumentType><code>name</code></dfn> getter steps are to return
 <a>this</a>'s <a for=DocumentType>name</a>.
 
-<p>The <dfn attribute for=DocumentType><code>publicId</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=DocumentType><code>publicId</code></dfn> getter steps are to return
 <a>this</a>'s <a>public ID</a>.
 
-<p>The <dfn attribute for=DocumentType><code>systemId</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=DocumentType><code>systemId</code></dfn> getter steps are to return
 <a>this</a>'s <a>system ID</a>.
 
 
@@ -5718,8 +5700,9 @@ concept is useful for HTML's <{template}> element and for <a for=/>shadow roots<
  <dd>Returns a new {{DocumentFragment}} <a>node</a>.
 </dl>
 
-<p>The <dfn constructor for=DocumentFragment><code>DocumentFragment()</code></dfn> constructor, when
-invoked, must return a new {{DocumentFragment}} <a>node</a> whose <a for=Node>node document</a> is
+<p>The
+<dfn constructor for=DocumentFragment lt=DocumentFragment()><code>new DocumentFragment()</code></dfn>
+constructor steps are to set <a>this</a>'s <a for=Node>node document</a> to
 <a>current global object</a>'s <a>associated <code>Document</code></a>.
 
 
@@ -5763,10 +5746,10 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 <a for=Event/path>invocation target</a>, and <a for=/>shadow root</a>'s
 <a for=DocumentFragment>host</a> otherwise.
 
-<p>The <dfn attribute for=ShadowRoot><code>mode</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=ShadowRoot><code>mode</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>mode</a>.</p>
 
-<p>The <dfn attribute for=ShadowRoot><code>host</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=ShadowRoot><code>host</code></dfn> getter steps are to return
 <a>this</a>'s <a for=DocumentFragment>host</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>onslotchange</code></dfn> attribute is an
@@ -6409,16 +6392,16 @@ A <a>node</a>'s
  <dd>Returns the <a for=Element>HTML-uppercased qualified name</a>.
 </dl>
 
-<p>The <dfn attribute for=Element><code>namespaceURI</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Element><code>namespaceURI</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Element>namespace</a>.
 
-<p>The <dfn attribute for=Element><code>prefix</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Element><code>prefix</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Element>namespace prefix</a>.
 
-<p>The <dfn attribute for=Element><code>localName</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Element><code>localName</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Element>local name</a>.
 
-<p>The <dfn attribute for=Element><code>tagName</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=Element><code>tagName</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Element>HTML-uppercased qualified name</a>.
 
 <hr>
@@ -6461,7 +6444,7 @@ steps:</p>
 <p>The <dfn attribute for=Element><code>className</code></dfn> attribute must
 <a for=Attr>reflect</a> the "<code>class</code>" content attribute.
 
-<p>The <dfn attribute for=Element><code>classList</code></dfn> attribute's getter must return a
+<p>The <dfn attribute for=Element><code>classList</code></dfn> getter steps are to return a
 {{DOMTokenList}} object whose associated <a for=/>element</a> is <a>this</a> and whose associated
 <a>attribute</a>'s <a for=Attr>local name</a> is <code>class</code>. The <a>token set</a> of this
 particular {{DOMTokenList}} object are also known as the <a for="/">element</a>'s
@@ -6527,22 +6510,21 @@ namespace.</p>
  is <var>namespace</var> and <a for=Attr>local name</a> is <var>localName</var>.
 </dl>
 
-<p>The <dfn method for=Element><code>hasAttributes()</code></dfn> method, when invoked, must return
-false if <a>this</a>'s <a for=Element>attribute list</a> <a for=list>is empty</a>, and true
-otherwise.
+<p>The <dfn method for=Element><code>hasAttributes()</code></dfn> method steps are to return false
+if <a>this</a>'s <a for=Element>attribute list</a> <a for=list>is empty</a>; otherwise true.
 
-<p>The <dfn attribute for=Element><code>attributes</code></dfn> attribute's getter must return the
+<p>The <dfn attribute for=Element><code>attributes</code></dfn> getter steps are to return the
 associated {{NamedNodeMap}}.
 
-<p>The <dfn method for=Element><code>getAttributeNames()</code></dfn> method, when invoked, must
-return the <a for=Attr>qualified names</a> of the <a>attributes</a> in <a>this</a>'s
-<a for=Element>attribute list</a>, in order, and a new <a for=/>list</a> otherwise.
+<p>The <dfn method for=Element><code>getAttributeNames()</code></dfn> method steps are to return the
+<a for=Attr>qualified names</a> of the <a>attributes</a> in <a>this</a>'s
+<a for=Element>attribute list</a>, in order; otherwise a new <a for=/>list</a>.
 
 <p class=note>These are not guaranteed to be unique.<!-- A theoretical getAttributeNamesNS() could
 return an array of unique two-value-arrays. -->
 
-<p>The <dfn method for=Element><code>getAttribute(<var>qualifiedName</var>)</code></dfn> method,
-when invoked, must run these steps:
+<p>The <dfn method for=Element><code>getAttribute(<var>qualifiedName</var>)</code></dfn> method
+steps are:
 
 <ol>
  <li><p>Let <var>attr</var> be the result of
@@ -6556,7 +6538,7 @@ when invoked, must run these steps:
 
 <p>The
 <dfn method for=Element><code>getAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>attr</var> be the result of
@@ -6570,7 +6552,7 @@ method, when invoked, must these steps:
 
 <p>The
 <dfn method for=Element><code>setAttribute(<var>qualifiedName</var>, <var>value</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>If <var>qualifiedName</var> does not match the <code><a type>Name</a></code> production in
@@ -6595,7 +6577,7 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for=Element><code>setAttributeNS(<var>namespace</var>, <var>qualifiedName</var>, <var>value</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>namespace</var>, <var>prefix</var>, and <var>localName</var> be the result of
@@ -6607,17 +6589,16 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for=Element><code>removeAttribute(<var>qualifiedName</var>)</code></dfn>
-method, when invoked, must <a lt="remove an attribute by name">remove an attribute</a> given
+method steps are to <a lt="remove an attribute by name">remove an attribute</a> given
 <var>qualifiedName</var> and <a>this</a>, and then return undefined.
 
 <p>The
 <dfn method for=Element><code>removeAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must
-<a lt="remove an attribute by namespace and local name">remove an attribute</a> given
-<var>namespace</var>, <var>localName</var>, and <a>this</a>, and then return undefined.
+method steps are to <a lt="remove an attribute by namespace and local name">remove an attribute</a>
+given <var>namespace</var>, <var>localName</var>, and <a>this</a>, and then return undefined.
 
-<p>The <dfn method for=Element><code>hasAttribute(<var>qualifiedName</var>)</code></dfn> method,
-when invoked, must run these steps:
+<p>The <dfn method for=Element><code>hasAttribute(<var>qualifiedName</var>)</code></dfn> method
+steps are:
 
 <ol>
  <li><p>If <a>this</a> is in the <a>HTML namespace</a> and its <a for=Node>node document</a> is an
@@ -6629,7 +6610,7 @@ when invoked, must run these steps:
 </ol>
 
 <p>The <dfn method for=Element><code>toggleAttribute(<var>qualifiedName</var>, <var>force</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>If <var>qualifiedName</var> does not match the <code><a type>Name</a></code> production in
@@ -6666,7 +6647,7 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for=Element><code>hasAttributeNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li>If <var>namespace</var> is the empty string, set it to null.
@@ -6682,13 +6663,12 @@ method, when invoked, must run these steps:
 <hr>
 
 <p>The <dfn method for=Element><code>getAttributeNode(<var>qualifiedName</var>)</code></dfn>
-method, when invoked, must return the result of
-<a lt="get an attribute by name">getting an attribute</a> given <var>qualifiedName</var> and
-<a>this</a>.
+method steps are to return the result of <a lt="get an attribute by name">getting an attribute</a>
+given <var>qualifiedName</var> and <a>this</a>.
 
 <p>The
 <dfn method for=Element><code>getAttributeNodeNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must return the result of
+method steps are to return the result of
 <a lt="get an attribute by namespace and local name">getting an attribute</a> given
 <var>namespace</var>, <var>localName</var>, and <a>this</a>.
 
@@ -6697,8 +6677,8 @@ method, when invoked, must return the result of
 invoked, must return the result of <a lt="set an attribute">setting an attribute</a> given
 <var>attr</var> and <a>this</a>.
 
-<p>The <dfn method for=Element><code>removeAttributeNode(<var>attr</var>)</code></dfn> method,
-when invoked, must run these steps:
+<p>The <dfn method for=Element><code>removeAttributeNode(<var>attr</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li><p>If <a>this</a>'s <a for=Element>attribute list</a> does not <a for=list>contain</a>
@@ -6720,8 +6700,7 @@ when invoked, must run these steps:
  <a for=/>shadow root</a>'s <a for=ShadowRoot>mode</a> is "<code>open</code>", and null otherwise.
 </dl>
 
-<p>The <dfn method for=Element><code>attachShadow(<var>init</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Element><code>attachShadow(<var>init</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <a>this</a>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
@@ -6793,8 +6772,7 @@ invoked, must run these steps:
  <li><p>Return <var>shadow</var>.
 </ol>
 
-<p>The <dfn attribute for=Element><code>shadowRoot</code></dfn> attribute's getter must run these
-steps:
+<p>The <dfn attribute for=Element><code>shadowRoot</code></dfn> getter steps are:
 
 <ol>
  <li><p>Let <var>shadow</var> be <a>this</a>'s <a for=Element>shadow root</a>.
@@ -6819,8 +6797,7 @@ steps:
  <var>element</var>, and false otherwise.
 </dl>
 
-The <dfn method for=Element><code>closest(<var>selectors</var>)</code></dfn>
-method, when invoked, must run these steps:
+<p>The <dfn method for=Element><code>closest(<var>selectors</var>)</code></dfn> method steps are:
 
 <ol>
  <li>Let <var>s</var> be the result of
@@ -6863,18 +6840,17 @@ are:
 <hr>
 
 <p>The <dfn method for=Element><code>getElementsByTagName(<var>qualifiedName</var>)</code></dfn>
-method, when invoked, must return the
-<a>list of elements with qualified name <var>qualifiedName</var></a> for <a>this</a>.
+method steps are to return the <a>list of elements with qualified name <var>qualifiedName</var></a>
+for <a>this</a>.
 
 <p>The
 <dfn method for=Element><code>getElementsByTagNameNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must return the
-<a>list of elements with namespace <var>namespace</var> and local name <var>localName</var></a> for
-<a>this</a>.
+method steps are to return the <a>list of elements with namespace <var>namespace</var> and local
+name <var>localName</var></a> for <a>this</a>.
 
 <p>The <dfn method for=Element><code>getElementsByClassName(<var>classNames</var>)</code></dfn>
-method, when invoked, must return the <a>list of elements with class names <var>classNames</var></a>
-for <a>this</a>.
+method steps are to return the <a>list of elements with class names <var>classNames</var></a> for
+<a>this</a>.
 
 <hr>
 
@@ -6911,12 +6887,12 @@ for <a>this</a>.
 
 <p>The
 <dfn method for=Element><code>insertAdjacentElement(<var>where</var>, <var>element</var>)</code></dfn>
-method, when invoked, must return the result of running <a>insert adjacent</a>, give <a>this</a>,
+method steps are to return the result of running <a>insert adjacent</a>, give <a>this</a>,
 <var>where</var>, and <var>element</var>.
 
 <p>The
 <dfn method for=Element><code>insertAdjacentText(<var>where</var>, <var>data</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>text</var> be a new {{Text}} <a>node</a>  whose <a for=CharacterData>data</a> is
@@ -6961,11 +6937,10 @@ range zero to its <a for=NamedNodeMap>attribute list</a>'s <a for=list>size</a> 
 the <a for=NamedNodeMap>attribute list</a> <a for=list>is empty</a>, in which case there are no
 <a>supported property indices</a>.
 
-<p>The <dfn attribute for="NamedNodeMap"><code>length</code></dfn> attribute's getter must return
+<p>The <dfn attribute for="NamedNodeMap"><code>length</code></dfn> getter steps are to return
 the <a for=NamedNodeMap>attribute list</a>'s <a for=list>size</a>.
 
-<p>The <dfn method for="NamedNodeMap"><code>item(<var>index</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for="NamedNodeMap"><code>item(<var>index</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>index</var> is equal to or greater than <a>this</a>'s
@@ -7001,16 +6976,14 @@ steps:
 </ol>
 
 <p>The <dfn method for="NamedNodeMap"><code>getNamedItem(<var>qualifiedName</var>)</code></dfn>
-method, when invoked, must return the result of
-<a lt="get an attribute by name">getting an attribute</a> given <var>qualifiedName</var> and
-<a for=NamedNodeMap>element</a>.
+method steps are to return the result of <a lt="get an attribute by name">getting an attribute</a>
+given <var>qualifiedName</var> and <a for=NamedNodeMap>element</a>.
 
 <p>The
 <dfn method for="NamedNodeMap"><code>getNamedItemNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must return the result of
+method steps are to return the result of
 <a lt="get an attribute by namespace and local name">getting an attribute</a> given
-<var>namespace</var>, <var>localName</var>, and
-<a for=NamedNodeMap>element</a>.
+<var>namespace</var>, <var>localName</var>, and <a for=NamedNodeMap>element</a>.
 
 <p>The <dfn method for="NamedNodeMap"><code>setNamedItem(<var>attr</var>)</code></dfn> and
 <dfn method for="NamedNodeMap"><code>setNamedItemNS(<var>attr</var>)</code></dfn>
@@ -7018,7 +6991,7 @@ methods, when invoked, must return the result of <a lt="set an attribute">settin
 given <var>attr</var> and <a for=NamedNodeMap>element</a>.
 
 <p>The <dfn method for="NamedNodeMap"><code>removeNamedItem(<var>qualifiedName</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>attr</var> be the result of
@@ -7033,7 +7006,7 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for="NamedNodeMap"><code>removeNamedItemNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>attr</var> be the result of
@@ -7104,19 +7077,19 @@ null.
 
 <hr>
 
-<p>The <dfn attribute for="Attr"><code>namespaceURI</code></dfn> attribute's getter must return the
-<a for=Attr>namespace</a>.
+<p>The <dfn attribute for="Attr"><code>namespaceURI</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Attr>namespace</a>.
 
-<p>The <dfn attribute for="Attr"><code>prefix</code></dfn> attribute's getter must return the
+<p>The <dfn attribute for="Attr"><code>prefix</code></dfn> getter steps are to return <a>this</a>'s
 <a for=Attr>namespace prefix</a>.
 
-<p>The <dfn attribute for="Attr"><code>localName</code></dfn> attribute's getter must return the
-<a for=Attr>local name</a>.
+<p>The <dfn attribute for="Attr"><code>localName</code></dfn> getter steps are to return
+<a>this</a>'s <a for=Attr>local name</a>.
 
-<p>The <dfn attribute for="Attr"><code>name</code></dfn> attribute's getter must return the
+<p>The <dfn attribute for="Attr"><code>name</code></dfn> getter steps are to return <a>this</a>'s
 <a for=Attr>qualified name</a>.
 
-<p>The <dfn attribute for="Attr"><code>value</code></dfn> attribute's getter must return the
+<p>The <dfn attribute for="Attr"><code>value</code></dfn> getter steps are to return <a>this</a>'s
 <a for=Attr>value</a>.
 
 <p>To <dfn>set an existing attribute value</dfn>, given an <a>attribute</a> <var>attribute</var> and
@@ -7129,17 +7102,17 @@ string <var>value</var>, run these steps:
  <li><p>Otherwise, <a lt="change an attribute">change</a> <var>attribute</var> to <var>value</var>.
 </ol>
 
-<p>The {{Attr/value}} attribute's setter must <a>set an existing attribute value</a> with
-<a>this</a> and the given value.
+<p>The {{Attr/value}} setter steps are to <a>set an existing attribute value</a> with <a>this</a>
+and the given value.
 
 <hr>
 
-<p>The <dfn attribute for="Attr"><code>ownerElement</code></dfn> attribute's getter must return
+<p>The <dfn attribute for="Attr"><code>ownerElement</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Attr>element</a>.
 
 <hr>
 
-<p>The <dfn attribute for="Attr"><code>specified</code></dfn> attribute's getter must return true.
+<p>The <dfn attribute for="Attr"><code>specified</code></dfn> getter steps are to return true.
 
 
 <h3 id=interface-characterdata>Interface {{CharacterData}}</h3>
@@ -7268,36 +7241,36 @@ To <dfn export for="CharacterData, Text, Comment, ProcessingInstruction" id=conc
  <a for=CharacterData>data</a>.
 </ol>
 
-<p>The <dfn attribute for=CharacterData><code>data</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=CharacterData><code>data</code></dfn> getter steps are to return
 <a>this</a>'s <a for=CharacterData>data</a>. Its setter must <a>replace data</a> with node
 <a>this</a>, offset 0, count <a>this</a>'s <a for=Node>length</a>, and data new value.
 
-<p>The <dfn attribute for=CharacterData><code>length</code></dfn> attribute's getter must return
+<p>The <dfn attribute for=CharacterData><code>length</code></dfn> getter steps are to return
 <a>this</a>'s <a for=Node>length</a>.
 
 <p>The
 <dfn method for=CharacterData><code>substringData(<var>offset</var>, <var>count</var>)</code></dfn>
-method, when invoked, must return the result of running <a>substring data</a> with node <a>this</a>,
+method steps are to return the result of running <a>substring data</a> with node <a>this</a>,
 offset <var>offset</var>, and count <var>count</var>.
 
-<p>The <dfn method for=CharacterData><code>appendData(<var>data</var>)</code></dfn> method, when
-invoked, must <a>replace data</a> with node <a>this</a>, offset <a>this</a>'s
-<a for=Node>length</a>, count 0, and data <var>data</var>.
+<p>The <dfn method for=CharacterData><code>appendData(<var>data</var>)</code></dfn> method steps are
+to <a>replace data</a> with node <a>this</a>, offset <a>this</a>'s <a for=Node>length</a>, count 0,
+and data <var>data</var>.
 
 <p>The
 <dfn method for=CharacterData><code>insertData(<var>offset</var>, <var>data</var>)</code></dfn>
-method, when invoked, must <a>replace data</a> with node <a>this</a>, offset <var>offset</var>,
-count 0, and data <var>data</var>.
+method steps are to <a>replace data</a> with node <a>this</a>, offset <var>offset</var>, count 0,
+and data <var>data</var>.
 
 <p>The
 <dfn method for=CharacterData><code>deleteData(<var>offset</var>, <var>count</var>)</code></dfn>
-method, when invoked, must <a>replace data</a> with node <a>this</a>, offset <var>offset</var>,
-count <var>count</var>, and data the empty string.
+method steps are to <a>replace data</a> with node <a>this</a>, offset <var>offset</var>, count
+<var>count</var>, and data the empty string.
 
 <p>The
 <dfn method for=CharacterData><code>replaceData(<var>offset</var>, <var>count</var>, <var>data</var>)</code></dfn>
-method, when invoked, must <a>replace data</a> with node <a>this</a>, offset <var>offset</var>,
-count <var>count</var>, and data <var>data</var>.
+method steps are to <a>replace data</a> with node <a>this</a>, offset <var>offset</var>, count
+<var>count</var>, and data <var>data</var>.
 
 
 <h3 id=interface-text>Interface {{Text}}</h3>
@@ -7355,9 +7328,9 @@ the {{Text}} <a for=/>node</a> <a>children</a> of <var>node</var>, in <a>tree or
 
 <hr>
 
-<p>The <dfn constructor for=Text><code>Text(<var>data</var>)</code></dfn> constructor, when invoked,
-must return a new {{Text}} <a>node</a> whose <a for=CharacterData>data</a> is <var>data</var> and
-<a for=Node>node document</a> is <a>current global object</a>'s
+<p>The <dfn constructor for=Text lt=Text(data)><code>new Text(<var>data</var>)</code></dfn>
+constructor steps are to set <a>this</a>'s <a for=CharacterData>data</a> to <var>data</var> and
+<a>this</a>'s <a for=Node>node document</a> to <a>current global object</a>'s
 <a>associated <code>Document</code></a>.
 
 To <dfn export id=concept-text-split lt="split a Text node">split</dfn> a {{Text}}
@@ -7424,10 +7397,10 @@ To <dfn export id=concept-text-split lt="split a Text node">split</dfn> a {{Text
  <li>Return <var>new node</var>.
 </ol>
 
-<p>The <dfn method for=Text><code>splitText(<var>offset</var>)</code></dfn> method, when invoked,
-must <a lt="split a Text node">split</a> <a>this</a> with offset <var>offset</var>.
+<p>The <dfn method for=Text><code>splitText(<var>offset</var>)</code></dfn> method steps are to
+<a lt="split a Text node">split</a> <a>this</a> with offset <var>offset</var>.
 
-<p>The <dfn attribute for=Text><code>wholeText</code></dfn> attribute's getter must return the
+<p>The <dfn attribute for=Text><code>wholeText</code></dfn> getter steps are to return the
 <a for=string>concatenation</a> of the <a for=CharacterData>data</a> of the
 <a>contiguous <code>Text</code> nodes</a> of <a>this</a>, in <a>tree order</a>.
 
@@ -7471,9 +7444,9 @@ interface Comment : CharacterData {
  <a for=CharacterData>data</a> is <var>data</var>.
 </dl>
 
-<p>The <dfn constructor for=Comment><code>Comment(<var>data</var>)</code></dfn> constructor, when
-invoked, must return a new {{Comment}} <a>node</a> whose <a for=CharacterData>data</a> is
-<var>data</var> and <a for=Node>node document</a> is <a>current global object</a>'s
+<p>The <dfn constructor for=Comment lt=Comment(data)><code>new Comment(<var>data</var>)</code></dfn>
+constructor steps are to set <a>this</a>'s <a for=CharacterData>data</a> to <var>data</var> and
+<a>this</a>'s <a for=Node>node document</a> to <a>current global object</a>'s
 <a>associated <code>Document</code></a>.
 
 
@@ -7640,25 +7613,24 @@ interface AbstractRange {
  <dd>Returns <var>range</var>'s <a for=range>end offset</a>.
 
  <dt><code><var ignore>collapsed</var> = <var>range</var> . <a attribute for=AbstractRange>collapsed</a></code>
- <dd>Returns true if <var>range</var> is <a for=range>collapsed</a>, and false otherwise.
+ <dd>Returns true if <var>range</var> is <a for=range>collapsed</a>; otherwise false.
 </dl>
 
 <p>The
 <dfn id=dom-range-startcontainer attribute for=AbstractRange><code>startContainer</code></dfn>
-attribute's getter must return <a>this</a>'s <a for=range>start node</a>.
+getter steps are to return <a>this</a>'s <a for=range>start node</a>.
 
 <p>The <dfn id=dom-range-startoffset attribute for=AbstractRange><code>startOffset</code></dfn>
-attribute's getter must return <a>this</a>'s <a for=range>start offset</a>.
+getter steps are to return <a>this</a>'s <a for=range>start offset</a>.
 
 <p>The <dfn id=dom-range-endcontainer attribute for=AbstractRange><code>endContainer</code></dfn>
-attribute's getter must return <a>this</a>'s <a for=range>end node</a>.
+getter steps are to return <a>this</a>'s <a for=range>end node</a>.
 
 <p>The <dfn id=dom-range-endoffset attribute for=AbstractRange><code>endOffset</code></dfn>
-attribute's getter must return <a>this</a>'s <a for=range>end offset</a>.
+getter steps are to return <a>this</a>'s <a for=range>end offset</a>.
 
 <p>The <dfn id=dom-range-collapsed attribute for=AbstractRange><code>collapsed</code></dfn>
-attribute's getter must return true if <a>this</a> is <a for=range>collapsed</a>, and false
-otherwise.
+getter steps are to return true if <a>this</a> is <a for=range>collapsed</a>; otherwise false.
 
 
 <h3 id=interface-staticrange>Interface {{StaticRange}}</h3>
@@ -7678,26 +7650,24 @@ interface StaticRange : AbstractRange {
 </pre>
 
 <dl class=domintro>
- <dt><code><var>staticRange</var> = new <a constructor lt="StaticRange(init)">StaticRange</a>(init)</code>
+ <dt><code><var ignore>staticRange</var> = new <a constructor lt="StaticRange(init)">StaticRange</a>(init)</code>
  <dd><p>Returns a new <a>range</a> object that does not update when the <a>node tree</a> mutates.
 </dl>
 
-<p>The <dfn constructor for=StaticRange><code>StaticRange(<var>init</var>)</code></dfn> constructor,
-when invoked, must run these steps:
+<p>The
+<dfn constructor for=StaticRange lt="StaticRange(init)"><code>new StaticRange(<var>init</var>)</code></dfn>
+constructor steps are:
 
 <ol>
- <li><p>If <var>init</var>'s {{StaticRangeInit/startContainer}} or {{StaticRangeInit/endContainer}}
- is a {{DocumentType}} or {{Attr}} <a for=/>node</a>, then <a>throw</a> an
- "{{InvalidNodeTypeError!!exception}}" {{DOMException}}.
+ <li><p>If <var>init</var>["{{StaticRangeInit/startContainer}}"] or
+ <var>init</var>["{{StaticRangeInit/endContainer}}"] is a {{DocumentType}} or {{Attr}}
+ <a for=/>node</a>, then <a>throw</a> an "{{InvalidNodeTypeError!!exception}}" {{DOMException}}.
 
- <li><p>Let <var>staticRange</var> be a new {{StaticRange}} object.
-
- <li><p>Set <var>staticRange</var>'s <a for=range>start</a> to (<var>init</var>'s
- {{StaticRangeInit/startContainer}}, <var>init</var>'s {{StaticRangeInit/startOffset}}) and
- <a for=range>end</a> to (<var>init</var>'s {{StaticRangeInit/endContainer}}, <var>init</var>'s
- {{StaticRangeInit/endOffset}}).
-
- <li><p>Return <var>staticRange</var>.
+ <li><p>Set <a>this</a>'s <a for=range>start</a> to
+ (<var>init</var>["{{StaticRangeInit/startContainer}}"],
+ <var>init</var>["{{StaticRangeInit/startOffset}}"]) and <a for=range>end</a> to
+ (<var>init</var>["{{StaticRangeInit/endContainer}}"],
+ <var>init</var>["{{StaticRangeInit/endOffset}}"]).
 </ol>
 
 
@@ -7821,10 +7791,9 @@ but not its <a for=range>end node</a>, or vice versa.
  <dd>Returns a new <a>live range</a>.
 </dl>
 
-<p>The <dfn constructor for=Range><code>Range()</code></dfn> constructor, when invoked, must return
-a new <a>live range</a> with
-(<a>current global object</a>'s <a>associated <code>Document</code></a>, 0) as its
-<a for=range>start</a> and <a for=range>end</a>.
+<p>The <dfn constructor for=Range lt="Range()"><code>new Range()</code></dfn> constructor steps are
+to set <a>this</a>'s <a for=range>start</a> and <a for=range>end</a> to
+(<a>current global object</a>'s <a>associated <code>Document</code></a>, 0).
 
 <hr>
 
@@ -7838,8 +7807,7 @@ a new <a>live range</a> with
  <a for=range>end node</a>.
 </dl>
 
-<p>The <dfn attribute for=Range><code>commonAncestorContainer</code></dfn> attribute's getter must
-run these steps:
+<p>The <dfn attribute for=Range><code>commonAncestorContainer</code></dfn> getter steps are:
 
 <ol>
  <li>Let <var>container</var> be
@@ -7907,16 +7875,15 @@ steps:
   </dl>
 </ol>
 
-<p>The <dfn method for=Range><code>setStart(<var>node</var>, <var>offset</var>)</code></dfn> method,
-when invoked, must <a>set the start</a> of <a>this</a> to <a>boundary point</a>
+<p>The <dfn method for=Range><code>setStart(<var>node</var>, <var>offset</var>)</code></dfn> method
+steps are to <a>set the start</a> of <a>this</a> to <a>boundary point</a>
 (<var>node</var>, <var>offset</var>).
 
-<p>The <dfn method for=Range><code>setEnd(<var>node</var>, <var>offset</var>)</code></dfn> method,
-when invoked, must <a>set the end</a> of <a>this</a> to <a>boundary point</a>
+<p>The <dfn method for=Range><code>setEnd(<var>node</var>, <var>offset</var>)</code></dfn> method
+steps are to <a>set the end</a> of <a>this</a> to <a>boundary point</a>
 (<var>node</var>, <var>offset</var>).
 
-<p>The <dfn method for=Range><code>setStartBefore(<var>node</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Range><code>setStartBefore(<var>node</var>)</code></dfn> method steps are:
 
 <ol>
  <li>Let <var>parent</var> be <var>node</var>'s
@@ -7932,8 +7899,7 @@ invoked, must run these steps:
  <a for=tree>index</a>).
 </ol>
 
-<p>The <dfn method for=Range><code>setStartAfter(<var>node</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=Range><code>setStartAfter(<var>node</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>.
@@ -7945,8 +7911,7 @@ must run these steps:
  (<var>parent</var>, <var>node</var>'s <a for=tree>index</a> plus 1).
 </ol>
 
-<p>The <dfn method for=Range><code>setEndBefore(<var>node</var>)</code></dfn>, when invoked, method
-must run these steps:
+<p>The <dfn method for=Range><code>setEndBefore(<var>node</var>)</code></dfn> method steps are:
 
 <ol>
  <li>Let <var>parent</var> be <var>node</var>'s
@@ -7961,8 +7926,7 @@ must run these steps:
  (<var>parent</var>, <var>node</var>'s <a for=tree>index</a>).
 </ol>
 
-<p>The <dfn method for=Range><code>setEndAfter(<var>node</var>)</code></dfn> method, when invoked,
-must run these steps:
+<p>The <dfn method for=Range><code>setEndAfter(<var>node</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>.
@@ -7974,9 +7938,9 @@ must run these steps:
  (<var>parent</var>, <var>node</var>'s <a for=tree>index</a> plus 1).
 </ol>
 
-<p>The <dfn method for=Range><code>collapse(<var>toStart</var>)</code></dfn> method, when invoked,
-must if <var>toStart</var> is true, set <a for=range>end</a> to <a for=range>start</a>, and set
-<a for=range>start</a> to <a for=range>end</a> otherwise.
+<p>The <dfn method for=Range><code>collapse(<var>toStart</var>)</code></dfn> method steps are to, if
+<var>toStart</var> is true, set <a for=range>end</a> to <a for=range>start</a>; otherwise set
+<a for=range>start</a> to <a for=range>end</a>.
 
 <p>To <dfn export id=concept-range-select for=range>select</dfn> a <a for=/>node</a> <var>node</var>
 within a <a>range</a> <var>range</var>, run these steps:
@@ -7996,11 +7960,11 @@ within a <a>range</a> <var>range</var>, run these steps:
  (<var>parent</var>, <var>index</var> plus 1).
 </ol>
 
-<p>The <dfn method for=Range><code>selectNode(<var>node</var>)</code></dfn> method, when invoked,
-must <a for=range>select</a> <var>node</var> within <a>this</a>.
+<p>The <dfn method for=Range><code>selectNode(<var>node</var>)</code></dfn> method steps are to
+<a for=range>select</a> <var>node</var> within <a>this</a>.
 
-<p>The <dfn method for=Range><code>selectNodeContents(<var>node</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Range><code>selectNodeContents(<var>node</var>)</code></dfn> method steps
+are:
 
 <ol>
  <li>If <var>node</var> is a
@@ -8024,7 +7988,7 @@ invoked, must run these steps:
 
 <p>The
 <dfn method for=Range><code>compareBoundaryPoints(<var>how</var>, <var>sourceRange</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li>
@@ -8110,8 +8074,7 @@ method, when invoked, must run these steps:
    </dl>
 </ol>
 
-<p>The <dfn method for=Range><code>deleteContents()</code></dfn> method, when invoked, must
-run these steps:
+<p>The <dfn method for=Range><code>deleteContents()</code></dfn> method steps are:
 
 <ol>
  <li><p>If <a>this</a> is <a for=range>collapsed</a>, then return.
@@ -8467,8 +8430,8 @@ run these steps:
  <li>Return <var>fragment</var>.
 </ol>
 
-<p>The <dfn method for=Range><code>extractContents()</code></dfn> method, when invoked, must return
-the result of <a for="live range">extracting</a> <a>this</a>.
+<p>The <dfn method for=Range><code>extractContents()</code></dfn> method steps are to return the
+result of <a for="live range">extracting</a> <a>this</a>.
 
 <p>To
 <dfn export id=concept-range-clone for="live range" lt="clone the contents|cloning the contents">clone the contents</dfn>
@@ -8683,8 +8646,8 @@ of a <a>live range</a> <var>range</var>, run these steps:
  <li>Return <var>fragment</var>.
 </ol>
 
-<p>The <dfn method for=Range><code>cloneContents()</code></dfn> method, when invoked, must return
-the result of <a for="live range">cloning the contents</a> of <a>this</a>.
+<p>The <dfn method for=Range><code>cloneContents()</code></dfn> method steps are to return the
+result of <a for="live range">cloning the contents</a> of <a>this</a>.
 
 <p>To <dfn export id=concept-range-insert for="live range">insert</dfn> a <a for=/>node</a>
 <var>node</var> into a <a>live range</a> <var>range</var>, run these steps:
@@ -8790,11 +8753,11 @@ the result of <a for="live range">cloning the contents</a> of <a>this</a>.
  <a for=range>end</a> to (<var>parent</var>, <var>newOffset</var>).
 </ol>
 
-<p>The <dfn method for=Range><code>insertNode(<var>node</var>)</code></dfn> method, when invoked,
-must <a for="live range">insert</a> <var>node</var> into <a>this</a>.
+<p>The <dfn method for=Range><code>insertNode(<var>node</var>)</code></dfn> method steps are to
+<a for="live range">insert</a> <var>node</var> into <a>this</a>.
 
-<p>The <dfn method for=Range><code>surroundContents(<var>newParent</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Range><code>surroundContents(<var>newParent</var>)</code></dfn> method steps
+are:
 
 <!--
 IE9 and Chrome 12 dev throw exceptions before doing any DOM mutations in at
@@ -8840,10 +8803,10 @@ check first thing, which matches everyone but Firefox.
  range lies in a single text node). -->
 </ol>
 
-<p>The <dfn method for=Range><code>cloneRange()</code></dfn> method, when invoked, must return a new
+<p>The <dfn method for=Range><code>cloneRange()</code></dfn> method steps are to return a new
 <a>live range</a> with the same <a for=range>start</a> and <a for=range>end</a> as <a>this</a>.
 
-<p>The <dfn method for=Range><code>detach()</code></dfn> method, when invoked, must do nothing.
+<p>The <dfn method for=Range><code>detach()</code></dfn> method steps are to do nothing.
 <span class=note>Its functionality (disabling a {{Range}} object) was removed, but the method itself
 is preserved for compatibility.</span>
 
@@ -8862,7 +8825,7 @@ is preserved for compatibility.</span>
 <div class=impl>
 
 <p>The <dfn method for=Range><code>isPointInRange(<var>node</var>, <var>offset</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 <!-- Tested October 2011 on Firefox 9.0a2 and Chrome 16 dev.  IE9 and Opera
 11.50 don't support the method. -->
 
@@ -8899,7 +8862,7 @@ method, when invoked, must run these steps:
 </ol>
 
 <p>The <dfn method for=Range><code>comparePoint(<var>node</var>, <var>offset</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 <!-- IE9 doesn't support this method at all.  Firefox 12.0a1, Chrome 17 dev,
 and Opera Next 12.00 alpha all do. -->
 
@@ -8933,8 +8896,7 @@ and Opera Next 12.00 alpha all do. -->
 
 <hr>
 
-<p>The <dfn method for=Range><code>intersectsNode(<var>node</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for=Range><code>intersectsNode(<var>node</var>)</code></dfn> method steps are:
 <!-- Supported by Chrome 17 dev and Opera Next 12.00 alpha, but not IE9 or
 Firefox 12.0a1. -->
 
@@ -9118,20 +9080,20 @@ filter matches any <a for=/>node</a>.
 
 <hr>
 
-<p>The <dfn attribute for=NodeIterator><code>root</code></dfn> attribute's getter, when invoked,
-must return <a>this</a>'s <a for=traversal>root</a>.
+<p>The <dfn attribute for=NodeIterator><code>root</code></dfn> getter steps are to return
+<a>this</a>'s <a for=traversal>root</a>.
 
-<p>The <dfn attribute for=NodeIterator><code>referenceNode</code></dfn> attribute's getter, when
-invoked, must return <a>this</a>'s <a for=NodeIterator>reference</a>.
+<p>The <dfn attribute for=NodeIterator><code>referenceNode</code></dfn> getter steps are to return
+<a>this</a>'s <a for=NodeIterator>reference</a>.
 
-<p>The <dfn attribute for=NodeIterator><code>pointerBeforeReferenceNode</code></dfn> attribute's
-getter, when invoked, must return <a>this</a>'s <a for=NodeIterator>pointer before reference</a>.
+<p>The <dfn attribute for=NodeIterator><code>pointerBeforeReferenceNode</code></dfn> getter steps
+are to return <a>this</a>'s <a for=NodeIterator>pointer before reference</a>.
 
-<p>The <dfn attribute for=NodeIterator><code>whatToShow</code></dfn> attribute's getter, when
-invoked, must return <a>this</a>'s <a for=traversal>whatToShow</a>.
+<p>The <dfn attribute for=NodeIterator><code>whatToShow</code></dfn> getter steps are to return
+<a>this</a>'s <a for=traversal>whatToShow</a>.
 
-<p>The <dfn attribute for=NodeIterator><code>filter</code></dfn> attribute's getter, when invoked,
-must return <a>this</a>'s <a for=traversal>filter</a>.
+<p>The <dfn attribute for=NodeIterator><code>filter</code></dfn> getter steps are to return
+<a>this</a>'s <a for=traversal>filter</a>.
 
 <p>To <dfn export id=concept-nodeiterator-traverse for=NodeIterator>traverse</dfn>, given a
 {{NodeIterator}} object <var>iterator</var> and a direction <var>direction</var>, run these steps:
@@ -9183,15 +9145,15 @@ must return <a>this</a>'s <a for=traversal>filter</a>.
  <li><p>Return <var>node</var>.
 </ol>
 
-<p>The <dfn method for=NodeIterator><code>nextNode()</code></dfn> method, when invoked, must return
-the result of <a for=NodeIterator>traversing</a> with <a>this</a> and next.
+<p>The <dfn method for=NodeIterator><code>nextNode()</code></dfn> method steps are to return the
+result of <a for=NodeIterator>traversing</a> with <a>this</a> and next.
 
-<p>The <dfn method for=NodeIterator><code>previousNode()</code></dfn> method, when invoked, must
-return the result of <a for=NodeIterator>traversing</a> with <a>this</a> and previous.
+<p>The <dfn method for=NodeIterator><code>previousNode()</code></dfn> method steps are to return the
+result of <a for=NodeIterator>traversing</a> with <a>this</a> and previous.
 
-<p>The <dfn method for=NodeIterator><code>detach()</code></dfn> method, when invoked, must do
-nothing. <span class=note>Its functionality (disabling a {{NodeIterator}} object) was removed, but
-the method itself is preserved for compatibility.</span>
+<p>The <dfn method for=NodeIterator><code>detach()</code></dfn> method steps are to do nothing.
+<span class=note>Its functionality (disabling a {{NodeIterator}} object) was removed, but the method
+itself is preserved for compatibility.</span>
 
 
 <h3 id=interface-treewalker>Interface {{TreeWalker}}</h3>
@@ -9222,25 +9184,24 @@ method on {{Document}} objects.
 <p class="note no-backref">As mentioned earlier {{TreeWalker}} objects have an associated
 <a for=traversal>root</a>, <a for=traversal>whatToShow</a>, and <a for=traversal>filter</a> as well.
 
-<p>The <dfn attribute for=TreeWalker><code>root</code></dfn> attribute's getter, when invoked, must
-return <a>this</a>'s <a for=traversal>root</a>.
+<p>The <dfn attribute for=TreeWalker><code>root</code></dfn> getter steps are to return
+<a>this</a>'s <a for=traversal>root</a>.
 
-<p>The <dfn attribute for=TreeWalker><code>whatToShow</code></dfn> attribute's getter, when invoked,
-must return <a>this</a>'s <a for=traversal>whatToShow</a>.
+<p>The <dfn attribute for=TreeWalker><code>whatToShow</code></dfn> getter steps are to return
+<a>this</a>'s <a for=traversal>whatToShow</a>.
 
-<p>The <dfn attribute for=TreeWalker><code>filter</code></dfn> attribute's getter, when invoked,
-must return <a>this</a>'s <a for=traversal>filter</a>.
+<p>The <dfn attribute for=TreeWalker><code>filter</code></dfn> getter steps are to return
+<a>this</a>'s <a for=traversal>filter</a>.
 
-<p>The <dfn attribute for=TreeWalker><code>currentNode</code></dfn> attribute's getter, when
-invoked, must return <a>this</a>'s <a for=TreeWalker>current</a>.
+<p>The <dfn attribute for=TreeWalker><code>currentNode</code></dfn> getter steps are to return
+<a>this</a>'s <a for=TreeWalker>current</a>.
 
-<p>The {{TreeWalker/currentNode}} attribute's setter, when invoked, must set <a>this</a>'s
+<p>The {{TreeWalker/currentNode}} setter steps are to set <a>this</a>'s
 <a for=TreeWalker>current</a> to the given value.
 
 <hr>
 
-<p>The <dfn method for=TreeWalker><code>parentNode()</code></dfn> method, when invoked, must run
-these steps:
+<p>The <dfn method for=TreeWalker><code>parentNode()</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>node</var> be <a>this</a>'s <a for=TreeWalker>current</a>.
@@ -9313,10 +9274,10 @@ these steps:
  <li><p>Return null.
 </ol>
 
-<p>The <dfn method for=TreeWalker><code>firstChild()</code></dfn> method, when invoked, must
+<p>The <dfn method for=TreeWalker><code>firstChild()</code></dfn> method steps are to
 <a>traverse children</a> with <a>this</a> and first.
 
-<p>The <dfn method for=TreeWalker><code>lastChild()</code></dfn> method, when invoked, must
+<p>The <dfn method for=TreeWalker><code>lastChild()</code></dfn> method steps are to
 <a>traverse children</a> with <a>this</a> and last.
 
 <p>To <dfn noexport id=concept-traverse-siblings>traverse siblings</dfn>, given a <var>walker</var>
@@ -9366,14 +9327,13 @@ and <var>type</var>, run these steps:
   </ol>
 </ol>
 
-<p>The <dfn method for=TreeWalker><code>nextSibling()</code></dfn> method, when invoked, must
+<p>The <dfn method for=TreeWalker><code>nextSibling()</code></dfn> method steps are to
 <a>traverse siblings</a> with <a>this</a> and next.
 
-<p>The <dfn method for=TreeWalker><code>previousSibling()</code></dfn> method, when invoked, must
+<p>The <dfn method for=TreeWalker><code>previousSibling()</code></dfn> method steps are to
 <a>traverse siblings</a> with <a>this</a> and previous.
 
-<p>The <dfn method for=TreeWalker><code>previousNode()</code></dfn> method, when invoked, must run
-these steps:
+<p>The <dfn method for=TreeWalker><code>previousNode()</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>node</var> be <a>this</a>'s <a for=TreeWalker>current</a>.
@@ -9423,8 +9383,7 @@ these steps:
  <li><p>Return null.
 </ol>
 
-<p>The <dfn method for=TreeWalker><code>nextNode()</code></dfn> method, when invoked, must run these
-steps:
+<p>The <dfn method for=TreeWalker><code>nextNode()</code></dfn> method steps are:
 
 <ol>
  <li><p>Let <var>node</var> be <a>this</a>'s <a for=TreeWalker>current</a>.
@@ -9694,8 +9653,7 @@ are to return the result of running <a>get an attribute value</a> given the asso
 <a>token set</a>'s <a for=set>size</a> minus one, unless <a>token set</a> <a for=set>is empty</a>,
 in which case there are no <a>supported property indices</a>.
 
-<p>The <dfn method for="DOMTokenList"><code>item(<var>index</var>)</code></dfn> method, when
-invoked, must run these steps:
+<p>The <dfn method for="DOMTokenList"><code>item(<var>index</var>)</code></dfn> method steps are:
 
 <ol>
  <li><p>If <var>index</var> is equal to or greater than <a>this</a>'s <a>token set</a>'s
@@ -9704,13 +9662,13 @@ invoked, must run these steps:
  <li><p>Return <a>this</a>'s <a>token set</a>[<var>index</var>].
 </ol>
 
-<p>The <dfn method for="DOMTokenList"><code>contains(<var>token</var>)</code></dfn> method, when
-invoked, must return true if <a>this</a>'s <a>token set</a>[<var>token</var>] <a for=set>exists</a>,
-and false otherwise.</p>
+<p>The <dfn method for="DOMTokenList"><code>contains(<var>token</var>)</code></dfn> method steps are
+to return true if <a>this</a>'s <a>token set</a>[<var>token</var>] <a for=set>exists</a>; otherwise
+false.
 
 <p>The
 <dfn method for="DOMTokenList" lt="add(tokens)|add()"><code>add(<var>tokens</var>&hellip;)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li>
@@ -9732,7 +9690,7 @@ method, when invoked, must run these steps:
 
 <p>The
 <dfn method for="DOMTokenList" lt="remove(tokens)|remove()"><code>remove(<var>tokens</var>&hellip;)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li>
@@ -9753,7 +9711,7 @@ method, when invoked, must run these steps:
 </ol>
 
 <p>The <dfn method for=DOMTokenList><code>toggle(<var>token</var>, <var>force</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>If <var>token</var> is the empty string, then <a>throw</a> a "{{SyntaxError!!exception}}"
@@ -9784,7 +9742,7 @@ for web compatibility.
 
 <p>The
 <dfn method for=DOMTokenList><code>replace(<var>token</var>, <var>newToken</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 <!-- Argument order based on String.prototype.replace(), not replaceChild() -->
 
 <ol>
@@ -9810,7 +9768,7 @@ for web compatibility.
 
 <p>The
 <dfn method for="DOMTokenList" lt="supports(token)"><code>supports(<var>token</var>)</code></dfn>
-method, when invoked, must run these steps:
+method steps are:
 
 <ol>
  <li><p>Let <var>result</var> be the return value of <a>validation steps</a> called with

--- a/dom.bs
+++ b/dom.bs
@@ -498,7 +498,7 @@ the empty list.</p>
  <dt><code><var>event</var> . {{Event/bubbles}}</code>
  <dd>Returns true or false depending on how <var>event</var> was initialized. True if
  <var>event</var> goes through its <a for=Event>target</a>'s <a for=tree>ancestors</a> in reverse
- <a>tree order</a>, and false otherwise.
+ <a>tree order</a>; otherwise false.
 
  <dt><code><var>event</var> . {{Event/cancelable}}</code>
  <dd>Returns true or false depending on how <var>event</var> was initialized. Its return
@@ -512,13 +512,13 @@ the empty list.</p>
  the operation that caused <var>event</var> to be <a>dispatched</a> that it needs to be canceled.
 
  <dt><code><var>event</var> . {{Event/defaultPrevented}}</code>
- <dd>Returns true if {{Event/preventDefault()}} was invoked successfully to indicate cancelation,
- and false otherwise.
+ <dd>Returns true if {{Event/preventDefault()}} was invoked successfully to indicate cancelation;
+ otherwise false.
 
  <dt><code><var>event</var> . {{Event/composed}}</code>
  <dd>Returns true or false depending on how <var>event</var> was initialized. True if
  <var>event</var> invokes listeners past a {{ShadowRoot}} <a>node</a> that is the
- <a for=tree>root</a> of its <a for=Event>target</a>, and false otherwise.
+ <a for=tree>root</a> of its <a for=Event>target</a>; otherwise false.
 
  <dt><code><var>event</var> . {{Event/isTrusted}}</code>
  <dd>Returns true if <var>event</var> was
@@ -827,7 +827,7 @@ was initialized to.
 
 <p>The
 <dfn method for=CustomEvent><code>initCustomEvent(<var>type</var>, <var>bubbles</var>, <var>cancelable</var>, <var>detail</var>)</code></dfn>
-method must, when invoked, run these steps:
+method steps are:
 
 <ol>
  <li><p>If <a>this</a>'s <a>dispatch flag</a> is set, then return.
@@ -1063,7 +1063,7 @@ are not to be used for anything else. [[!HTML]]
  <dt><code><var>target</var> . <a method for=EventTarget lt=dispatchEvent()>dispatchEvent</a>(<var>event</var>)</code>
  <dd><p><a>Dispatches</a> a synthetic event <var>event</var> to <var>target</var> and returns true
  if either <var>event</var>'s {{Event/cancelable}} attribute value is false or its
- {{Event/preventDefault()}} method was not invoked, and false otherwise.
+ {{Event/preventDefault()}} method was not invoked; otherwise false.
 </dl>
 
 <p>To <dfn export for=Event id=concept-flatten-options>flatten</dfn> <var>options</var>, run these
@@ -1277,7 +1277,7 @@ for discussion).
    <var>targetOverride</var>, <var>relatedTarget</var>, <var>touchTargets</var>, and false.
 
    <li><p>Let <var>isActivationEvent</var> be true, if <var>event</var> is a {{MouseEvent}} object
-   and <var>event</var>'s {{Event/type}} attribute is "<code>click</code>", and false otherwise.
+   and <var>event</var>'s {{Event/type}} attribute is "<code>click</code>"; otherwise false.
 
    <li><p>If <var>isActivationEvent</var> is true and <var>target</var> has
    <a for=EventTarget>activation behavior</a>, then set <var>activationTarget</var> to
@@ -1364,7 +1364,7 @@ for discussion).
    <a for=Event/path>shadow-adjusted target</a>, <var>clearTargetsStruct</var>'s
    <a for=Event/path>relatedTarget</a>, or an {{EventTarget}} object in
    <var>clearTargetsStruct</var>'s <a for=Event/path>touch target list</a> is a <a for=/>node</a>
-   and its <a for=tree>root</a> is a <a for=/>shadow root</a>, and false otherwise.
+   and its <a for=tree>root</a> is a <a for=/>shadow root</a>; otherwise false.
 
    <li><p>If <var>activationTarget</var> is non-null and <var>activationTarget</var> has
    <a for=EventTarget>legacy-pre-activation behavior</a>, then run <var>activationTarget</var>'s
@@ -1439,7 +1439,7 @@ for discussion).
    <var>activationTarget</var>'s <a for=EventTarget>legacy-canceled-activation behavior</a>.
   </ol>
 
- <li><p>Return false if <var>event</var>'s <a>canceled flag</a> is set, and true otherwise.
+ <li><p>Return false if <var>event</var>'s <a>canceled flag</a> is set; otherwise true.
 </ol>
 
 <p>To <dfn noexport id=concept-event-path-append>append to an event path</dfn>, given an
@@ -1791,8 +1791,8 @@ interface AbortSignal : EventTarget {
  <dd>Returns an {{AbortSignal}} instance whose <a for=AbortSignal>aborted flag</a> is set.
 
  <dt><code><var>signal</var> . <a attribute for=AbortSignal>aborted</a></code>
- <dd>Returns true if this {{AbortSignal}}'s {{AbortController}} has signaled to abort, and false
- otherwise.
+ <dd>Returns true if this {{AbortSignal}}'s {{AbortController}} has signaled to abort; otherwise
+ false.
 </dl>
 
 <p>An {{AbortSignal}} object has an associated <dfn export for=AbortSignal>aborted flag</dfn>. It is
@@ -2065,7 +2065,7 @@ can be used to explore this matter in more detail.
 <a for=tree>root</a> is a <a>document</a>.
 
 <p>The <dfn export>document element</dfn> of a <a>document</a> is the <a for="/">element</a> whose
-<a for=tree>parent</a> is that <a>document</a>, if it exists, and null otherwise.
+<a for=tree>parent</a> is that <a>document</a>, if it exists; otherwise null.
 
 <p class="note no-backref">Per the <a>node tree</a> constraints, there can be only one such
 <a for="/">element</a>.
@@ -2199,12 +2199,12 @@ steps:</p>
 
  <li><p>If <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>", then
  return the <a>slot</a> in <var>shadow</var>'s <a for=tree>descendants</a> whose
- <a>manually assigned nodes</a> <a for=set>contains</a> <var>slottable</var>, if any, and null
- otherwise.
+ <a>manually assigned nodes</a> <a for=set>contains</a> <var>slottable</var>, if any; otherwise
+ null.
 
  <li><p>Return the first <a>slot</a> in <a>tree order</a> in <var>shadow</var>'s
  <a for=tree>descendants</a> whose <a for=slot>name</a> is <var>slottable</var>'s
- <a for=slottable>name</a>, if any, and null otherwise.</p></li>
+ <a for=slottable>name</a>, if any; otherwise null.
 </ol>
 
 <p>To <dfn export lt="find slottables|finding slottables" id=find-slotables>find slottables</dfn>
@@ -2831,10 +2831,10 @@ Element includes ParentNode;
  <dd>Returns the <a for=tree>child</a> <a for="/">elements</a>.
 
  <dt><code><var>element</var> = <var>node</var> . {{ParentNode/firstElementChild}}</code>
- <dd>Returns the first <a for=tree>child</a> that is an <a for="/">element</a>, and null otherwise.
+ <dd>Returns the first <a for=tree>child</a> that is an <a for="/">element</a>; otherwise null.
 
  <dt><code><var>element</var> = <var>node</var> . {{ParentNode/lastElementChild}}</code>
- <dd>Returns the last <a for=tree>child</a> that is an <a for="/">element</a>, and null otherwise.
+ <dd>Returns the last <a for=tree>child</a> that is an <a for="/">element</a>; otherwise null.
 
  <!-- childElementCount is redundant -->
 
@@ -2925,7 +2925,7 @@ are:
 
 <p>The <dfn method for=ParentNode><code>querySelector(<var>selectors</var>)</code></dfn> method
 steps are to return the first result of running <a>scope-match a selectors string</a>
-<var>selectors</var> against <a>this</a>, if the result is not an empty list, and null otherwise.
+<var>selectors</var> against <a>this</a>, if the result is not an empty list; otherwise null.
 
 <p>The <dfn method for=ParentNode><code>querySelectorAll(<var>selectors</var>)</code></dfn> method
 steps are to return the <a lt="static collection">static</a> result of running
@@ -2949,16 +2949,12 @@ CharacterData includes NonDocumentTypeChildNode;
 
 <dl class=domintro>
  <dt><code><var>element</var> = <var>node</var> . {{previousElementSibling}}</code>
- <dd>Returns the first
- <a>preceding</a>
- <a for=tree>sibling</a> that
- is an <a for="/">element</a>, and null otherwise.
+ <dd>Returns the first <a>preceding</a> <a for=tree>sibling</a> that is an <a for=/>element</a>;
+ otherwise null.
 
  <dt><code><var>element</var> = <var>node</var> . {{nextElementSibling}}</code>
- <dd>Returns the first
- <a>following</a>
- <a for=tree>sibling</a> that
- is an <a for="/">element</a>, and null otherwise.
+ <dd>Returns the first <a>following</a> <a for=tree>sibling</a> that is an <a for=/>element</a>;
+ otherwise null.
 </dl>
 
 <p>The <dfn attribute for=NonDocumentTypeChildNode><code>previousElementSibling</code></dfn> getter
@@ -3021,14 +3017,14 @@ CharacterData includes ChildNode;
  <li><p>If <var>parent</var> is null, then return.
 
  <li><p>Let <var>viablePreviousSibling</var> be <a>this</a>'s first <a>preceding</a>
- <a for=tree>sibling</a> not in <var>nodes</var>, and null otherwise.
+ <a for=tree>sibling</a> not in <var>nodes</var>; otherwise null.
 
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a>, given
  <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
- <li><p>If <var>viablePreviousSibling</var> is null, set it to <var>parent</var>'s
- <a for=tree>first child</a>, and to <var>viablePreviousSibling</var>'s <a for=tree>next sibling</a>
- otherwise.
+ <li><p>If <var>viablePreviousSibling</var> is null, then set it to <var>parent</var>'s
+ <a for=tree>first child</a>; otherwise to <var>viablePreviousSibling</var>'s
+ <a for=tree>next sibling</a>.
 
  <li><p><a>Pre-insert</a> <var>node</var> into <var>parent</var> before
  <var>viablePreviousSibling</var>.
@@ -3042,7 +3038,7 @@ CharacterData includes ChildNode;
  <li><p>If <var>parent</var> is null, then return.
 
  <li><p>Let <var>viableNextSibling</var> be <a>this</a>'s first <a>following</a>
- <a for=tree>sibling</a> not in <var>nodes</var>, and null otherwise.
+ <a for=tree>sibling</a> not in <var>nodes</var>; otherwise null.
 
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a>, given
  <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
@@ -3059,7 +3055,7 @@ CharacterData includes ChildNode;
  <li><p>If <var>parent</var> is null, then return.
 
  <li><p>Let <var>viableNextSibling</var> be <a>this</a>'s first <a>following</a>
- <a for=tree>sibling</a> not in <var>nodes</var>, and null otherwise.
+ <a for=tree>sibling</a> not in <var>nodes</var>; otherwise null.
 
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a>, given
  <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
@@ -3676,16 +3672,13 @@ interface MutationRecord {
  <dt><code><var>record</var> . {{MutationRecord/previousSibling}}</code>
  <dt><code><var>record</var> . {{MutationRecord/nextSibling}}</code>
  <dd>Return the <a lt="previous sibling">previous</a> and <a for=tree>next sibling</a> respectively
- of the added or removed <a for=/>nodes</a>, and null otherwise.
+ of the added or removed <a for=/>nodes</a>; otherwise null.
 
  <dt><code><var>record</var> . {{MutationRecord/attributeName}}</code>
- <dd>Returns the
- <a for=Attr>local name</a> of the
- changed <a>attribute</a>, and null otherwise.
+ <dd>Returns the <a for=Attr>local name</a> of the changed <a>attribute</a>; otherwise null.
 
  <dt><code><var>record</var> . {{MutationRecord/attributeNamespace}}</code>
- <dd>Returns the <a for=Attr>namespace</a> of the
- changed <a>attribute</a>, and null otherwise.
+ <dd>Returns the <a for=Attr>namespace</a> of the changed <a>attribute</a>; otherwise null.
 
  <dt><code><var>record</var> . {{MutationRecord/oldValue}}</code>
  <dd>The return value depends on
@@ -3797,8 +3790,8 @@ is used by all <a for=/>nodes</a> ({{Document}}, {{DocumentType}}, {{DocumentFra
 <a>adopt</a> algorithm.
 
 <p>A <a>node</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns the
-<a>node</a>'s <a>assigned slot</a>, if <a>node</a> is <a>assigned</a>, and <a>node</a>'s
-<a for=tree>parent</a> otherwise.
+<a>node</a>'s <a>assigned slot</a>, if <a>node</a> is <a>assigned</a>; otherwise <a>node</a>'s
+<a for=tree>parent</a>.
 
 <p class="note no-backref">Each <a for=/>node</a> also has a <a>registered observer list</a>.
 
@@ -3974,14 +3967,14 @@ first matching statement, switching on <a>this</a>:
  <dd>Returns <var>node</var>'s <a for=Node>node document</a>'s <a>document base URL</a>.
 </dl>
 
-The <dfn attribute for=Node><code>baseURI</code></dfn> getter steps are to return
+<p>The <dfn attribute for=Node><code>baseURI</code></dfn> getter steps are to return <a>this</a>'s
 <a for=Node>node document</a>'s <a>document base URL</a>, <a lt="URL serializer" spec=url>serialized</a>.
 
 <hr>
 
 <dl class=domintro>
  <dt><code><var>node</var> . {{Node/isConnected}}</code>
- <dd><p>Returns true if <var>node</var> is <a>connected</a> and false otherwise.
+ <dd><p>Returns true if <var>node</var> is <a>connected</a>; otherwise false.
 
  <dt><code><var>node</var> . {{Node/ownerDocument}}</code>
  <dd>
@@ -4023,10 +4016,10 @@ The <dfn attribute for=Node><code>baseURI</code></dfn> getter steps are to retur
 </dl>
 
 <p>The <dfn attribute for=Node><code>isConnected</code></dfn> getter steps are to return true,
-if <a>this</a> is <a>connected</a>, and false otherwise.</p>
+if <a>this</a> is <a>connected</a>; otherwise false.</p>
 
 <p>The <dfn attribute for=Node><code>ownerDocument</code></dfn> getter steps are to return null,
-if <a>this</a> is a <a>document</a>, and <a>this</a>'s <a for=Node>node document</a> otherwise.
+if <a>this</a> is a <a>document</a>; otherwise <a>this</a>'s <a for=Node>node document</a>.
 
 <p class=note>The <a for=Node>node document</a> of a <a>document</a> is that <a>document</a> itself.
 All <a for=/>nodes</a> have a <a for=Node>node document</a> at all times.
@@ -4414,14 +4407,11 @@ return true if <var>otherNode</var> is <a>this</a>; otherwise false.
   </dl>
 
  <dt><code><var>node</var> . {{Node/contains(other)}}</code>
- <dd>Returns true if <var>other</var> is an
- <a>inclusive descendant</a>
- of <var>node</var>, and false otherwise.
+ <dd>Returns true if <var>other</var> is an <a>inclusive descendant</a> of <var>node</var>;
+ otherwise false.
 </dl>
 
-These are the constants
-{{compareDocumentPosition()}}
-returns as mask:
+<p>These are the constants {{compareDocumentPosition()}} returns as mask:
 
 <ul class="brief">
  <li><dfn const for=Node>DOCUMENT_POSITION_DISCONNECTED</dfn> (1);
@@ -4609,7 +4599,7 @@ for an <var>element</var> using <var>namespace</var>, run these steps:
 
    <dt>{{Document}}
    <dd><p>Return the result of <a>locating a namespace prefix</a> for its <a>document element</a>,
-   if its <a>document element</a> is non-null, and null otherwise.
+   if its <a>document element</a> is non-null; otherwise null.
 
    <dt>{{DocumentType}}
    <dt>{{DocumentFragment}}
@@ -4617,11 +4607,11 @@ for an <var>element</var> using <var>namespace</var>, run these steps:
 
    <dt>{{Attr}}
    <dd><p>Return the result of <a>locating a namespace prefix</a> for its <a for=Attr>element</a>,
-   if its <a for=Attr>element</a> is non-null, and null otherwise.
+   if its <a for=Attr>element</a> is non-null; otherwise null.
 
    <dt>Any other node
    <dd><p>Return the result of <a>locating a namespace prefix</a> for its <a>parent element</a>, if
-   its <a>parent element</a> is non-null, and null otherwise.
+   its <a>parent element</a> is non-null; otherwise null.
   </dl>
 </ol>
 
@@ -4644,8 +4634,8 @@ are:
  <li><p>Let <var>defaultNamespace</var> be the result of running <a>locate a namespace</a> for
  <a>this</a> using null.
 
- <li><p>Return true if <var>defaultNamespace</var> is the same as <var>namespace</var>, and false
- otherwise.
+ <li><p>Return true if <var>defaultNamespace</var> is the same as <var>namespace</var>; otherwise
+ false.
 </ol>
 
 <hr>
@@ -4763,8 +4753,8 @@ for a <a>node</a> <var>root</var> is the
 
   <p>The comparisons for the <a for=Element>classes</a> must be done in an
   <a>ASCII case-insensitive</a> manner if <var>root</var>'s <a for=Node>node document</a>'s
-  <a for=Document>mode</a> is "<code>quirks</code>", and in an <a for=string>identical to</a> manner
-  otherwise.
+  <a for=Document>mode</a> is "<code>quirks</code>"; otherwise in an <a for=string>identical to</a>
+  manner.
 </ol>
 
 When invoked with the same argument, the same {{HTMLCollection}}
@@ -4824,10 +4814,10 @@ dictionary ElementCreationOptions {
 };
 </pre>
 
-{{Document}} <a for=/>nodes</a> are simply
+<p>{{Document}} <a for=/>nodes</a> are simply
 known as <dfn export id=concept-document lt="document">documents</dfn>.
 
-Each <a>document</a> has an associated
+<p>Each <a>document</a> has an associated
 <dfn export for=Document id=concept-document-encoding>encoding</dfn> (an <a for="/">encoding</a>),
 <dfn export for=Document id=concept-document-content-type>content type</dfn> (a string),
 <dfn export for=Document id=concept-document-url>URL</dfn> (a <a for=/>URL</a>),
@@ -4838,19 +4828,18 @@ Each <a>document</a> has an associated
 [[!URL]]
 [[!HTML]]
 
-Unless stated otherwise, a <a>document</a>'s <a for=Document>encoding</a> is the <a>utf-8</a>
+<p>Unless stated otherwise, a <a>document</a>'s <a for=Document>encoding</a> is the <a>utf-8</a>
 <a for="/">encoding</a>, <a for=Document>content type</a> is
 "<code>application/xml</code>", <a for=Document>URL</a> is "<code>about:blank</code>",
 <a for=Document>origin</a> is an <a>opaque origin</a>,
 <a for=Document>type</a> is "<code>xml</code>", and its
 <a for=Document>mode</a> is "<code>no-quirks</code>".
 
-A <a>document</a> is said to be an <dfn export>XML document</dfn> if its
-<a for=Document>type</a> is "<code>xml</code>", and an <dfn export>HTML document</dfn>
-otherwise. Whether a <a>document</a> is an <a>HTML document</a> or an <a>XML document</a>
-affects the behavior of certain APIs.
+<p>A <a>document</a> is said to be an <dfn export>XML document</dfn> if its <a for=Document>type</a>
+is "<code>xml</code>"; otherwise an <dfn export>HTML document</dfn>. Whether a <a>document</a> is an
+<a>HTML document</a> or an <a>XML document</a> affects the behavior of certain APIs.
 
-A <a>document</a> is said to be in
+<p>A <a>document</a> is said to be in
 <dfn export id=concept-document-no-quirks>no-quirks mode</dfn> if its
 <a for=Document>mode</a> is "<code>no-quirks</code>",
 <dfn export id=concept-document-quirks>quirks mode</dfn> if its <a for=Document>mode</a>
@@ -4871,8 +4860,8 @@ is "<code>quirks</code>", and
 
 <p>A <a>document</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
 null if <var>event</var>'s {{Event/type}} attribute value is "<code>load</code>" or
-<a>document</a> does not have a <a for=Document>browsing context</a>, and the <a>document</a>'s
-<a>relevant global object</a> otherwise.
+<a>document</a> does not have a <a for=Document>browsing context</a>; otherwise the
+<a>document</a>'s <a>relevant global object</a>.
 
 <hr>
 
@@ -4889,9 +4878,8 @@ null if <var>event</var>'s {{Event/type}} attribute value is "<code>load</code>"
 
  <dt><code><var>document</var> . {{Document/compatMode}}</code>
  <dd>
-  Returns the string "<code>BackCompat</code>" if <var>document</var>'s
-  <a for=Document>mode</a> is "<code>quirks</code>", and "<code>CSS1Compat</code>"
-  otherwise.
+  Returns the string "<code>BackCompat</code>" if <var>document</var>'s <a for=Document>mode</a> is
+  "<code>quirks</code>"; otherwise "<code>CSS1Compat</code>".
 
  <dt><code><var>document</var> . {{Document/characterSet}}</code>
  <dd>Returns <var>document</var>'s
@@ -5054,7 +5042,7 @@ method steps are to return the <a>list of elements with class names <var>classNa
   (if <var>document</var> is an <a>HTML document</a>, <var>localName</var> gets lowercased). The
   <a for="/">element</a>'s <a for=Element>namespace</a> is the <a>HTML namespace</a> when
   <var>document</var> is an <a>HTML document</a> or <var>document</var>'s
-  <a for=Document>content type</a> is "<code>application/xhtml+xml</code>", and null otherwise.
+  <a for=Document>content type</a> is "<code>application/xhtml+xml</code>"; otherwise null.
 
   <p>If <var>localName</var> does not match the <code><a type>Name</a></code> production an
   "{{InvalidCharacterError!!exception}}" {{DOMException}} will be thrown.
@@ -5123,13 +5111,11 @@ method steps are to return the <a>list of elements with class names <var>classNa
   "{{InvalidCharacterError!!exception}}" {{DOMException}} will be thrown.
 </dl>
 
-The <dfn export id=concept-element-interface>element interface</dfn> for any
-<var>name</var> and <var>namespace</var> is {{Element}}, unless
-stated otherwise.
+<p>The <dfn export id=concept-element-interface>element interface</dfn> for any <var>name</var> and
+<var>namespace</var> is {{Element}}, unless stated otherwise.
 
-<p class="note no-backref">The HTML Standard will e.g. define that for <code>html</code>
-and the <a>HTML namespace</a>, the {{HTMLHtmlElement}} interface is used.
-[[!HTML]]
+<p class=note>The HTML Standard will, e.g., define that for <code>html</code> and the
+<a>HTML namespace</a>, the {{HTMLHtmlElement}} interface is used. [[!HTML]]
 
 <p>The
 <dfn method for=Document><code>createElement(<var>localName</var>, <var>options</var>)</code></dfn>
@@ -5149,7 +5135,7 @@ method steps are:
 
  <li><p>Let <var>namespace</var> be the <a>HTML namespace</a>, if <a>this</a> is an
  <a>HTML document</a> or <a>this</a>'s <a for=Document>content type</a> is
- "<code>application/xhtml+xml</code>", and null otherwise.
+ "<code>application/xhtml+xml</code>"; otherwise null.
 
  <li><p>Return the result of <a>creating an element</a> given <a>this</a>, <var>localName</var>,
  <var>namespace</var>, null, <var>is</var>, and with the <var>synchronous custom elements</var> flag
@@ -5743,8 +5729,8 @@ It is initially set to false.</p>
 <p>A <a for=/>shadow root</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
 null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow root</a> is the
 <a for=tree>root</a> of <var>event</var>'s <a for=Event>path</a>'s first struct's
-<a for=Event/path>invocation target</a>, and <a for=/>shadow root</a>'s
-<a for=DocumentFragment>host</a> otherwise.
+<a for=Event/path>invocation target</a>; otherwise <a for=/>shadow root</a>'s
+<a for=DocumentFragment>host</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>mode</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>mode</a>.</p>
@@ -5772,8 +5758,7 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 
 <p>The <dfn export id=concept-shadow-including-root>shadow-including root</dfn> of an object is its
 <a for=tree>root</a>'s <a for=DocumentFragment>host</a>'s <a>shadow-including root</a>, if the
-object's <a for=tree>root</a> is a <a for=/>shadow root</a>, and its <a for=tree>root</a>
-otherwise.</p>
+object's <a for=tree>root</a> is a <a for=/>shadow root</a>; otherwise its <a for=tree>root</a>.
 
 <p>An object <var>A</var> is a
 <dfn export id=concept-shadow-including-descendant>shadow-including descendant</dfn> of an object
@@ -5955,9 +5940,9 @@ again by an <a lt="upgrade an element">upgrade</a>.</p>
 
 <p>An <a for=/>element</a>'s
 <dfn export id=concept-element-qualified-name for=Element>qualified name</dfn> is its
-<a for=Element>local name</a> if its <a for=Element>namespace prefix</a> is null, and its
+<a for=Element>local name</a> if its <a for=Element>namespace prefix</a> is null; otherwise its
 <a for=Element>namespace prefix</a>, followed by "<code>:</code>", followed by its
-<a for=Element>local name</a>, otherwise.
+<a for=Element>local name</a>.
 
 <p>An <a for=/>element</a>'s <dfn for=Element>HTML-uppercased qualified name</dfn> is the return
 value of these steps:
@@ -6233,7 +6218,7 @@ steps:
  <a>ASCII lowercase</a>.
 
  <li><p>Return the first <a>attribute</a> in <var>element</var>'s <a for=Element>attribute list</a>
- whose <a for=Attr>qualified name</a> is <var>qualifiedName</var>, and null otherwise.
+ whose <a for=Attr>qualified name</a> is <var>qualifiedName</var>; otherwise null.
 </ol>
 
 <p>To
@@ -6242,14 +6227,11 @@ given a <var>namespace</var>, <var>localName</var>, and <a for="/">element</a> <
 run these steps:
 
 <ol>
- <li>If <var>namespace</var> is the empty string, set it to null.
+ <li><p>If <var>namespace</var> is the empty string, then set it to null.
 
- <li>Return the <a>attribute</a> in
- <var>element</var>'s <a for=Element>attribute list</a>
- whose <a for="Attr">namespace</a> is
- <var>namespace</var> and
- <a for="Attr">local name</a> is
- <var>localName</var>, if any, and null otherwise.
+ <li><p>Return the <a>attribute</a> in <var>element</var>'s <a for=Element>attribute list</a> whose
+ <a for="Attr">namespace</a> is <var>namespace</var> and <a for="Attr">local name</a> is
+ <var>localName</var>, if any; otherwise null.
 </ol>
 
 <p>To <dfn export id=concept-element-attributes-get-value>get an attribute value</dfn> given an
@@ -6461,7 +6443,7 @@ namespace.</p>
 
 <dl class=domintro>
  <dt><code><var>element</var> . <a method for=Element lt=hasAttributes()>hasAttributes</a>()</code>
- <dd><p>Returns true if <var>element</var> has attributes, and false otherwise.
+ <dd><p>Returns true if <var>element</var> has attributes; otherwise false.
 
  <dt><code><var>element</var> . <a method for=Element lt=getAttributeNames()>getAttributeNames</a>()</code>
  <dd><p>Returns the <a for=Attr>qualified names</a> of all <var>element</var>'s <a>attributes</a>.
@@ -6499,11 +6481,11 @@ namespace.</p>
   present and adding it if it is not present. If <var>force</var> is true, adds
   <var>qualifiedName</var>. If <var>force</var> is false, removes <var>qualifiedName</var>.
 
-  <p>Returns true if <var>qualifiedName</var> is now present, and false otherwise.
+  <p>Returns true if <var>qualifiedName</var> is now present; otherwise false.
 
  <dt><code><var>element</var> . <a method for=Element lt=hasAttribute()>hasAttribute</a>(<var>qualifiedName</var>)</code>
  <dd><p>Returns true if <var>element</var> has an <a>attribute</a> whose
- <a for=Attr>qualified name</a> is <var>qualifiedName</var>, and false otherwise.
+ <a for=Attr>qualified name</a> is <var>qualifiedName</var>; otherwise false.
 
  <dt><code><var>element</var> . <a method for=Element lt=hasAttributeNS()>hasAttributeNS</a>(<var>namespace</var>, <var>localName</var>)</code>
  <dd><p>Returns true if <var>element</var> has an <a>attribute</a> whose <a for=Attr>namespace</a>
@@ -6606,10 +6588,11 @@ steps are:
  <a>ASCII lowercase</a>.
 
  <li><p>Return true if <a>this</a> <a lt="has an attribute">has</a> an <a>attribute</a> whose
- <a for=Attr>qualified name</a> is <var>qualifiedName</var>, and false otherwise.
+ <a for=Attr>qualified name</a> is <var>qualifiedName</var>; otherwise false.
 </ol>
 
-<p>The <dfn method for=Element><code>toggleAttribute(<var>qualifiedName</var>, <var>force</var>)</code></dfn>
+<p>The
+<dfn method for=Element><code>toggleAttribute(<var>qualifiedName</var>, <var>force</var>)</code></dfn>
 method steps are:
 
 <ol>
@@ -6650,21 +6633,18 @@ method steps are:
 method steps are:
 
 <ol>
- <li>If <var>namespace</var> is the empty string, set it to null.
+ <li><p>If <var>namespace</var> is the empty string, then set it to null.
 
- <li>Return true if <a>this</a>
- <a lt="has an attribute">has</a> an
- <a>attribute</a> whose
- <a for="Attr">namespace</a> is <var>namespace</var>
- and <a for="Attr">local name</a> is
- <var>localName</var>, and false otherwise.
+ <li>Return true if <a>this</a> <a lt="has an attribute">has</a> an <a>attribute</a> whose
+ <a for="Attr">namespace</a> is <var>namespace</var> and <a for="Attr">local name</a> is
+ <var>localName</var>; otherwise false.
 </ol>
 
 <hr>
 
-<p>The <dfn method for=Element><code>getAttributeNode(<var>qualifiedName</var>)</code></dfn>
-method steps are to return the result of <a lt="get an attribute by name">getting an attribute</a>
-given <var>qualifiedName</var> and <a>this</a>.
+<p>The <dfn method for=Element><code>getAttributeNode(<var>qualifiedName</var>)</code></dfn> method
+steps are to return the result of <a lt="get an attribute by name">getting an attribute</a> given
+<var>qualifiedName</var> and <a>this</a>.
 
 <p>The
 <dfn method for=Element><code>getAttributeNodeNS(<var>namespace</var>, <var>localName</var>)</code></dfn>
@@ -6673,9 +6653,9 @@ method steps are to return the result of
 <var>namespace</var>, <var>localName</var>, and <a>this</a>.
 
 <p>The <dfn method for=Element><code>setAttributeNode(<var>attr</var>)</code></dfn> and
-<dfn method for=Element><code>setAttributeNodeNS(<var>attr</var>)</code></dfn> methods, when
-invoked, must return the result of <a lt="set an attribute">setting an attribute</a> given
-<var>attr</var> and <a>this</a>.
+<dfn method for=Element><code>setAttributeNodeNS(<var>attr</var>)</code></dfn> methods steps are to
+return the result of <a lt="set an attribute">setting an attribute</a> given <var>attr</var> and
+<a>this</a>.
 
 <p>The <dfn method for=Element><code>removeAttributeNode(<var>attr</var>)</code></dfn> method steps
 are:
@@ -6792,9 +6772,8 @@ are:
  <var>selectors</var>, and null otherwise.
 
  <dt><code><var>element</var> . {{matches(selectors)}}</code>
- <dd>Returns true if matching <var>selectors</var> against
- <var>element</var>'s <a for=tree>root</a> yields
- <var>element</var>, and false otherwise.
+ <dd>Returns true if matching <var>selectors</var> against <var>element</var>'s <a for=tree>root</a>
+ yields <var>element</var>; otherwise false.
 </dl>
 
 <p>The <dfn method for=Element><code>closest(<var>selectors</var>)</code></dfn> method steps are:
@@ -6986,9 +6965,9 @@ method steps are to return the result of
 <var>namespace</var>, <var>localName</var>, and <a for=NamedNodeMap>element</a>.
 
 <p>The <dfn method for="NamedNodeMap"><code>setNamedItem(<var>attr</var>)</code></dfn> and
-<dfn method for="NamedNodeMap"><code>setNamedItemNS(<var>attr</var>)</code></dfn>
-methods, when invoked, must return the result of <a lt="set an attribute">setting an attribute</a>
-given <var>attr</var> and <a for=NamedNodeMap>element</a>.
+<dfn method for="NamedNodeMap"><code>setNamedItemNS(<var>attr</var>)</code></dfn> method steps are
+to return the result of <a lt="set an attribute">setting an attribute</a> given <var>attr</var> and
+<a for=NamedNodeMap>element</a>.
 
 <p>The <dfn method for="NamedNodeMap"><code>removeNamedItem(<var>qualifiedName</var>)</code></dfn>
 method steps are:
@@ -9596,7 +9575,7 @@ are to return the result of running <a>get an attribute value</a> given the asso
  <dd><p>Returns the token with index <var>index</var>.
 
  <dt><code><var>tokenlist</var> . {{DOMTokenList/contains(token)}}</code>
- <dd><p>Returns true if <var>token</var> is present, and false otherwise.
+ <dd><p>Returns true if <var>token</var> is present; otherwise false.
 
  <dt><code><var>tokenlist</var> . <a for=DOMTokenList lt="add()">add(<var>tokens</var>&hellip;)</a></code>
  <dd>
@@ -9620,7 +9599,7 @@ are to return the result of running <a>get an attribute value</a> given the asso
   adding it if it's not present. If <var>force</var> is true, adds <var>token</var>
   (same as {{add()}}). If <var>force</var> is false, removes <var>token</var> (same
   as {{DOMTokenList/remove()}}).
-  <p>Returns true if <var>token</var> is now present, and false otherwise.
+  <p>Returns true if <var>token</var> is now present; otherwise false.
   <p>Throws a "{{SyntaxError!!exception}}" {{DOMException}} if <var>token</var> is empty.
   <p>Throws an "{{InvalidCharacterError!!exception}}" {{DOMException}} if <var>token</var> contains
   any spaces.
@@ -9628,7 +9607,7 @@ are to return the result of running <a>get an attribute value</a> given the asso
  <dt><code><var>tokenlist</var> . <a method for=DOMTokenList lt=replace()>replace(<var>token</var>, <var>newToken</var>)</a></code>
  <dd>
   <p>Replaces <var>token</var> with <var>newToken</var>.
-  <p>Returns true if <var>token</var> was replaced with <var>newToken</var>, and false otherwise.
+  <p>Returns true if <var>token</var> was replaced with <var>newToken</var>; otherwise false.
   <p>Throws a "{{SyntaxError!!exception}}" {{DOMException}} if one of the arguments is the empty
   string.
   <p>Throws an "{{InvalidCharacterError!!exception}}" {{DOMException}} if one of the arguments


### PR DESCRIPTION
In particular adopt the getter/setter/method/constructor steps pattern.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 15, 2021, 12:27 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwhatpr.org%2Fdom%2F969%2Facfe96b.html&doc2=https%3A%2F%2Fwhatpr.org%2Fdom%2F969.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%23969.)._
</details>
