### PR TITLE
Missing dot for `concept-node-remove`s first step.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2743,7 +2743,7 @@ indicated in the <a for=/>remove</a> algorithm below.
 <i>suppress observers flag</i>, run these steps:
 
 <ol>
- <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>
+ <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>.
 
  <li><p>Assert: <var>parent</var> is non-null.
 


### PR DESCRIPTION
@annevk said "that's not great" out loud. Twice!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1086.html" title="Last updated on Jun 9, 2022, 9:11 AM UTC (86e2614)">Preview</a> | <a href="https://whatpr.org/dom/1086/20012f1...86e2614.html" title="Last updated on Jun 9, 2022, 9:11 AM UTC (86e2614)">Diff</a>