### PR TITLE
Editorial: clarify namespace validate and extract

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -210,8 +210,17 @@ run these steps:
 
  <li><p>Let <var>localName</var> be <var>qualifiedName</var>.
 
- <li><p>If <var>qualifiedName</var> contains a U+003A (:), then <a>strictly split</a> the string on
- it and set <var>prefix</var> to the part before and <var>localName</var> to the part after.
+ <li>
+  <p>If <var>qualifiedName</var> contains a U+003A (:), then:
+
+  <ol>
+   <li><p>Let <var>splitResult</var> be the result of running <a>strictly split</a> given
+   <var>qualifiedName</var> and U+003A (:).
+
+   <li><p>Set <var>prefix</var> to <var>splitResult</var>[0].
+
+   <li><p>Set <var>localName</var> to <var>splitResult</var>[1].
+  </ol>
 
  <li><p>If <var>prefix</var> is non-null and <var>namespace</var> is null, then <a>throw</a> a
  "{{NamespaceError!!exception}}" {{DOMException}}.


### PR DESCRIPTION
Clarify the usage of strictly split a string in the algorithm validate and extract defined for namespaces.

Fixes: https://github.com/whatwg/dom/issues/1134


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1135.html" title="Last updated on Dec 13, 2022, 2:48 PM UTC (0242fae)">Preview</a> | <a href="https://whatpr.org/dom/1135/1aa6fb0...0242fae.html" title="Last updated on Dec 13, 2022, 2:48 PM UTC (0242fae)">Diff</a>