### PR TITLE
Expose events/aborts everywhere

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -372,7 +372,7 @@ been {{Event/AT_TARGET}}.
 <h3 id=interface-event>Interface {{Event}}</h3>
 
 <pre class=idl>
-[Exposed=(Window,Worker,AudioWorklet)]
+[Exposed=*]
 interface Event {
   constructor(DOMString type, optional EventInit eventInitDict = {});
 
@@ -787,7 +787,7 @@ workers or worklets, and is inaccurate for events dispatched in <a>shadow trees<
 <h3 id=interface-customevent>Interface {{CustomEvent}}</h3>
 
 <pre class=idl>
-[Exposed=(Window,Worker)]
+[Exposed=*]
 interface CustomEvent : Event {
   constructor(DOMString type, optional CustomEventInit eventInitDict = {});
 
@@ -935,7 +935,7 @@ for historical reasons.
 <h3 id=interface-eventtarget>Interface {{EventTarget}}</h3>
 
 <pre class=idl>
-[Exposed=(Window,Worker,AudioWorklet)]
+[Exposed=*]
 interface EventTarget {
   constructor();
 
@@ -1721,7 +1721,7 @@ function doAmazingness({signal}) {
 <h3 id=interface-abortcontroller>Interface {{AbortController}}</h3>
 
 <pre class=idl>
-[Exposed=(Window,Worker)]
+[Exposed=*]
 interface AbortController {
   constructor();
 
@@ -1767,7 +1767,7 @@ constructor steps are:
 <h3 id=interface-AbortSignal>Interface {{AbortSignal}}</h3>
 
 <pre class=idl>
-[Exposed=(Window,Worker)]
+[Exposed=*]
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort();
 


### PR DESCRIPTION
Ref: https://github.com/tc39/proposal-shadowrealm/issues/331

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Positive initial signals from Google, Apple, Mozilla on the general direction.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/31852
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1281880
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1747059
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=234554

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1024.html" title="Last updated on Dec 10, 2021, 2:24 PM UTC (15f19fb)">Preview</a> | <a href="https://whatpr.org/dom/1024/3c6704a...15f19fb.html" title="Last updated on Dec 10, 2021, 2:24 PM UTC (15f19fb)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 21, 2021, 1:47 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Fdom%2F15f19fba6b32964189ec96456c30c9303fc995e7%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201024)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%231024.)._
</details>
