### PR TITLE
Introduce AbortSignal.timeout()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1773,6 +1773,7 @@ to <a for=AbortSignal>signal abort</a> on <a>this</a>'s <a for=AbortController>s
 [Exposed=(Window,Worker)]
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort(optional any reason);
+  [NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
 
   readonly attribute boolean aborted;
   readonly attribute any reason;
@@ -1784,6 +1785,11 @@ interface AbortSignal : EventTarget {
  <dt><code>AbortSignal . <a method for=AbortSignal>abort</a>(<var>reason</var>)</code>
  <dd>Returns an {{AbortSignal}} instance whose <a for=AbortSignal>abort reason</a> is set to
  <var>reason</var> if not undefined; otherwise to an "{{AbortError!!exception}}" {{DOMException}}.
+
+ <dt><code>AbortSignal . <a method for=AbortSignal lt=timeout(milliseconds)>timeout</a>(<var>milliseconds</var>)</code>
+ <dd>Returns an {{AbortSignal}} instance which will be aborted in <var>milliseconds</var>
+ milliseconds. Its <a for=AbortSignal>abort reason</a> will be set to a
+ "{{TimeoutError!!exception}}" {{DOMException}}.
 
  <dt><code><var>signal</var> . <a attribute for=AbortSignal>aborted</a></code>
  <dd>Returns true if this {{AbortSignal}}'s {{AbortController}} has signaled to abort; otherwise
@@ -1832,6 +1838,31 @@ are:
  otherwise to a new "{{AbortError!!exception}}" {{DOMException}}.
 
  <li>Return <var>signal</var>.
+</ol>
+
+<p>The static <dfn method for=AbortSignal><code>timeout(<var>milliseconds</var>)</code></dfn> method
+steps are:
+
+<ol>
+ <li><p>Let <var>signal</var> be a new {{AbortSignal}} object.
+
+ <li><p>Let <var>global</var> be <var>signal</var>'s <a>relevant global object</a>.
+
+ <li>
+  <p><a>Run steps after a timeout</a> given <var>global</var>, "<code>AbortSignal-timeout</code>",
+  <var>milliseconds</var>, and the following step:</p>
+
+  <ol>
+   <li><p><a>Queue a global task</a> on the <a>timer task source</a> given <var>global</var> to
+   <a for=AbortSignal>signal abort</a> given <var>signal</var> and a new
+   "{{TimeoutError!!exception}}" {{DOMException}}.
+  </ol>
+
+  <p>For the duration of this timeout, if <var>signal</var> has any event listeners registered for
+  its {{AbortSignal/abort}} event, there must be a strong reference from <var>global</var> to
+  <var>signal</var>.
+
+ <li><p>Return <var>signal</var>.
 </ol>
 
 <p>The <dfn attribute for=AbortSignal>aborted</dfn> getter steps are to return true if <a>this</a>


### PR DESCRIPTION
Closes #951.

### Mini-explainer for TAG review/blink-dev purposes:

This introduces a new static method, `AbortSignal.timeout(milliseconds)`, which returns a newly-created `AbortSignal` that, after `milliseconds` milliseconds, becomes automatically aborted. The `AbortSignal`'s `reason` property will be a `"TimeoutError"` `DOMException`.

The main motivating use case for this is helping web developers easily time out async operations, such as `fetch()`. For example, now you can write:

```js
fetch(url, { signal: AbortSignal.timeout(10_000) });
```

to ensure your fetch operation has a 10-second timeout. A more full example would be:

```js
try {
  const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
  const result = await res.text();
  // ...
} catch (e) {
  if (e.name === "TimeoutError") {
    // It took more than 10 seconds to get the result!
  } else if (e.name === "AbortError") {
    // The fetch was explicitly aborted, e.g. by the user pressing the stop button!
  } else {
    // Something horrible went wrong, like a network error!
  }
}
```

This has come up in the context of several specs; see discussions on fetch at https://github.com/whatwg/fetch/issues/951 and streams at https://github.com/WICG/serial/issues/122#issuecomment-785427831. It is generally helpful for any operation that takes an `AbortSignal`, including web-developer-defined operations.

Interesting points of discussion are:

- It is specifically important that the reason be a `"TimeoutError"` `DOMException`, instead of the default-for-`AbortSignal` `"AbortError"` `DOMException`. This is because developers almost always want to discriminate between those two: a timeout is a proper failure which they might show to users, whereas an abort usually more of a "third state" (alongside success and failure) which usually they don't want to tell users about. (E.g., because the user is the one that caused the abort in the first place.)

- We treat the `milliseconds` argument the same as [`scheduler.postTask()`](https://wicg.github.io/scheduling-apis/#dom-scheduler-posttask), and almost the same as `setTimeout()`. (The difference is, we don't have the nested-clamping-to-4-ms behavior that `setTimeout()` does.) In particular this means that the timer does *not* advance while the document is in bfcache, or the worker is suspended. See https://github.com/whatwg/dom/pull/1032#issuecomment-976900712 for the reasoning there.

Future work: this feature would benefit greatly from a solution for combining `AbortSignal`s, so that people could have an operation that aborts on _either_ a timeout _or_ an explicit abort. For example, something like this:

```js
// NOT REAL CODE, YET:
const controller = new AbortController();
fetch(url, { signal: AbortSignal.all([AbortSignal.timeout(10_000), controller.signal]) });

abortButton.onclick = () => controller.abort();
```

Unfortunately there are a lot of possible shapes for such an API and so we still need to do a bit more work and research to find the best one. That's tracked in https://github.com/whatwg/dom/issues/920. Until then, people can combine such signals manually, as discussed in that issue thread.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * [Chromium](https://github.com/whatwg/dom/issues/951#issuecomment-785432044)
   * [Gecko](https://github.com/whatwg/dom/pull/1032#pullrequestreview-811812958)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/32622
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1181925
   * Firefox: TODO
   * Safari: TODO

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

----

<details>
<summary>Now-obsolete discussion of "Subtle things to deal with"</summary>

* Need to export "timer task source" from HTML
* What portions of the delay logic from [setTimeout](https://html.spec.whatwg.org/#timer-initialisation-steps) and [postTask](https://wicg.github.io/scheduling-apis/#schedule-a-posttask-task) should we port over here?
  * I so far ported: wait milliseconds; ensure ordering within a global; and allow implementation-defined extra waiting (e.g. to align on CPU wakeups or allow throttling while in the background).
  * I'm on the fence as to whether we should port suspending the timer while the document is in bfcache or the worker is suspended. For e.g. fetch timeouts, it doesn't seem to matter much whether you were in bfcache/suspended; if the server took 30 wall-clock seconds to respond, you probably want to give up. On the other hand, it might be strange (or hard to implement) for this timer mechanism to behave differently from others on the platform.
  * Should these timers impact [idle callback deadline computation](https://html.spec.whatwg.org/#event-loop-processing-model:map-of-active-timers)? postTask timers do not, but that may be an oversight. @shaseley @noamr
  * I think that, like postTask, we should not port the nesting and clamping messiness from setTimeout. The implementation-defined extra time is enough.
* Probably it's time to centralize this delay logic so that this spec, HTML, and postTask can reuse it. But we'd need to decide on the above questions first.
</details>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1032.html" title="Last updated on Dec 6, 2021, 10:09 AM UTC (7df51fe)">Preview</a> | <a href="https://whatpr.org/dom/1032/982c7e2...7df51fe.html" title="Last updated on Dec 6, 2021, 10:09 AM UTC (7df51fe)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1032.html" title="Last updated on Feb 2, 2022, 10:07 PM UTC (7df51fe)">Preview</a> | <a href="https://whatpr.org/dom/1032/982c7e2...7df51fe.html" title="Last updated on Feb 2, 2022, 10:07 PM UTC (7df51fe)">Diff</a>