### PR TITLE
[meta] Define slotchange event

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3420,7 +3420,7 @@ run these steps:
   </ol>
 
  <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a> named
- <dfn event for=HTMLSlotElement>slotchange</dfn>, with its {{Event/bubbles}} attribute set to true, 
+ <dfn event for=HTMLSlotElement>slotchange</dfn>, with its {{Event/bubbles}} attribute set to true,
  at <var>slot</var>.
 </ol>
 

--- a/dom.bs
+++ b/dom.bs
@@ -3420,8 +3420,8 @@ run these steps:
   </ol>
 
  <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a> named
- <dfn event for=HTMLSlotElement>slotchange</dfn>, with its {{Event/bubbles}} attribute
-  set to true, at <var>slot</var>.
+ <dfn event for=HTMLSlotElement>slotchange</dfn>, with its {{Event/bubbles}} attribute set to true, 
+ at <var>slot</var>.
 </ol>
 
 <hr>

--- a/dom.bs
+++ b/dom.bs
@@ -3419,9 +3419,9 @@ run these steps:
    and <var>mo</var>. If this throws an exception, catch it, and <a>report the exception</a>.
   </ol>
 
- <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a>
- named <dfn event for=HTMLSlotElement>slotchange</dfn>, with its {{Event/bubbles}} attribute set to true, at
- <var>slot</var>.
+ <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a> named
+ <dfn event for=HTMLSlotElement>slotchange</dfn>, with its {{Event/bubbles}} attribute
+  set to true, at <var>slot</var>.
 </ol>
 
 <hr>

--- a/dom.bs
+++ b/dom.bs
@@ -3420,7 +3420,7 @@ run these steps:
   </ol>
 
  <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a>
- named {{HTMLSlotElement/slotchange}}, with its {{Event/bubbles}} attribute set to true, at
+ named <dfn event for=HTMLSlotElement>slotchange</dfn>, with its {{Event/bubbles}} attribute set to true, at
  <var>slot</var>.
 </ol>
 


### PR DESCRIPTION
Following discussions in https://github.com/whatwg/html/issues/8340, the events index in the HTML spec will be restricted to event types that gets fired within the HTML spec. The `slotchange` event will be dropped as a result.

This turns the mention of the `slotchange` event into a proper event type definition, so that other specs (including the HTML spec) can reference it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1115.html" title="Last updated on Oct 4, 2022, 3:52 PM UTC (1db0fe4)">Preview</a> | <a href="https://whatpr.org/dom/1115/fa3aea5...1db0fe4.html" title="Last updated on Oct 4, 2022, 3:52 PM UTC (1db0fe4)">Diff</a>