### PR TITLE
Editorial: Fix a reference to "extract a live range"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -8799,7 +8799,7 @@ check first thing, which matches everyone but Firefox.
   <p class=note>For historical reasons {{CharacterData}}
   <a for=/>nodes</a> are not checked here and end up throwing later on as a side effect.
 
- <li><p>Let <var>fragment</var> be the result of <a lt="live range">extracting</a> <a>this</a>.
+ <li><p>Let <var>fragment</var> be the result of <a for="live range">extracting</a> <a>this</a>.
  <!-- If the range contains a DocumentType, Firefox 4.0 and Opera 11.00 don't
  immediately throw here. Firefox removes the non-DocumentType nodes and
  throws, Opera removes all nodes and doesn't throw. This applies to


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1068.html" title="Last updated on Mar 21, 2022, 8:47 PM UTC (02d92c2)">Preview</a> | <a href="https://whatpr.org/dom/1068/dbb7916...02d92c2.html" title="Last updated on Mar 21, 2022, 8:47 PM UTC (02d92c2)">Diff</a>