### PR TITLE
Add pop-up light dismiss logic to event dispatching

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1393,7 +1393,7 @@ property of the event being dispatched.
      <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
      {{Event/CAPTURING_PHASE}}.
 
-     <li><p>Run {light dismiss open pop-ups} given <var>struct</var>'s <a
+     <li><p>Run {light dismiss open pop-ups} given <var>event</var> and <var>struct</var>'s <a
      for=Event/path>invocation target</a>.
 
      <li><p><a>Invoke</a> with <var>struct</var>, <var>event</var>, "<code>capturing</code>", and

--- a/dom.bs
+++ b/dom.bs
@@ -1393,6 +1393,9 @@ property of the event being dispatched.
      <li><p>Otherwise, set <var>event</var>'s {{Event/eventPhase}} attribute to
      {{Event/CAPTURING_PHASE}}.
 
+     <li><p>Run {light dismiss open pop-ups} given <var>struct</var>'s <a
+     for=Event/path>invocation target</a>.
+
      <li><p><a>Invoke</a> with <var>struct</var>, <var>event</var>, "<code>capturing</code>", and
      <var>legacyOutputDidListenersThrowFlag</var> if given.
     </ol>


### PR DESCRIPTION
This was moved from the HTML spec PR for the popup attribute based on this advice: https://github.com/whatwg/html/pull/8221#discussion_r987585621
TODO add a better description

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/html/semantics/popups
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1307772
   * Firefox: …
   * Safari: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1117.html" title="Last updated on Oct 27, 2022, 6:32 PM UTC (f4cef07)">Preview</a> | <a href="https://whatpr.org/dom/1117/bf5f6c2...f4cef07.html" title="Last updated on Oct 27, 2022, 6:32 PM UTC (f4cef07)">Diff</a>