### PR TITLE
Add abort reason to AbortSignal

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1114,8 +1114,8 @@ participate in a tree structure.</p>
  <a>service worker events</a>, then <a>report a warning to the console</a> that this might not give
  the expected results. [[!SERVICE-WORKERS]]
 
- <li><p>If <a for="event listener">signal</a> is not null and is [=AbortSignal/aborted=], then
- return.
+ <li><p>If <var>listener</var>'s <a for="event listener">signal</a> is not null and is
+ [=AbortSignal/aborted=], then return.
 
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 
@@ -1741,11 +1741,11 @@ interface AbortController {
  <dt><code><var>controller</var> . <a attribute for=AbortController>signal</a></code>
  <dd>Returns the {{AbortSignal}} object associated with this object.
 
- <dt><code><var>controller</var> . <a method for=AbortController lt=abort()>abort</a>
- (<var>reason</var>)</code>
+ <dt><code><var>controller</var> . <a method for=AbortController lt=abort()>abort</a>(<var>reason</var>)</code>
  <dd>Invoking this method will store <var>reason</var> in this object's {{AbortSignal}}'s
  [=AbortSignal/abort reason=], and signal to any observers that the associated activity is to be
- aborted.
+ aborted. If <var>reason</var> is undefined, then an "{{AbortError!!exception}}" {{DOMException}}
+ will be stored.
 </dl>
 
 <p>An {{AbortController}} object has an associated <dfn for=AbortController>signal</dfn> (an
@@ -1784,7 +1784,7 @@ interface AbortSignal : EventTarget {
 <dl class=domintro>
  <dt><code>AbortSignal . <a method for=AbortSignal>abort</a>(<var>reason</var>)</code>
  <dd>Returns an {{AbortSignal}} instance whose <a for=AbortSignal>abort reason</a> is set to
- <var>reason</var> if provided, otherwise to an "{{AbortError!!exception}}" {{DOMException}}.
+ <var>reason</var> if not undefined; otherwise to an "{{AbortError!!exception}}" {{DOMException}}.
 
  <dt><code><var>signal</var> . <a attribute for=AbortSignal>aborted</a></code>
  <dd>Returns true if this {{AbortSignal}}'s {{AbortController}} has signaled to abort; otherwise


### PR DESCRIPTION
Based on the discussion in https://github.com/whatwg/streams/issues/1165, it was suggested that we add an abort reason property to [AbortSignal](https://dom.spec.whatwg.org/#abortsignal). This PR makes the initial changes to the base primitives in the DOM spec, before we make changes to all other related specs that use the AbortSignal.

@domenic Is it okay if you please help take a look?
/cc @yutakahirano

- [x] At least two implementers are interested (and none opposed):
   * Google
   * Mozilla
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/31291
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1263410
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1737771
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=232299


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1027.html" title="Last updated on Nov 4, 2021, 5:24 AM UTC (723f5e8)">Preview</a> | <a href="https://whatpr.org/dom/1027/0715c2f...723f5e8.html" title="Last updated on Nov 4, 2021, 5:24 AM UTC (723f5e8)">Diff</a>