### PR TITLE
Add AbortSignal.any()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1812,7 +1812,7 @@ interface AbortSignal : EventTarget {
  <dt><code>AbortSignal . <a method for=AbortSignal lt=any(signals)>any</a>(<var>signals</var>)</code>
  <dd>Returns an {{AbortSignal}} instance which will be aborted once any of <var>signals</var> is
  aborted. Its <a for=AbortSignal>abort reason</a> will be set to whichever one of <var>signals</var>
- cause it to be aborted.
+ caused it to be aborted.
 
  <dt><code>AbortSignal . <a method for=AbortSignal lt=timeout(milliseconds)>timeout</a>(<var>milliseconds</var>)</code>
  <dd>Returns an {{AbortSignal}} instance which will be aborted in <var>milliseconds</var>
@@ -1844,11 +1844,11 @@ specified otherwise, its value is the empty set.
 initially false.
 
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn>, which is a
-<a for=/>set</a> of weak references to {{AbortSignal}}s that the object is dependent on for its
-[=AbortSignal/aborted=] state. Unless specified otherwise, its value is the empty set.
+<a for=/>set</a> of weak references to {{AbortSignal}} objects that the object is dependent on for
+its [=AbortSignal/aborted=] state. Unless specified otherwise, its value is the empty set.
 
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>dependent signals</dfn>, which is a
-<a for=/>set</a> of weak references to {{AbortSignal}}s that are dependent on it for their
+<a for=/>set</a> of weak references to {{AbortSignal}} objects that are dependent on it for their
 [=AbortSignal/aborted=] state. Unless specified otherwise, its value is the empty set.
 
 <p>To <dfn export for=AbortSignal>add</dfn> an algorithm <var>algorithm</var> to an {{AbortSignal}}
@@ -1970,10 +1970,6 @@ an optional <var>reason</var>, run these steps:
  <li><p><a for=set>For each</a> <var>dependentSignal</var> of <var>signal</var>'s
  [=AbortSignal/dependent signals=], [=AbortSignal/signal abort=] on <var>dependentSignal</var> with
  <var>signal</var>'s [=AbortSignal/abort reason=].
-
- <li><p><a for=set>Empty</a> <var>signal</var>'s <a for=AbortSignal>dependent signals</a>.
-
- <li><p><a for=set>Empty</a> <var>signal</var>'s <a for=AbortSignal>source signals</a>.
 </ol>
 
 <p>To <dfn export>create a composite abort signal</dfn> from a list of {{AbortSignal}} objects
@@ -2028,15 +2024,16 @@ interface that inherits from it, and an optional <var>realm</var>, run these ste
      [=AbortSignal/dependent signals=].
     </ol>
   </ol>
+
  <li>Return <var>resultSignal</var>.
 </ol>
 
 
 <h4 id=abort-signal-garbage-collection>Garbage collection</h4>
 
-<p>A [=AbortSignal/composite=] {{AbortSignal}} object must not be garbage collected while its
-[=AbortSignal/source signals=] is non-empty unless it has no registered event listeners for its
-{{AbortSignal/abort}} event and its [=AbortSignal/abort algorithms=] is empty.
+<p>A non-[=AbortSignal/aborted=] [=AbortSignal/composite=] {{AbortSignal}} object must not be
+garbage collected while its [=AbortSignal/source signals=] is non-empty and it has registered event
+listeners for its {{AbortSignal/abort}} event or its [=AbortSignal/abort algorithms=] is non-empty.
 
 
 <h3 id=abortcontroller-api-integration>Using {{AbortController}} and {{AbortSignal}} objects in

--- a/dom.bs
+++ b/dom.bs
@@ -30,6 +30,7 @@ type: interface
 urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
  text: Construct; url: sec-construct; type: abstract-op
  type: dfn
+  text: current realm; url: current-realm
   text: realm; url: realm
   text: surrounding agent; url: surrounding-agent
 urlPrefix: https://w3c.github.io/hr-time/#; spec: HR-TIME
@@ -1830,45 +1831,30 @@ interface AbortSignal : EventTarget {
  {{AbortController}} has signaled to abort; otherwise, does nothing.
 </dl>
 
-<p>An {{AbortSignal}} object has an associated <dfn export for=AbortSignal>abort reason</dfn>, which is a
-JavaScript value. It is undefined unless specified otherwise.
+<p>An {{AbortSignal}} object has an associated <dfn export for=AbortSignal>abort reason</dfn> (a
+JavaScript value), which is initially undefined.
 
-<p>An {{AbortSignal}} object is <dfn export for="AbortSignal">aborted</dfn> when its
-[=AbortSignal/abort reason=] is not undefined.
-
-<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>abort algorithms</dfn>, which is a
-<a for=/>set</a> of algorithms which are to be executed when it is [=AbortSignal/aborted=]. Unless
-specified otherwise, its value is the empty set.
-
-<p>An {{AbortSignal}} object has a <dfn for="AbortSignal">composite</dfn> (a boolean), which is
-initially false.
-
-<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn>, which is a
-<a for=/>set</a> of weak references to {{AbortSignal}} objects that the object is dependent on for
-its [=AbortSignal/aborted=] state. Unless specified otherwise, its value is the empty set.
-
-<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>dependent signals</dfn>, which is a
-<a for=/>set</a> of weak references to {{AbortSignal}} objects that are dependent on it for their
-[=AbortSignal/aborted=] state. Unless specified otherwise, its value is the empty set.
-
-<p>To <dfn export for=AbortSignal>add</dfn> an algorithm <var>algorithm</var> to an {{AbortSignal}}
-object <var>signal</var>, run these steps:
-
-<ol>
- <li><p>If <var>signal</var> is [=AbortSignal/aborted=], then return.
-
- <li><p><a for=set>Append</a> <var>algorithm</var> to <var>signal</var>'s
- <a for=AbortSignal>abort algorithms</a>.
-</ol>
-
-<p>To <dfn export for=AbortSignal>remove</dfn> an algorithm <var>algorithm</var> from an
-{{AbortSignal}} <var>signal</var>, <a for=set>remove</a> <var>algorithm</var> from
-<var>signal</var>'s <a for=AbortSignal>abort algorithms</a>.
+<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>abort algorithms</dfn>, (a
+<a for=/>set</a> of algorithms which are to be executed when it is [=AbortSignal/aborted=]),
+which is initially empty.
 
 <p class=note>The [=AbortSignal/abort algorithms=] enable APIs with complex
 requirements to react in a reasonable way to {{AbortController/abort()}}. For example, a given API's
 [=AbortSignal/abort reason=] might need to be propagated to a cross-thread environment, such as a
 service worker.
+
+<p>An {{AbortSignal}} object has a <dfn for="AbortSignal">composite</dfn> (a boolean), which is
+initially false.
+
+<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn>, (a weak
+<a for=/>set</a> of {{AbortSignal}} objects that the object is dependent on for its
+[=AbortSignal/aborted=] state), which is initially empty.
+
+<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>dependent signals</dfn> (a weak
+<a for=/>set</a> of {{AbortSignal}} objects that are dependent on the obejct for their
+[=AbortSignal/aborted=] state), which is initially empty.
+
+<hr>
 
 <p>The static <dfn method for=AbortSignal><code>abort(<var>reason</var>)</code></dfn> method steps
 are:
@@ -1909,7 +1895,7 @@ steps are:
 
 <p>The static <dfn method for=AbortSignal><code>any(<var>signals</var>)</code></dfn> method
 steps are to return the result of <a>creating a composite abort signal</a> from <var>signals</var>
-using {{AbortSignal}}.
+using {{AbortSignal}} and the <a>current realm</a>.
 
 <p>The <dfn attribute for=AbortSignal>aborted</dfn> getter steps are to return true if <a>this</a>
 is [=AbortSignal/aborted=]; otherwise false.
@@ -1951,8 +1937,27 @@ is [=AbortSignal/aborted=]; otherwise false.
 {{AbortController}} object, but an API observing the {{AbortSignal}} object can choose to ignore
 them. For instance, if the operation has already completed.
 
+<hr>
+
+<p>An {{AbortSignal}} object is <dfn export for="AbortSignal">aborted</dfn> when its
+[=AbortSignal/abort reason=] is not undefined.
+
+<p>To <dfn export for=AbortSignal>add</dfn> an algorithm <var>algorithm</var> to an {{AbortSignal}}
+object <var>signal</var>:
+
+<ol>
+ <li><p>If <var>signal</var> is [=AbortSignal/aborted=], then return.
+
+ <li><p><a for=set>Append</a> <var>algorithm</var> to <var>signal</var>'s
+ <a for=AbortSignal>abort algorithms</a>.
+</ol>
+
+<p>To <dfn export for=AbortSignal>remove</dfn> an algorithm <var>algorithm</var> from an
+{{AbortSignal}} <var>signal</var>, <a for=set>remove</a> <var>algorithm</var> from
+<var>signal</var>'s <a for=AbortSignal>abort algorithms</a>.
+
 <p>To <dfn for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object <var>signal</var> and
-an optional <var>reason</var>, run these steps:
+an optional <var>reason</var>:
 
 <ol>
  <li><p>If <var>signal</var> is [=AbortSignal/aborted=], then return.
@@ -1974,16 +1979,12 @@ an optional <var>reason</var>, run these steps:
 
 <p>To <dfn export>create a composite abort signal</dfn> from a list of {{AbortSignal}} objects
 <var>signals</var>, using <var>signalInterface</var>, which must be either {{AbortSignal}} or an
-interface that inherits from it, and an optional <var>realm</var>, run these steps:
+interface that inherits from it, and a <var>realm</var>:
 
 <ol>
  <li>
   <p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
-  <var>signalInterface</var> using <var>realm</var> if given, otherwise using the default behavior
-  defined in Web IDL.
-
-  <p class=XXX>As of the time of this writing Web IDL does not yet define any default behavior;
-  see <a href="https://github.com/whatwg/webidl/issues/135">whatwg/webidl#135</a>.
+  <var>signalInterface</var> using <var>realm</var>.
 
  <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
 
@@ -3539,6 +3540,7 @@ dictionary MutationObserverInit {
 <ul class=brief>
  <li>A <dfn for=MutationObserver id=concept-mo-callback>callback</dfn> set on creation.
  <li>A <dfn for=MutationObserver>node list</dfn> (a <a for=/>list</a> of weak references to
+
  <a for=/>nodes</a>), which is initially empty.
  <li>A <dfn for=MutationObserver id=concept-mo-queue>record queue</dfn> (a <a for=/>queue</a> of
  zero or more {{MutationRecord}} objects), which is initially empty.

--- a/dom.bs
+++ b/dom.bs
@@ -1850,7 +1850,7 @@ requirements to react in a reasonable way to {{AbortController/abort()}}. For ex
 [=AbortSignal/abort reason=] might need to be propagated to a cross-thread environment, such as a
 service worker.
 
-<p>An {{AbortSignal}} object has a <dfn for="AbortSignal">composite</dfn> (a boolean), which is
+<p>An {{AbortSignal}} object has a <dfn for="AbortSignal">dependent</dfn> (a boolean), which is
 initially false.
 
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn> (a weak
@@ -1906,7 +1906,7 @@ steps are:
 
 <div algorithm>
 <p>The static <dfn method for=AbortSignal><code>any(<var>signals</var>)</code></dfn> method
-steps are to return the result of <a>creating a composite abort signal</a> from <var>signals</var>
+steps are to return the result of <a>creating a dependent abort signal</a> from <var>signals</var>
 using {{AbortSignal}} and the <a>current realm</a>.
 </div>
 
@@ -1997,7 +1997,7 @@ object <var>signal</var>:
 </div>
 
 <div algorithm>
-<p>To <dfn export>create a composite abort signal</dfn> from a list of {{AbortSignal}} objects
+<p>To <dfn export>create a dependent abort signal</dfn> from a list of {{AbortSignal}} objects
 <var>signals</var>, using <var>signalInterface</var>, which must be either {{AbortSignal}} or an
 interface that inherits from it, and a <var>realm</var>:
 
@@ -2009,14 +2009,14 @@ interface that inherits from it, and a <var>realm</var>:
  [=AbortSignal/aborted=], then set <var>resultSignal</var>'s [=AbortSignal/abort reason=] to
  <var>signal</var>'s [=AbortSignal/abort reason=] and return <var>resultSignal</var>.
 
- <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
+ <li><p>Set <var>resultSignal</var>'s [=AbortSignal/dependent=] to true.
 
  <li>
   <p><a for=list>For each</a> <var>signal</var> of <var>signals</var>:
 
   <ol>
    <li>
-    <p>If <var>signal</var>'s [=AbortSignal/composite=] is false, then:
+    <p>If <var>signal</var>'s [=AbortSignal/dependent=] is false, then:
 
     <ol>
      <li><p><a for=set>Append</a> <var>signal</var> to <var>resultSignal</var>'s
@@ -2032,7 +2032,7 @@ interface that inherits from it, and a <var>realm</var>:
 
     <ol>
      <li><p>Assert: <var>sourceSignal</var> is not [=AbortSignal/aborted=] and not
-     [=AbortSignal/composite=].
+     [=AbortSignal/dependent=].
 
      <li><p>If <var>resultSignal</var>'s [=AbortSignal/source signals=] <a for=set>contains</a>
      <var>sourceSignal</var>, then <a for=iteration>continue</a>.
@@ -2052,7 +2052,7 @@ interface that inherits from it, and a <var>realm</var>:
 
 <h4 id=abort-signal-garbage-collection>Garbage collection</h4>
 
-<p>A non-[=AbortSignal/aborted=] [=AbortSignal/composite=] {{AbortSignal}} object must not be
+<p>A non-[=AbortSignal/aborted=] [=AbortSignal/dependent=] {{AbortSignal}} object must not be
 garbage collected while its [=AbortSignal/source signals=] is non-empty and it has registered event
 listeners for its {{AbortSignal/abort}} event or its [=AbortSignal/abort algorithms=] is non-empty.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1981,9 +1981,13 @@ an optional <var>reason</var>, run these steps:
 interface that inherits from it, and an optional <var>realm</var>, run these steps:
 
 <ol>
- <li><p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
- <var>signalInterface</var> using <var>realm</var> if given, otherwise using the default behavior
- defined in Web IDL.
+ <li>
+  <p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
+  <var>signalInterface</var> using <var>realm</var> if given, otherwise using the default behavior
+  defined in Web IDL.
+
+  <p class=XXX>As of the time of this writing Web IDL does not yet define any default behavior;
+  see <a href="https://github.com/whatwg/webidl/issues/135">whatwg/webidl#135</a>.
 
  <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1851,7 +1851,7 @@ initially false.
 [=AbortSignal/aborted=] state), which is initially empty.
 
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>dependent signals</dfn> (a weak
-<a for=/>set</a> of {{AbortSignal}} objects that are dependent on the obejct for their
+<a for=/>set</a> of {{AbortSignal}} objects that are dependent on the object for their
 [=AbortSignal/aborted=] state), which is initially empty.
 
 <hr>
@@ -3540,7 +3540,6 @@ dictionary MutationObserverInit {
 <ul class=brief>
  <li>A <dfn for=MutationObserver id=concept-mo-callback>callback</dfn> set on creation.
  <li>A <dfn for=MutationObserver>node list</dfn> (a <a for=/>list</a> of weak references to
-
  <a for=/>nodes</a>), which is initially empty.
  <li>A <dfn for=MutationObserver id=concept-mo-queue>record queue</dfn> (a <a for=/>queue</a> of
  zero or more {{MutationRecord}} objects), which is initially empty.

--- a/dom.bs
+++ b/dom.bs
@@ -1782,8 +1782,11 @@ constructor steps are:
 <a>this</a>'s <a for=AbortController>signal</a>.
 
 <p>The <dfn method for=AbortController><code>abort(<var>reason</var>)</code></dfn> method steps are
-to <a for=AbortSignal>signal abort</a> on <a>this</a>'s <a for=AbortController>signal</a> with
-<var>reason</var> if it is given.
+to <a for=AbortController>request abort</a> on <a>this</a> with <var>reason</var> if it is given.
+
+<p>To <dfn export for=AbortController>request abort</dfn> on an {{AbortController}} <var>controller</var>
+with an optional <var>reason</var>, <a for=AbortSignal>signal abort</a> on <var>controller</var>'s
+<a for=AbortController>signal</a> with <var>reason</var> if it is given.
 
 <h3 id=interface-AbortSignal>Interface {{AbortSignal}}</h3>
 
@@ -1792,6 +1795,7 @@ to <a for=AbortSignal>signal abort</a> on <a>this</a>'s <a for=AbortController>s
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort(optional any reason);
   [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+  [NewObject] static AbortSignal _any(sequence&lt;AbortSignal> signals);
 
   readonly attribute boolean aborted;
   readonly attribute any reason;
@@ -1804,6 +1808,11 @@ interface AbortSignal : EventTarget {
  <dt><code>AbortSignal . <a method for=AbortSignal>abort</a>(<var>reason</var>)</code>
  <dd>Returns an {{AbortSignal}} instance whose <a for=AbortSignal>abort reason</a> is set to
  <var>reason</var> if not undefined; otherwise to an "{{AbortError!!exception}}" {{DOMException}}.
+
+ <dt><code>AbortSignal . <a method for=AbortSignal lt=any(signals)>any</a>(<var>signals</var>)</code>
+ <dd>Returns an {{AbortSignal}} instance which will be aborted if any of <var>signals</var> is
+ aborted. Its <a for=AbortSignal>abort reason</a> will be set to whichever one of <var>signals</var>
+ cause it to be aborted.
 
  <dt><code>AbortSignal . <a method for=AbortSignal lt=timeout(milliseconds)>timeout</a>(<var>milliseconds</var>)</code>
  <dd>Returns an {{AbortSignal}} instance which will be aborted in <var>milliseconds</var>
@@ -1830,6 +1839,17 @@ JavaScript value. It is undefined unless specified otherwise.
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>abort algorithms</dfn>, which is a
 <a for=/>set</a> of algorithms which are to be executed when it is [=AbortSignal/aborted=]. Unless
 specified otherwise, its value is the empty set.
+
+<p>An {{AbortSignal}} object has a <dfn for="AbortSignal">composite</dfn> (a boolean), which is
+initially false.
+
+<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn>, which is a
+<a for=/>set</a> of {{AbortSignal}}s the object is dependent on for its [=AbortSignal/aborted=]
+state. Unless specified otherwise, its value is the empty set.
+
+<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>dependent signals</dfn>, which is a
+<a for=/>set</a> of {{AbortSignal}}s that are dependent on it for their [=AbortSignal/aborted=]
+state. Unless specified otherwise, its value is the empty set.
 
 <p>To <dfn export for=AbortSignal>add</dfn> an algorithm <var>algorithm</var> to an {{AbortSignal}}
 object <var>signal</var>, run these steps:
@@ -1887,6 +1907,10 @@ steps are:
  <li><p>Return <var>signal</var>.
 </ol>
 
+<p>The static <dfn method for=AbortSignal><code>any(<var>signals</var>)</code></dfn> method
+steps are to return the result of <a for=AbortSignal>creating a composite abort signal</a> from
+<var>signals</var>.
+
 <p>The <dfn attribute for=AbortSignal>aborted</dfn> getter steps are to return true if <a>this</a>
 is [=AbortSignal/aborted=]; otherwise false.
 
@@ -1924,10 +1948,10 @@ is [=AbortSignal/aborted=]; otherwise false.
 <dfn event for=AbortSignal><code>abort</code></dfn>.
 
 <p class=note>Changes to an {{AbortSignal}} object represent the wishes of the corresponding
-{{AbortController}} object, but an API observing the {{AbortSignal}} object can chose to ignore
+{{AbortController}} object, but an API observing the {{AbortSignal}} object can choose to ignore
 them. For instance, if the operation has already completed.
 
-<p>To <dfn export for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object
+<p>To <dfn noexport for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object
 <var>signal</var> and an optional <var>reason</var>, run these steps:
 
 <ol>
@@ -1936,34 +1960,82 @@ them. For instance, if the operation has already completed.
  <li><p>Set <var>signal</var>'s [=AbortSignal/abort reason=] to <var>reason</var> if it is given;
  otherwise to a new "{{AbortError!!exception}}" {{DOMException}}.
 
- <li><p><a for=set>For each</a> <var>algorithm</var> in <var>signal</var>'s
+ <li><p><a for=set>For each</a> <var>algorithm</var> of <var>signal</var>'s
  [=AbortSignal/abort algorithms=]: run <var>algorithm</var>.
 
  <li><p><a for=set>Empty</a> <var>signal</var>'s <a for=AbortSignal>abort algorithms</a>.
 
  <li><p>[=Fire an event=] named {{AbortSignal/abort}} at <var>signal</var>.
+
+ <li><p><a for=set>For each</a> <var>dependentSignal</var> of <var>signal</var>'s
+ [=AbortSignal/dependent signals=], [=AbortSignal/signal abort=] on <var>dependentSignal</var> with
+ <var>signal</var>'s [=AbortSignal/abort reason=].
+
+ <li><p><a for=set>Empty</a> <var>signal</var>'s <a for=AbortSignal>dependent signals</a>.
+
+ <li><p><a for=set>Empty</a> <var>signal</var>'s <a for=AbortSignal>source signals</a>.
 </ol>
 
-<p>A <var>followingSignal</var> (an {{AbortSignal}}) is made to
-<dfn export for=AbortSignal>follow</dfn> a <var>parentSignal</var> (an {{AbortSignal}}) by running
-these steps:
+<p>To <dfn export for=AbortSignal>create a composite abort signal</dfn> from a list of
+{{AbortSignal}} objects <var>signals</var> or a single {{AbortSignal}} <var>signal</var>, an
+optional <var>signalInterface</var>, which must be either {{AbortSignal}} or an interface that
+inherits from it, and an optional <var>realm</var>, run these steps:
 
 <ol>
- <li><p>If <var>followingSignal</var> is [=AbortSignal/aborted=], then return.
+ <li><p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
+ <var>signalInterface</var> if given, otherwise {{AbortSignal}}, and using <var>realm</var> if
+ given, otherwise using the default behavior defined in Web IDL.
 
- <li><p>If <var>parentSignal</var> is [=AbortSignal/aborted=], then
- <a for=AbortSignal>signal abort</a> on <var>followingSignal</var> with <var>parentSignal</var>'s
- [=AbortSignal/abort reason=].
+ <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
 
- <li>
-  <p>Otherwise, <a for=AbortSignal lt=add>add the following abort steps</a> to
-  <var>parentSignal</var>:
+ <li><p>If <var>signal</var> was given, then set <var>signals</var> to a new <a for="/">list</a> and
+ <a for=list>append</a> <var>signal</var> to it.
 
+ <li><p><a for=list>For each</a> <var>signal</var> of <var>signals</var>: if <var>signal</var> is
+ [=AbortSignal/aborted=], then set <var>resultSignal</var>'s [=AbortSignal/abort reason=] to
+ <var>signal</var>'s [=AbortSignal/abort reason=] and return <var>resultSignal</var>.
+ </li>
+
+ <li><p><a for=list>For each</a> <var>signal</var> of <var>signals</var>:
   <ol>
-   <li><p><a for=AbortSignal>Signal abort</a> on <var>followingSignal</var> with
-   <var>parentSignal</var>'s [=AbortSignal/abort reason=].
+   <li><p>If <var>signal</var>'s [=AbortSignal/composite=] is false, then:
+    <ol>
+     <li><p><a for=set>Append</a> <var>signal</var> to <var>resultSignal</var>'s
+     [=AbortSignal/source signals=].
+
+     <li><p><a for=set>Append</a> <var>resultSignal</var> to <var>signal</var>'s
+     [=AbortSignal/dependent signals=].
+    </ol>
+
+   <li><p>Otherwise, <a for=list>for each</a> <var>sourceSignal</var> of <var>signal</var>'s
+   [=AbortSignal/source signals=]:
+    <ol>
+     <li><p>Assert: <var>sourceSignal</var> is not [=AbortSignal/aborted=] and not
+     [=AbortSignal/composite=].
+
+     <li><p>If <var>resultSignal</var>'s [=AbortSignal/source signals=] <a for=set>contains</a>
+     <var>sourceSignal</var>, then <a for=iteration>continue</a>.
+
+     <li><p><a for=set>Append</a> <var>sourceSignal</var> to <var>resultSignal</var>'s
+     [=AbortSignal/source signals=].
+
+     <li><p><a for=set>Append</a> <var>resultSignal</var> to <var>sourceSignal</var>'s
+     [=AbortSignal/dependent signals=].
+    </ol>
   </ol>
+ <li>Return <var>resultSignal</var>.
 </ol>
+
+<h4 id=abort-signal-garbage-collection>Garbage collection</h4>
+
+<p>An {{AbortSignal}} object holds weak references to its [=AbortSignal/source signals=].
+
+<p>A non-[=AbortSignal/composite=] {{AbortSignal}} object must hold strong references to its
+[=AbortSignal/dependent signals=] as long as the source can still [=AbortSignal/signal abort=] and
+the dependent signal has any event listeners registered for its {{AbortSignal/abort}} event or its
+[=AbortSignal/abort algorithms=] is not empty. An {{AbortSignal}} can no longer
+[=AbortSignal/signal abort=] if it is the {{AbortController/signal}} of an {{AbortController}} that
+has been garbage collected.
 
 
 <h3 id=abortcontroller-api-integration>Using {{AbortController}} and {{AbortSignal}} objects in

--- a/dom.bs
+++ b/dom.bs
@@ -1844,12 +1844,12 @@ specified otherwise, its value is the empty set.
 initially false.
 
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn>, which is a
-<a for=/>set</a> of {{AbortSignal}}s the object is dependent on for its [=AbortSignal/aborted=]
-state. Unless specified otherwise, its value is the empty set.
+<a for=/>set</a> of weak references to {{AbortSignal}}s that the object is dependent on for its
+[=AbortSignal/aborted=] state. Unless specified otherwise, its value is the empty set.
 
 <p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>dependent signals</dfn>, which is a
-<a for=/>set</a> of {{AbortSignal}}s that are dependent on it for their [=AbortSignal/aborted=]
-state. Unless specified otherwise, its value is the empty set.
+<a for=/>set</a> of weak references to {{AbortSignal}}s that are dependent on it for their
+[=AbortSignal/aborted=] state. Unless specified otherwise, its value is the empty set.
 
 <p>To <dfn export for=AbortSignal>add</dfn> an algorithm <var>algorithm</var> to an {{AbortSignal}}
 object <var>signal</var>, run these steps:
@@ -2027,16 +2027,12 @@ interface that inherits from it, and an optional <var>realm</var>, run these ste
  <li>Return <var>resultSignal</var>.
 </ol>
 
+
 <h4 id=abort-signal-garbage-collection>Garbage collection</h4>
 
-<p>An {{AbortSignal}} object holds weak references to its [=AbortSignal/source signals=].
-
-<p>A non-[=AbortSignal/composite=] {{AbortSignal}} object must hold strong references to its
-[=AbortSignal/dependent signals=] as long as the source can still [=AbortSignal/signal abort=] and
-the dependent signal has any event listeners registered for its {{AbortSignal/abort}} event or its
-[=AbortSignal/abort algorithms=] is not empty. An {{AbortSignal}} can no longer
-[=AbortSignal/signal abort=] if it is the {{AbortController/signal}} of an {{AbortController}} that
-has been garbage collected.
+<p>A [=AbortSignal/composite=] {{AbortSignal}} object must not be garbage collected while its
+[=AbortSignal/source signals=] is non-empty unless it has no registered event listeners for its
+{{AbortSignal/abort}} event and its [=AbortSignal/abort algorithms=] is empty.
 
 
 <h3 id=abortcontroller-api-integration>Using {{AbortController}} and {{AbortSignal}} objects in

--- a/dom.bs
+++ b/dom.bs
@@ -1782,9 +1782,9 @@ constructor steps are:
 <a>this</a>'s <a for=AbortController>signal</a>.
 
 <p>The <dfn method for=AbortController><code>abort(<var>reason</var>)</code></dfn> method steps are
-to <a for=AbortController>request abort</a> on <a>this</a> with <var>reason</var> if it is given.
+to <a for=AbortController>signal abort</a> on <a>this</a> with <var>reason</var> if it is given.
 
-<p>To <dfn export for=AbortController>request abort</dfn> on an {{AbortController}} <var>controller</var>
+<p>To <dfn export for=AbortController>signal abort</dfn> on an {{AbortController}} <var>controller</var>
 with an optional <var>reason</var>, <a for=AbortSignal>signal abort</a> on <var>controller</var>'s
 <a for=AbortController>signal</a> with <var>reason</var> if it is given.
 
@@ -1810,7 +1810,7 @@ interface AbortSignal : EventTarget {
  <var>reason</var> if not undefined; otherwise to an "{{AbortError!!exception}}" {{DOMException}}.
 
  <dt><code>AbortSignal . <a method for=AbortSignal lt=any(signals)>any</a>(<var>signals</var>)</code>
- <dd>Returns an {{AbortSignal}} instance which will be aborted if any of <var>signals</var> is
+ <dd>Returns an {{AbortSignal}} instance which will be aborted once any of <var>signals</var> is
  aborted. Its <a for=AbortSignal>abort reason</a> will be set to whichever one of <var>signals</var>
  cause it to be aborted.
 
@@ -1908,8 +1908,8 @@ steps are:
 </ol>
 
 <p>The static <dfn method for=AbortSignal><code>any(<var>signals</var>)</code></dfn> method
-steps are to return the result of <a for=AbortSignal>creating a composite abort signal</a> from
-<var>signals</var>.
+steps are to return the result of <a>creating a composite abort signal</a> from <var>signals</var>
+using {{AbortSignal}}.
 
 <p>The <dfn attribute for=AbortSignal>aborted</dfn> getter steps are to return true if <a>this</a>
 is [=AbortSignal/aborted=]; otherwise false.
@@ -1951,8 +1951,8 @@ is [=AbortSignal/aborted=]; otherwise false.
 {{AbortController}} object, but an API observing the {{AbortSignal}} object can choose to ignore
 them. For instance, if the operation has already completed.
 
-<p>To <dfn noexport for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object
-<var>signal</var> and an optional <var>reason</var>, run these steps:
+<p>To <dfn for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object <var>signal</var> and
+an optional <var>reason</var>, run these steps:
 
 <ol>
  <li><p>If <var>signal</var> is [=AbortSignal/aborted=], then return.
@@ -1976,29 +1976,28 @@ them. For instance, if the operation has already completed.
  <li><p><a for=set>Empty</a> <var>signal</var>'s <a for=AbortSignal>source signals</a>.
 </ol>
 
-<p>To <dfn export for=AbortSignal>create a composite abort signal</dfn> from a list of
-{{AbortSignal}} objects <var>signals</var> or a single {{AbortSignal}} <var>signal</var>, an
-optional <var>signalInterface</var>, which must be either {{AbortSignal}} or an interface that
-inherits from it, and an optional <var>realm</var>, run these steps:
+<p>To <dfn export>create a composite abort signal</dfn> from a list of {{AbortSignal}} objects
+<var>signals</var>, using <var>signalInterface</var>, which must be either {{AbortSignal}} or an
+interface that inherits from it, and an optional <var>realm</var>, run these steps:
 
 <ol>
  <li><p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
- <var>signalInterface</var> if given, otherwise {{AbortSignal}}, and using <var>realm</var> if
- given, otherwise using the default behavior defined in Web IDL.
+ <var>signalInterface</var> using <var>realm</var> if given, otherwise using the default behavior
+ defined in Web IDL.
 
  <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
-
- <li><p>If <var>signal</var> was given, then set <var>signals</var> to a new <a for="/">list</a> and
- <a for=list>append</a> <var>signal</var> to it.
 
  <li><p><a for=list>For each</a> <var>signal</var> of <var>signals</var>: if <var>signal</var> is
  [=AbortSignal/aborted=], then set <var>resultSignal</var>'s [=AbortSignal/abort reason=] to
  <var>signal</var>'s [=AbortSignal/abort reason=] and return <var>resultSignal</var>.
- </li>
 
- <li><p><a for=list>For each</a> <var>signal</var> of <var>signals</var>:
+ <li>
+  <p><a for=list>For each</a> <var>signal</var> of <var>signals</var>:
+
   <ol>
-   <li><p>If <var>signal</var>'s [=AbortSignal/composite=] is false, then:
+   <li>
+    <p>If <var>signal</var>'s [=AbortSignal/composite=] is false, then:
+
     <ol>
      <li><p><a for=set>Append</a> <var>signal</var> to <var>resultSignal</var>'s
      [=AbortSignal/source signals=].
@@ -2007,8 +2006,10 @@ inherits from it, and an optional <var>realm</var>, run these steps:
      [=AbortSignal/dependent signals=].
     </ol>
 
-   <li><p>Otherwise, <a for=list>for each</a> <var>sourceSignal</var> of <var>signal</var>'s
-   [=AbortSignal/source signals=]:
+   <li>
+    <p>Otherwise, <a for=list>for each</a> <var>sourceSignal</var> of <var>signal</var>'s
+    [=AbortSignal/source signals=]:
+
     <ol>
      <li><p>Assert: <var>sourceSignal</var> is not [=AbortSignal/aborted=] and not
      [=AbortSignal/composite=].

--- a/dom.bs
+++ b/dom.bs
@@ -1769,6 +1769,7 @@ interface AbortController {
 <p>An {{AbortController}} object has an associated <dfn for=AbortController>signal</dfn> (an
 {{AbortSignal}} object).
 
+<div algorithm>
 <p>The
 <dfn constructor for=AbortController lt="AbortController()"><code>new AbortController()</code></dfn>
 constructor steps are:
@@ -1778,16 +1779,22 @@ constructor steps are:
 
  <li><p>Set <a>this</a>'s <a for=AbortController>signal</a> to <var>signal</var>.
 </ol>
+</div>
 
 <p>The <dfn attribute for=AbortController><code>signal</code></dfn> getter steps are to return
 <a>this</a>'s <a for=AbortController>signal</a>.
 
+<div algorithm>
 <p>The <dfn method for=AbortController><code>abort(<var>reason</var>)</code></dfn> method steps are
 to <a for=AbortController>signal abort</a> on <a>this</a> with <var>reason</var> if it is given.
+</div>
 
-<p>To <dfn export for=AbortController>signal abort</dfn> on an {{AbortController}} <var>controller</var>
-with an optional <var>reason</var>, <a for=AbortSignal>signal abort</a> on <var>controller</var>'s
-<a for=AbortController>signal</a> with <var>reason</var> if it is given.
+<div algorithm>
+<p>To <dfn export for=AbortController>signal abort</dfn> on an {{AbortController}}
+<var>controller</var> with an optional <var>reason</var>, <a for=AbortSignal>signal abort</a> on
+<var>controller</var>'s <a for=AbortController>signal</a> with <var>reason</var> if it is given.
+</div>
+
 
 <h3 id=interface-AbortSignal>Interface {{AbortSignal}}</h3>
 
@@ -1846,7 +1853,7 @@ service worker.
 <p>An {{AbortSignal}} object has a <dfn for="AbortSignal">composite</dfn> (a boolean), which is
 initially false.
 
-<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn>, (a weak
+<p>An {{AbortSignal}} object has associated <dfn for=AbortSignal>source signals</dfn> (a weak
 <a for=/>set</a> of {{AbortSignal}} objects that the object is dependent on for its
 [=AbortSignal/aborted=] state), which is initially empty.
 
@@ -1856,6 +1863,7 @@ initially false.
 
 <hr>
 
+<div algorithm>
 <p>The static <dfn method for=AbortSignal><code>abort(<var>reason</var>)</code></dfn> method steps
 are:
 
@@ -1867,7 +1875,9 @@ are:
 
  <li>Return <var>signal</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>The static <dfn method for=AbortSignal><code>timeout(<var>milliseconds</var>)</code></dfn> method
 steps are:
 
@@ -1892,10 +1902,13 @@ steps are:
 
  <li><p>Return <var>signal</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>The static <dfn method for=AbortSignal><code>any(<var>signals</var>)</code></dfn> method
 steps are to return the result of <a>creating a composite abort signal</a> from <var>signals</var>
 using {{AbortSignal}} and the <a>current realm</a>.
+</div>
 
 <p>The <dfn attribute for=AbortSignal>aborted</dfn> getter steps are to return true if <a>this</a>
 is [=AbortSignal/aborted=]; otherwise false.
@@ -1942,6 +1955,7 @@ them. For instance, if the operation has already completed.
 <p>An {{AbortSignal}} object is <dfn export for="AbortSignal">aborted</dfn> when its
 [=AbortSignal/abort reason=] is not undefined.
 
+<div algorithm>
 <p>To <dfn export for=AbortSignal>add</dfn> an algorithm <var>algorithm</var> to an {{AbortSignal}}
 object <var>signal</var>:
 
@@ -1951,11 +1965,15 @@ object <var>signal</var>:
  <li><p><a for=set>Append</a> <var>algorithm</var> to <var>signal</var>'s
  <a for=AbortSignal>abort algorithms</a>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export for=AbortSignal>remove</dfn> an algorithm <var>algorithm</var> from an
 {{AbortSignal}} <var>signal</var>, <a for=set>remove</a> <var>algorithm</var> from
 <var>signal</var>'s <a for=AbortSignal>abort algorithms</a>.
+</div>
 
+<div algorithm>
 <p>To <dfn for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object <var>signal</var> and
 an optional <var>reason</var>:
 
@@ -1976,15 +1994,16 @@ an optional <var>reason</var>:
  [=AbortSignal/dependent signals=], [=AbortSignal/signal abort=] on <var>dependentSignal</var> with
  <var>signal</var>'s [=AbortSignal/abort reason=].
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export>create a composite abort signal</dfn> from a list of {{AbortSignal}} objects
 <var>signals</var>, using <var>signalInterface</var>, which must be either {{AbortSignal}} or an
 interface that inherits from it, and a <var>realm</var>:
 
 <ol>
- <li>
-  <p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
-  <var>signalInterface</var> using <var>realm</var>.
+ <li><p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
+ <var>signalInterface</var> using <var>realm</var>.
 
  <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
 
@@ -2026,8 +2045,9 @@ interface that inherits from it, and a <var>realm</var>:
     </ol>
   </ol>
 
- <li>Return <var>resultSignal</var>.
+ <li><p>Return <var>resultSignal</var>.
 </ol>
+</div>
 
 
 <h4 id=abort-signal-garbage-collection>Garbage collection</h4>

--- a/dom.bs
+++ b/dom.bs
@@ -1974,8 +1974,8 @@ object <var>signal</var>:
 </div>
 
 <div algorithm>
-<p>To <dfn for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object <var>signal</var> and
-an optional <var>reason</var>:
+<p>To <dfn export for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object
+<var>signal</var> and an optional <var>reason</var>:
 
 <ol>
  <li><p>If <var>signal</var> is [=AbortSignal/aborted=], then return.
@@ -2005,11 +2005,11 @@ interface that inherits from it, and a <var>realm</var>:
  <li><p>Let <var>resultSignal</var> be a <a for=/>new</a> object implementing
  <var>signalInterface</var> using <var>realm</var>.
 
- <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
-
  <li><p><a for=list>For each</a> <var>signal</var> of <var>signals</var>: if <var>signal</var> is
  [=AbortSignal/aborted=], then set <var>resultSignal</var>'s [=AbortSignal/abort reason=] to
  <var>signal</var>'s [=AbortSignal/abort reason=] and return <var>resultSignal</var>.
+
+ <li><p>Set <var>resultSignal</var>'s [=AbortSignal/composite=] to true.
 
  <li>
   <p><a for=list>For each</a> <var>signal</var> of <var>signals</var>:


### PR DESCRIPTION
<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

Hi DOM folks,

I've got a working implementation of [AbortSignal.any()](https://github.com/shaseley/abort-signal-any) with tentative WPT tests, so I wanted to send out a draft spec for thoughts/consideration. It's probably not ready as-is because it would break other specs (see below), but this is how I thought the end state might look.

### PR Description

This adds IDL and algorithms for [AbortSignal.any()](https://github.com/shaseley/abort-signal-any).

Implementation details:
 - This implements an optimization that puts all children on non-composite signals (i.e. those associated with a controller or timeout). This allows "intermediate" nodes (e.g. B in A follows B follows C) to be garbage collected if they are only being kept alive to propagate aborts.

 - This removes the follow algorithm, so callsites will need to be updated.

 - This makes "signal abort" private. This is done so we can make assumptions about when a signal can no longer abort. The few places that directly signal abort will be converted to use an AbortController (this also exposes an algorithm to "request abort" on a controller for this).

 - The "create a composite abort signal" algorithm takes an interface so that TaskSignal.any() can easily hook into it but create a TaskSignal.

 - Some algorithms that invoke "follow" create an AbortSignal in a particular realm. This enables doing that, but borrows some language from elsewhere in the spec w.r.t. doing the default thing. Neither of the other two static AbortSignal factory APIs specify a realm.

### Dependent / Follow-up work

As-is, this PR changes how other specs would interact with abort signals and controllers. The related work is to:
 1. Don't invoke "signal abort" outside of the DOM spec, use "request abort" on an abort controller instead: #1194.
 2. Don't invoke "follow" anywhere, use "create a composite abort signal" instead.
    1. https://github.com/whatwg/fetch/pull/1646
       1. https://github.com/w3c/ServiceWorker/pull/1678
    2. https://github.com/whatwg/streams/pull/1277
 3. (probably) Make sure algorithms are being removed when they will no longer have an effect, e.g. when the underlying operation is completed or failed: also #1194.

### Implementation Notes

There's an implementation of this in Chromium behind a flag in Canary (M112). The basic implementation was straightforward, but there was a bit of work to get the memory management implemented (what's described in the Garbage Collection section in the draft PR). Composite signals can't be GCed if they have abort algorithms (or abort event listeners) and there's a source signal that can still signal abort, but we weren't removing abort algorithms once they were "done", which prevented GC. I fixed this in Chromium, but we should probably also update specs too.

### PR Questions

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * [Gecko](https://github.com/mozilla/standards-positions/issues/774)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/37434 (tentative WPT tests)
   * https://github.com/web-platform-tests/wpt/pull/39785 (rename from tentative)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1323391
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1830781
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=256176
   * Deno (only for aborting and events): https://github.com/denoland/deno/issues/18944
   * Node.js (only for aborting and events): https://github.com/nodejs/node/issues/47811
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/396

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

### Additional Info

 - [TAG Review](https://github.com/w3ctag/design-reviews/issues/737) (completed)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1152.html" title="Last updated on May 5, 2023, 5:06 AM UTC (4e2146c)">Preview</a> | <a href="https://whatpr.org/dom/1152/fb0bf26...4e2146c.html" title="Last updated on May 5, 2023, 5:06 AM UTC (4e2146c)">Diff</a>