### PR TITLE
Prohibit ServiceWorker event handler update after the initialization.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1121,8 +1121,7 @@ participate in a tree structure.</p>
  <a for="service worker">script resource</a>'s
  <a for="script resource">has ever been evaluated flag</a> is set, and <var>listener</var>'s
  <a for="event listener">type</a> matches the {{Event/type}} attribute value of any of the
- <a>service worker events</a>, then <a>report a warning to the console</a> that this might not give
- the expected results. [[!SERVICE-WORKERS]]
+ <a>service worker events</a>, then throws INVALID_MODIFICATION_ERROR exception. [[!SERVICE-WORKERS]]
 
  <li><p>If <var>listener</var>'s <a for="event listener">signal</a> is not null and is
  [=AbortSignal/aborted=], then return.


### PR DESCRIPTION
This is a very early stage proposal on the specification change.  I hope to listen to what you think of the change.
I will update the following checklist afterwords.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
