### PR TITLE
Editorial: remove context object concept

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -59,10 +59,6 @@ spec:html; type:element
 [[!XML]]
 [[!XML-NAMES]]
 
-<p>The term <dfn export>context object</dfn> is an alias for <a>this</a>.
-
-<p class=note>Usage of <a>context object</a> is deprecated in favor of <a>this</a>.
-
 <p>When extensions are needed, the DOM Standard can be updated accordingly, or a new standard
 can be written that hooks into the provided extensibility hooks for
 <dfn export lt="other applicable specifications">applicable specifications</dfn>.


### PR DESCRIPTION
It has been deprecated for over a year. Now it is obsolete.

I created https://github.com/w3c/FileAPI/pull/164 for the File API. There might be other specifications that need updating before landing this. If you know of any, please let me know. I don't think WHATWG is affected anymore.

cc @marcoscaceres 