### PR TITLE
Introduce abortSignal.throwIfAborted()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1695,11 +1695,9 @@ controller.abort();</code></pre>
 
  <pre><code class=lang-javascript>
 function doAmazingness({signal}) {
-  if (signal.aborted) {
-    return Promise.reject(signal.reason);
-  }
-
   return new Promise((resolve, reject) => {
+    signal.throwIfAborted();
+
     // Begin doing amazingness, and call resolve(result) when done.
     // But also, watch for signals:
     signal.addEventListener('abort', () => {

--- a/dom.bs
+++ b/dom.bs
@@ -1776,6 +1776,7 @@ interface AbortSignal : EventTarget {
 
   readonly attribute boolean aborted;
   readonly attribute any reason;
+  undefined throwIfAborted();
 
   attribute EventHandler onabort;
 };</pre>
@@ -1786,11 +1787,14 @@ interface AbortSignal : EventTarget {
  <var>reason</var> if not undefined; otherwise to an "{{AbortError!!exception}}" {{DOMException}}.
 
  <dt><code><var>signal</var> . <a attribute for=AbortSignal>aborted</a></code>
- <dd>Returns true if this {{AbortSignal}}'s {{AbortController}} has signaled to abort; otherwise
- false.
+ <dd>Returns true if <var>signal</var>'s {{AbortController}} has signaled to abort; otherwise false.
 
  <dt><code><var>signal</var> . <a attribute for=AbortSignal>reason</a></code>
- <dd>Returns this {{AbortSignal}}'s <a for=AbortSignal>abort reason</a>.
+ <dd>Returns <var>signal</var>'s <a for=AbortSignal>abort reason</a>.
+
+ <dt><code><var>signal</var> . <a method for=AbortSignal lt=throwIfAborted()>throwIfAborted</a>()</code>
+ <dd>Throws <var>signal</var>'s <a for=AbortSignal>abort reason</a>, if <var>signal</var>'s
+ {{AbortController}} has signaled to abort; otherwise, does nothing.
 </dl>
 
 <p>An {{AbortSignal}} object has an associated <dfn export for=AbortSignal>abort reason</dfn>, which is a
@@ -1839,6 +1843,31 @@ is [=AbortSignal/aborted=]; otherwise false.
 
 <p>The <dfn attribute for=AbortSignal>reason</dfn> getter steps are to return <a>this</a>'s
 <a for=AbortSignal>abort reason</a>.
+
+<p>The <dfn method for=AbortSignal>throwIfAborted()</dfn> method steps are to throw <a>this</a>'s
+<a for=AbortSignal>abort reason</a>, if <a>this</a> is [=AbortSignal/aborted=].
+
+<div class=example id=example-throwifaborted>
+ <p>This method is primarily useful for when functions accepting {{AbortSignal}}s want to throw (or
+ return a rejected promise) at specific checkpoints, instead of passing along the {{AbortSignal}}
+ to other methods. For example, the following function allows aborting in between each attempt to
+ poll for a condition. This gives opportunities to abort the polling process, even though the
+ actual asynchronous operation (i.e., <code class=lang-javascript>await func()</code>) does not
+ accept an {{AbortSignal}}.
+
+ <pre class=lang-javascript>
+ async function waitForCondition(func, targetValue, { signal } = {}) {
+   while (true) {
+     signal?.throwIfAborted();
+
+     const result = await func();
+     if (result === targetValue) {
+       return;
+     }
+   }
+ }
+ </pre>
+</div>
 
 <p>The <dfn attribute for=AbortSignal><code>onabort</code></dfn> attribute is an
 <a>event handler IDL attribute</a> for the <dfn export for=AbortSignal><code>onabort</code></dfn>


### PR DESCRIPTION
Closes #927.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/31947
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1273458
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1745372
   * Safari: https://bugs.webkit.org/show_bug.cgi?id=234127

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1034.html" title="Last updated on Dec 10, 2021, 8:37 AM UTC (0645ef6)">Preview</a> | <a href="https://whatpr.org/dom/1034/982c7e2...0645ef6.html" title="Last updated on Dec 10, 2021, 8:37 AM UTC (0645ef6)">Diff</a>