### PR TITLE
Add validity criteria for StaticRange

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -7665,6 +7665,7 @@ constructor steps are:
  <a for="boundary point">equal</a> to its <a for=range>end</a>.
 </ul>
 
+
 <h3 id=interface-range>Interface {{Range}}</h3>
 
 <pre class=idl>

--- a/dom.bs
+++ b/dom.bs
@@ -7650,8 +7650,7 @@ constructor steps are:
  <var>init</var>["{{StaticRangeInit/endOffset}}"]).
 </ol>
 
-<p>A {{StaticRange}} is <dfn for=StaticRange export>valid</dfn> if and only if all of the following
-conditions are true:
+<p>A {{StaticRange}} is <dfn for=StaticRange export>valid</dfn> if all of the following are true:
 
 <ul>
  <li><p>Its <a for=range>start</a> and <a for=range>end</a> are in the same <a>node tree</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -7650,6 +7650,21 @@ constructor steps are:
  <var>init</var>["{{StaticRangeInit/endOffset}}"]).
 </ol>
 
+<p>A {{StaticRange}} is <dfn for=StaticRange export>valid</dfn> if and only if all of the following
+conditions are true:
+
+<ul>
+ <li><p>Its <a for=range>start</a> and <a for=range>end</a> are in the same <a>node tree</a>.
+
+ <li><p>Its <a for=range>start offset</a> is between 0 and its <a for=range>start node</a>'s
+ <a>length</a>, inclusive.
+
+ <li><p>Its <a for=range>end offset</a> is between 0 and its <a for=range>end node</a>'s
+ <a>length</a>, inclusive.
+
+ <li><p>Its <a for=range>start</a> is <a for="boundary point">before</a> or
+ <a for="boundary point">equal</a> to its <a for=range>end</a>.
+</ul>
 
 <h3 id=interface-range>Interface {{Range}}</h3>
 
@@ -10013,6 +10028,7 @@ Chris Paris,
 Chris Rebert,
 Cyrille Tuzi,
 Dan Burzo,
+Daniel Clark,
 Daniel Glazman,
 Darin Fisher,
 David Bruant,


### PR DESCRIPTION
Add criteria defining whether a StaticRange is valid.

This will be used by the CSS [Highlight API](https://drafts.csswg.org/css-highlight-api-1/) to determine whether or not to paint highlights specified by StaticRanges. See https://drafts.csswg.org/css-highlight-api-1/#range-invalidation (which will be updated to point to the DOM spec definition) and the CSSWG [resolution](https://github.com/w3c/csswg-drafts/issues/4597#issuecomment-905688814) that Highlight API should use StaticRanges internally rather than backing them with live Ranges.

Resolves #947.

- [X] At least two implementers are interested (and none opposed):
   * Chromium has implemented Highlight API based on StaticRange using this validity criteria. 
   * Webkit has implemented an experimental version of Highlight API, and agreed to the use of StaticRange per the [resolution notes](https://github.com/w3c/csswg-drafts/issues/4597#issuecomment-905688814).
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/master/css/css-highlight-api/painting/
     * Note, the validity criteria aren't exposed directly, but these Highlight API painting tests depend on the validity criteria to 
       determine when to paint or paint a given StaticRange. See in particular custom-highlight-painting-invalidation-*.html
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed (for Highlight API):
   * Chrome: [crbug.com/1164461](https://crbug.com/1164461)
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1703961
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=204903

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1009.html" title="Last updated on Aug 31, 2021, 10:58 AM UTC (2aeabe9)">Preview</a> | <a href="https://whatpr.org/dom/1009/f2a2ded...2aeabe9.html" title="Last updated on Aug 31, 2021, 10:58 AM UTC (2aeabe9)">Diff</a>