### PR TITLE
Editorial: remove reference to time origin

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -34,7 +34,6 @@ urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
   text: surrounding agent; url: surrounding-agent
 urlPrefix: https://w3c.github.io/hr-time/#; spec: HR-TIME
  type:typedef; urlPrefix: dom-; text: DOMHighResTimeStamp
- type:dfn; text: time origin; url: dfn-time-origin
  type:dfn; text: current high resolution time; url: dfn-current-high-resolution-time
  type:dfn; text: relative high resolution coarse time; url: dfn-relative-high-resolution-coarse-time
 </pre>
@@ -511,7 +510,7 @@ the empty list.</p>
 
  <dt><code><var>event</var> . {{Event/timeStamp}}</code>
  <dd>Returns the <var>event</var>'s timestamp as the number of milliseconds measured relative to
- the <a>time origin</a>.
+ the occurrence.
 </dl>
 
 <p>The <dfn attribute for=Event><code>type</code></dfn> attribute must return the value it was


### PR DESCRIPTION
Closes #1149.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1151.html" title="Last updated on Feb 6, 2023, 7:33 AM UTC (0afea28)">Preview</a> | <a href="https://whatpr.org/dom/1151/8b0a622...0afea28.html" title="Last updated on Feb 6, 2023, 7:33 AM UTC (0afea28)">Diff</a>