### PR TITLE
Add "mode locked" flag to Document, plus an algorithm to use it

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4268,8 +4268,8 @@ dom-Range-extractContents, dom-Range-cloneContents -->
   <dl class=switch>
    <dt>{{Document}}
    <dd><p>Set <var>copy</var>'s <a for=Document>encoding</a>, <a for=Document>content type</a>,
-   <a for=Document>URL</a>, <a for=Document>origin</a>, <a for=Document>type</a>, and
-   <a for=Document>mode</a>, to those of <var>node</var>.
+   <a for=Document>URL</a>, <a for=Document>origin</a>, <a for=Document>type</a>,
+   <a for=Document>mode</a>, and <a for=Document>mode locked</a> to those of <var>node</var>.
 
    <dt>{{DocumentType}}
    <dd><p>Set <var>copy</var>'s <a for=DocumentType>name</a>, <a>public ID</a>, and
@@ -4821,6 +4821,7 @@ known as <dfn export id=concept-document lt="document">documents</dfn>.
 <dfn export for=Document id=concept-document-origin>origin</dfn> (an <a for=/>origin</a>),
 <dfn export for=Document id=concept-document-type>type</dfn> ("<code>xml</code>" or "<code>html</code>"), and
 <dfn export for=Document id=concept-document-mode>mode</dfn> ("<code>no-quirks</code>", "<code>quirks</code>", or "<code>limited-quirks</code>").
+<dfn export for=Document id=concept-document-mode-locked>mode locked</dfn> (a boolean).
 [[!ENCODING]]
 [[!URL]]
 [[!HTML]]
@@ -4829,8 +4830,9 @@ known as <dfn export id=concept-document lt="document">documents</dfn>.
 <a for=/>encoding</a>, <a for=Document>content type</a> is
 "<code>application/xml</code>", <a for=Document>URL</a> is "<code>about:blank</code>",
 <a for=Document>origin</a> is an <a>opaque origin</a>,
-<a for=Document>type</a> is "<code>xml</code>", and its
-<a for=Document>mode</a> is "<code>no-quirks</code>".
+<a for=Document>type</a> is "<code>xml</code>",
+<a for=Document>mode</a> is "<code>no-quirks</code>", and
+its <a for=Document>mode locked</a> is false.
 
 <p>A <a>document</a> is said to be an <dfn export>XML document</dfn> if its <a for=Document>type</a>
 is "<code>xml</code>"; otherwise an <dfn export>HTML document</dfn>. Whether a <a>document</a> is an
@@ -4859,6 +4861,14 @@ is "<code>quirks</code>", and
 null if <var>event</var>'s {{Event/type}} attribute value is "<code>load</code>" or
 <a>document</a> does not have a <a for=Document>browsing context</a>; otherwise the
 <a>document</a>'s <a>relevant global object</a>.
+
+<p>A <a>document</a>'s <dfn export id=concept-document-set-the-mode>set the mode</dfn> algorithm,
+given a <var>new mode</var>, performs the following steps:
+
+<ol>
+ <li><p>If <a>this</a>'s <a for=Document>mode locked</a> is true, return.
+ <li><p>Set <a>this</a>'s <a for=Document>mode</a> to <var>new mode</var>.
+</ol>
 
 <hr>
 


### PR DESCRIPTION
This goes along with https://github.com/whatwg/html/pull/6745. This PR adds a "mode locked" flag to Document, which can be used to lock the [mode](https://dom.spec.whatwg.org/#concept-document-mode), so that it cannot be later changed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/989.html" title="Last updated on Jun 9, 2021, 10:30 PM UTC (748d3c0)">Preview</a> | <a href="https://whatpr.org/dom/989/f346858...748d3c0.html" title="Last updated on Jun 9, 2021, 10:30 PM UTC (748d3c0)">Diff</a>