### PR TITLE
Correct MutationObserver ownership story

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3467,12 +3467,12 @@ dictionary MutationObserverInit {
 
 <p>Each {{MutationObserver}} object has these associated concepts:
 
-<ul>
- <li>A <dfn noexport for=MutationObserver id=concept-mo-callback>callback</dfn> set on creation.
- <li>A <dfn noexport for=MutationObserver>node list</dfn> (a <a for=/>list</a> of weak references to
+<ul class=brief>
+ <li>A <dfn for=MutationObserver id=concept-mo-callback>callback</dfn> set on creation.
+ <li>A <dfn for=MutationObserver>node list</dfn> (a <a for=/>list</a> of weak references to
  <a for=/>nodes</a>), which is initially empty.
- <li>A <dfn export for=MutationObserver id=concept-mo-queue>record queue</dfn> (a <a for=/>queue</a>
- of zero or more {{MutationRecord}} objects), which is initially empty.
+ <li>A <dfn for=MutationObserver id=concept-mo-queue>record queue</dfn> (a <a for=/>queue</a> of
+ zero or more {{MutationRecord}} objects), which is initially empty.
 </ul>
 
 <dl class=domintro>
@@ -3609,7 +3609,7 @@ method steps are:
    <a for="registered observer">options</a> is <var>options</var> to <var>target</var>'s
    <a>registered observer list</a>.
 
-   <li><p><a for=list>Append</a> <var>target</var> to <a>this</a>'s
+   <li><p><a for=list>Append</a> a weak reference to <var>target</var> to <a>this</a>'s
    <a for=MutationObserver>node list</a>.
   </ol>
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -3363,7 +3363,7 @@ must return null.
 (a boolean), which is initially false. [[!HTML]]
 
 <p>Each <a>similar-origin window agent</a> also has
-<dfn noexport id=mutation-observer-list>mutation observers</dfn> (a <a for=/>set</a> of zero or more
+<dfn id=mutation-observer-list>pending mutation observers</dfn> (a <a for=/>set</a> of zero or more
 {{MutationObserver}} objects), which is initially empty.
 
 <p>To
@@ -3385,7 +3385,9 @@ run these steps:
  <li><p>Set the <a>surrounding agent</a>'s <a>mutation observer microtask queued</a> to false.
 
  <li><p>Let <var>notifySet</var> be a <a for=set>clone</a> of the <a>surrounding agent</a>'s
- <a>mutation observers</a>.
+ <a>pending mutation observers</a>.
+
+ <li><p><a for=set>Empty</a> the <a>surrounding agent</a>'s <a>pending mutation observers</a>.
 
  <li><p>Let <var>signalSet</var> be a <a for=set>clone</a> of the <a>surrounding agent</a>'s
  <a>signal slots</a>.
@@ -3467,7 +3469,7 @@ dictionary MutationObserverInit {
 
 <ul>
  <li>A <dfn noexport for=MutationObserver id=concept-mo-callback>callback</dfn> set on creation.
- <li>A <dfn noexport for=MutationObserver>node list</dfn> (a <a for=/>list</a> of
+ <li>A <dfn noexport for=MutationObserver>node list</dfn> (a <a for=/>list</a> of weak references to
  <a for=/>nodes</a>), which is initially empty.
  <li>A <dfn export for=MutationObserver id=concept-mo-queue>record queue</dfn> (a <a for=/>queue</a>
  of zero or more {{MutationRecord}} objects), which is initially empty.
@@ -3548,14 +3550,8 @@ dictionary MutationObserverInit {
 
 <p>The
 <dfn constructor for=MutationObserver lt=MutationObserver(callback)><code>new MutationObserver(<var>callback</var>)</code></dfn>
-constructor steps are:
-
-<ol>
- <li><p>Set <a>this</a>'s <a for=MutationObserver>callback</a> to <var>callback</var>.
-
- <li><p><a for=set>Append</a> <a>this</a> to <a>this</a>'s <a>relevant agent</a>'s
- <a>mutation observers</a>.
-</ol>
+constructor steps are to set <a>this</a>'s <a for=MutationObserver>callback</a> to
+<var>callback</var>.
 
 <p>The
 <dfn method for=MutationObserver><code>observe(<var>target</var>, <var>options</var>)</code></dfn>
@@ -3716,6 +3712,9 @@ method steps are:
 
    <li><p><a for=queue>Enqueue</a> <var>record</var> to <var>observer</var>'s
    <a for=MutationObserver>record queue</a>.
+
+   <li><p><a for=set>Append</a> <var>observer</var> to the <a>surrounding agent</a>'s
+   <a>pending mutation observers</a>.
   </ol>
 
  <li><p><a>Queue a mutation observer microtask</a>.
@@ -3809,15 +3808,6 @@ interface MutationRecord {
 <dfn attribute for="MutationRecord">attributeNamespace</dfn>, and
 <dfn attribute for="MutationRecord">oldValue</dfn> attributes must return the values they were
 initialized to.
-
-
-<h4 id=garbage-collection>Garbage collection</h4>
-
-<p><a for=/>Nodes</a> have a strong reference to <a>registered observers</a> in their
-<a>registered observer list</a>.
-
-<p><a>Registered observers</a> in a <a for=/>node</a>'s <a>registered observer list</a> have a weak
-reference to the <a for=/>node</a>.
 
 
 <h3 id=interface-node>Interface {{Node}}</h3>
@@ -10073,6 +10063,7 @@ Elliott Sprehn,
 Emilio Cobos Álvarez,
 Eric Bidelman,
 Erik Arvidsson,
+François Remy<!-- FremyCompany; GitHub -->,
 Gary Kacmarcik,
 Gavin Nicol,
 Giorgio Liscio,
@@ -10165,6 +10156,7 @@ Sam Dutton,
 Sam Sneddon,
 Samuel Giles,
 Sanket Joshi,
+Scott Haseley<!-- shaseley; GitHub -->,
 Sebastian Mayr,
 Seo Sanghyeon,
 Sergey G. Grekhov,
@@ -10185,7 +10177,7 @@ Tobie Langel,
 Tom Pixley,
 Travis Leithead,
 Trevor Rowbotham,
-<i>triple-underscore</i>,<!--GitHub-->
+<i>triple-underscore</i><!--GitHub-->,
 Tristan Fraipont,
 Veli Şenol,
 Vidur Apparao,


### PR DESCRIPTION
The existing design had some leaks and was also different from implementations. In particular, assume you have two mutation observers and a change triggered the first one as well as a slot change. Then if in the reaction to the first one a further change triggers the second one it would run before the slot change per the existing specification, but that didn't match implementations and more importantly didn't allow for garbage collection.

Test: https://github.com/web-platform-tests/wpt/blob/master/shadow-dom/slotchange-event.html#L540-L594.

Fixes #713. Fixes #1159. Closes #720.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1160.html" title="Last updated on Feb 17, 2023, 9:12 AM UTC (5d7c322)">Preview</a> | <a href="https://whatpr.org/dom/1160/0111a95...5d7c322.html" title="Last updated on Feb 17, 2023, 9:12 AM UTC (5d7c322)">Diff</a>