### PR TITLE
Maybe throw NotSupportedError for createEvent('touchevent')

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5391,6 +5391,11 @@ are:
  <li><p>Let <var>constructor</var> be null.
 
  <li>
+  <p>If <var>interface</var> is an <a>ASCII case-insensitive</a> match for "<code>touchevent</code>"
+  and the user agent's <a>expose legacy touch event APIs</a> is false, then <a>throw</a> a
+  "{{NotSupportedError!!exception}}" {{DOMException}}.
+
+ <li>
   <p>If <var>interface</var> is an <a>ASCII case-insensitive</a> match for any of the strings in the
   first column in the following table, then set <var>constructor</var> to the interface in the
   second column on the same row as the matching string:


### PR DESCRIPTION
See https://github.com/w3c/touch-events/issues/64

Depends on https://github.com/w3c/touch-events/pull/111

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Already implemented in Chromium, Gecko, WebKit.
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
