### PR TITLE
Pass eventInitDict to event constructing steps

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -839,8 +839,8 @@ method steps are:
 
 <a lt="Other applicable specifications">Specifications</a> may define
 <dfn export id=concept-event-constructor-ext>event constructing steps</dfn> for all or some
-<a for=/>events</a>. The algorithm is passed an <var>event</var> as indicated in the
-<a>inner event creation steps</a>.
+<a for=/>events</a>. The algorithm is passed an <a>event</a> <var>event</var> and an {{EventInit}}
+<var>eventInitDict</var> as indicated in the <a>inner event creation steps</a>.
 
 <p class=note>This construct can be used by {{Event}} subclasses that have a more complex structure
 than a simple 1:1 mapping between their initializing dictionary members and IDL attributes.
@@ -915,7 +915,7 @@ correct defaults.</p>
  <var>event</var> has an attribute whose <a spec=webidl>identifier</a> is <var>member</var>, then
  initialize that attribute to <var>value</var>.
 
- <li><p>Run the <a>event constructing steps</a> with <var>event</var>.
+ <li><p>Run the <a>event constructing steps</a> with <var>event</var> and <var>dictionary</var>.
 
  <li><p>Return <var>event</var>.
 </ol>


### PR DESCRIPTION
Fixes #999.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 21, 2021, 2:23 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Fdom%2F1eadf0a4a271acc92013d1c0de8c730ac96204f9%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201002)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%231002.)._
</details>
