### PR TITLE
Add ShadowRoot.prototype.delegatesFocus attribute

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5697,6 +5697,7 @@ constructor steps are to set <a>this</a>'s <a for=Node>node document</a> to
 [Exposed=Window]
 interface ShadowRoot : DocumentFragment {
   readonly attribute ShadowRootMode mode;
+  readonly attribute boolean delegatesFocus;
   readonly attribute SlotAssignmentMode slotAssignment;
   readonly attribute Element host;
   attribute EventHandler onslotchange;
@@ -5734,6 +5735,12 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 <p>The <dfn attribute for=ShadowRoot><code>mode</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>mode</a>.</p>
 
+<p>The <dfn attribute for=ShadowRoot><code>delegatesFocus</code></dfn> getter steps are to return
+<a>this</a>'s <a for=ShadowRoot>delegates focus</a>.</p>
+
+<p>The <dfn attribute for=ShadowRoot><code>slotAssignment</code></dfn> getter steps are to return
+<a>this</a>'s <a for=ShadowRoot>slot assignment</a>.
+
 <p>The <dfn attribute for=ShadowRoot><code>host</code></dfn> getter steps are to return
 <a>this</a>'s <a for=DocumentFragment>host</a>.
 
@@ -5741,9 +5748,6 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 <a>event handler IDL attribute</a> for the
 <dfn for=ShadowRoot export><code>onslotchange</code></dfn> <a>event handler</a>, whose
 <a>event handler event type</a> is {{HTMLSlotElement/slotchange}}.
-
-<p>The <dfn attribute for=ShadowRoot><code>slotAssignment</code></dfn> getter steps are to return
-<a>this</a>'s <a for=ShadowRoot>slot assignment</a>.
 
 <hr>
 


### PR DESCRIPTION
Fixes https://github.com/whatwg/dom/issues/931.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome: Shipped a long time ago (unclear if the lack of a spec was known)
   * Firefox: @smaug---- says "[shouldn't be harmful](https://github.com/whatwg/dom/issues/931#issuecomment-741928360)"
   * Safari: @rniwa says "[I'll be in the favor for adding this readonly attribute to make the API more interoperable.](https://github.com/whatwg/dom/issues/931#issuecomment-742821660)"
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/28593
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1706275
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=224805

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/974.html" title="Last updated on Apr 20, 2021, 8:46 AM UTC (afa6c67)">Preview</a> | <a href="https://whatpr.org/dom/974/fd0ef08...afa6c67.html" title="Last updated on Apr 20, 2021, 8:46 AM UTC (afa6c67)">Diff</a>