### PR TITLE
Limit AbortSignal.timeout to Window and Worker

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1771,7 +1771,7 @@ to <a for=AbortSignal>signal abort</a> on <a>this</a>'s <a for=AbortController>s
 [Exposed=*]
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort(optional any reason);
-  [NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+  [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
 
   readonly attribute boolean aborted;
   readonly attribute any reason;


### PR DESCRIPTION
Worklets are designed with minimal event loops such that they need only run a single task and corresponding microtasks, making APIs that schedule additional tasks unsuitable for worklets. This restricts the availability of AbortSignal.timeout to Window and Worker since the API schedules a task to implement the timeout.

Closes #1054.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1055.html" title="Last updated on Feb 4, 2022, 8:50 PM UTC (9da62cc)">Preview</a> | <a href="https://whatpr.org/dom/1055/db4088a...9da62cc.html" title="Last updated on Feb 4, 2022, 8:50 PM UTC (9da62cc)">Diff</a>