### PR TITLE
[Editorial] Typo occurance -> occurrence in section's id

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1668,7 +1668,8 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
 </div>
 
 
-<h3 id=action-versus-occurance>Action versus occurrence</h3>
+<h3 id="action-versus-occurrence"><span id=action-versus-occurance>Action versus occurrence</span
+></h3>
 
 <p>An <a>event</a> signifies an occurrence, not an action. Phrased differently, it
 represents a notification from an algorithm and can be used to influence the future course

--- a/dom.bs
+++ b/dom.bs
@@ -1668,8 +1668,7 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
 </div>
 
 
-<h3 id="action-versus-occurrence"><span id=action-versus-occurance>Action versus occurrence</span
-></h3>
+<h3 id="action-versus-occurrence" oldids="action-versus-occurance">Action versus occurrence</h3>
 
 <p>An <a>event</a> signifies an occurrence, not an action. Phrased differently, it
 represents a notification from an algorithm and can be used to influence the future course

--- a/dom.bs
+++ b/dom.bs
@@ -10214,6 +10214,7 @@ Tom Pixley,
 Travis Leithead,
 Trevor Rowbotham,
 <i>triple-underscore</i>,<!--GitHub-->
+Tristan Fraipont,
 Veli Şenol,
 Vidur Apparao,
 Warren He,


### PR DESCRIPTION
This commit fixes a small typo in the id of the section https://dom.spec.whatwg.org/#action-versus-occurance.
Since this id is probably used in many places, we kept a `<span>` with the previous id to preserve the previous link (Thanks @sideshowbarker for the suggestion).

Ps: I'm not too used to bikeshed, but for whatever reasons it was requesting the id to be hardcoded, instead of deriving it from the title's content.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * N/A this is editorial only
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * N/A
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1100.html" title="Last updated on Aug 1, 2022, 1:02 PM UTC (52de3e5)">Preview</a> | <a href="https://whatpr.org/dom/1100/b294497...52de3e5.html" title="Last updated on Aug 1, 2022, 1:02 PM UTC (52de3e5)">Diff</a>