### PR TITLE
Add the IDL of XSLTProcessor

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9877,6 +9877,34 @@ methods on {{Document}}.
 
 
 
+<h2 id=xslt>XSLT</h2>
+
+<p class=XXX><cite>XSL Transformations (XSLT)</cite> is a language for transforming XML documents
+into other XML documents. The APIs defined in this section have been widely implemented, and are
+maintained here so that they can be updated when <cite>Web IDL</cite> changes. Complete definitions
+of these APIs remain necessary and such work is tracked and can be contributed to in
+<a href="https://github.com/whatwg/dom/issues/181">whatwg/dom#181</a>. [[XSLT]]
+
+
+<h3 id=interface-xsltprocessor>Interface {{XSLTProcessor}}</h3>
+
+<pre class=idl>
+[Exposed=Window]
+interface XSLTProcessor {
+  constructor();
+  undefined importStylesheet(Node style);
+  [CEReactions] DocumentFragment transformToFragment(Node source, Document output);
+  [CEReactions] Document transformToDocument(Node source);
+  undefined setParameter([LegacyNullToEmptyString] DOMString namespaceURI, DOMString localName, any value);
+  any getParameter([LegacyNullToEmptyString] DOMString namespaceURI, DOMString localName);
+  undefined removeParameter([LegacyNullToEmptyString] DOMString namespaceURI, DOMString localName);
+  undefined clearParameters();
+  undefined reset();
+};
+</pre>
+
+
+
 <h2 id=historical>Historical</h2>
 
 <p>This standard used to contain several interfaces and interface members that have been removed.


### PR DESCRIPTION
Copied from https://wiki.whatwg.org/wiki/DOM_XSLTProcessor.

Part of https://github.com/whatwg/dom/issues/181.

- [x] At least two implementers are interested (and none opposed):
   * Already shipped for a very long time.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/xslt/idlharness.tentative.window.html?run_id=5629877849948160&run_id=5674415519956992&run_id=5740158517248000&run_id=5649823409635328


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/972.html" title="Last updated on Apr 16, 2021, 7:49 AM UTC (97202ee)">Preview</a> | <a href="https://whatpr.org/dom/972/a73380f...97202ee.html" title="Last updated on Apr 16, 2021, 7:49 AM UTC (97202ee)">Diff</a>