### PR TITLE
Aborting: clarify usage for non-promise APIs

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1667,7 +1667,7 @@ The API which wishes to support aborting can accept an {{AbortSignal}} object, a
 determine how to proceed.
 
 <p>APIs that rely upon {{AbortController}} are encouraged to respond to {{AbortController/abort()}}
-by rejecting any unsettled promise with a new "{{AbortError!!exception}}" {{DOMException}}.
+by rejecting any unsettled promise with the {{AbortSignal}}'s [=AbortSignal/abort reason=].
 
 <div class=example id=aborting-ongoing-activities-example>
  <p>A hypothetical <code>doAmazingness({ ... })</code> method could accept an {{AbortSignal}} object
@@ -1696,7 +1696,7 @@ controller.abort();</code></pre>
  <pre><code class=lang-javascript>
 function doAmazingness({signal}) {
   if (signal.aborted) {
-    return Promise.reject(new DOMException('Aborted', 'AbortError'));
+    return Promise.reject(signal.reason);
   }
 
   return new Promise((resolve, reject) => {
@@ -1704,15 +1704,19 @@ function doAmazingness({signal}) {
     // But also, watch for signals:
     signal.addEventListener('abort', () => {
       // Stop doing amazingness, and:
-      reject(new DOMException('Aborted', 'AbortError'));
+      reject(signal.reason);
     });
   });
 }
 </code></pre>
-
- <p>APIs that require more granular control could extend both {{AbortController}} and
- {{AbortSignal}} objects according to their needs.
 </div>
+
+<p>APIs that do not return promises can either react in an equivalent manner or opt to not surface
+the {{AbortSignal}}'s [=AbortSignal/abort reason=] at all. {{EventTarget/addEventListener()}} is an
+example of an API where the latter made sense.
+
+<p>APIs that require more granular control could extend both {{AbortController}} and
+{{AbortSignal}} objects according to their needs.
 
 
 <h3 id=interface-abortcontroller>Interface {{AbortController}}</h3>


### PR DESCRIPTION
Also clean up some remaining instances that didn't use signal.reason.

Closes #961.

---

Some changes here are copied from #1032 and some could be further improved in #1034. Given that those will likely take a bit more I figured we should at least get this clarified while people are updating their APIs to account for signal's abort reason.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 6, 2021, 9:57 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwhatpr.org%2Fdom%2F1040%2F3e51b89.html&doc2=https%3A%2F%2Fwhatpr.org%2Fdom%2F1040.html)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%231040.)._
</details>
