### PR TITLE
Update createNSResolver and lookupNamespaceURI()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4589,6 +4589,9 @@ the interface <var>node</var> <a>implements</a>:
  <dt>{{Element}}
  <dd>
   <ol>
+   <li><p>If <var>prefix</var> is "<code>xml</code>", then return <a>XML namespace</a>.
+   <li><p>If <var>prefix</var> is "<code>xmlns</code>", then return <a>XMLNS namespace</a>.
+
    <li><p>If its <a for=Element>namespace</a> is non-null and its
    <a for=Element>namespace prefix</a> is <var>prefix</var>, then return
    <a for=Element>namespace</a>.
@@ -9849,13 +9852,22 @@ callback interface XPathNSResolver {
 
 interface mixin XPathEvaluatorBase {
   [NewObject] XPathExpression createExpression(DOMString expression, optional XPathNSResolver? resolver = null);
-  XPathNSResolver createNSResolver(Node nodeResolver);
+  Node createNSResolver(Node nodeResolver);
   // XPathResult.ANY_TYPE = 0
   XPathResult evaluate(DOMString expression, Node contextNode, optional XPathNSResolver? resolver = null, optional unsigned short type = 0, optional XPathResult? result = null);
 };
 Document includes XPathEvaluatorBase;
 </pre>
 
+<dl class=domintro>
+ <dt><code><var ignore>evaluator</var> . {{XPathEvaluatorBase/createNSResolver(nodeResolver)}}</code>
+ <dd><p>Returns the specified <var>nodeResolver</var> as is.
+</dl>
+
+<p>The
+<dfn method for="XPathEvaluatorBase"><code>createNSResolver(<var>nodeResolver</var>)</code></dfn>
+method returns the specified <var>nodeResolver</var> without any side effects. This method exists only
+for a historical reason.</p>
 
 <h3 id=interface-xpathevaluator>Interface {{XPathEvaluator}}</h3>
 

--- a/dom.bs
+++ b/dom.bs
@@ -4589,8 +4589,9 @@ the interface <var>node</var> <a>implements</a>:
  <dt>{{Element}}
  <dd>
   <ol>
-   <li><p>If <var>prefix</var> is "<code>xml</code>", then return <a>XML namespace</a>.
-   <li><p>If <var>prefix</var> is "<code>xmlns</code>", then return <a>XMLNS namespace</a>.
+   <li><p>If <var>prefix</var> is "<code>xml</code>", then return the <a>XML namespace</a>.
+
+   <li><p>If <var>prefix</var> is "<code>xmlns</code>", then return the <a>XMLNS namespace</a>.
 
    <li><p>If its <a for=Element>namespace</a> is non-null and its
    <a for=Element>namespace prefix</a> is <var>prefix</var>, then return
@@ -9852,22 +9853,19 @@ callback interface XPathNSResolver {
 
 interface mixin XPathEvaluatorBase {
   [NewObject] XPathExpression createExpression(DOMString expression, optional XPathNSResolver? resolver = null);
-  Node createNSResolver(Node nodeResolver);
+  Node createNSResolver(Node nodeResolver); // legacy
   // XPathResult.ANY_TYPE = 0
   XPathResult evaluate(DOMString expression, Node contextNode, optional XPathNSResolver? resolver = null, optional unsigned short type = 0, optional XPathResult? result = null);
 };
 Document includes XPathEvaluatorBase;
 </pre>
 
-<dl class=domintro>
- <dt><code><var ignore>evaluator</var> . {{XPathEvaluatorBase/createNSResolver(nodeResolver)}}</code>
- <dd><p>Returns the specified <var>nodeResolver</var> as is.
-</dl>
-
 <p>The
-<dfn method for="XPathEvaluatorBase"><code>createNSResolver(<var>nodeResolver</var>)</code></dfn>
-method returns the specified <var>nodeResolver</var> without any side effects. This method exists only
-for a historical reason.</p>
+<dfn method for=XPathEvaluatorBase><code>createNSResolver(<var>nodeResolver</var>)</code></dfn>
+method steps are to return <var>nodeResolver</var>.
+
+<p class=note>This method exists only for historical reasons.
+
 
 <h3 id=interface-xpathevaluator>Interface {{XPathEvaluator}}</h3>
 


### PR DESCRIPTION
* createNSResolver() returns the specified node.
* Element.lookupNamespaceURI() should handle 'xml' and 'xmlns' prefixes by default

Fixes #857

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium: I'm positive
   * Gecko: Already shipped
   * WebKit: Positive; See https://github.com/whatwg/dom/issues/857#issuecomment-650694254
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/38636
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1418215
   * Gecko: N/A (already shipped)
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=252716
   * Deno (only for aborting and events): N/A
   * Node.js (only for aborting and events): N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/24724

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1165.html" title="Last updated on Feb 22, 2023, 4:10 PM UTC (6be6b1d)">Preview</a> | <a href="https://whatpr.org/dom/1165/d34d52d...6be6b1d.html" title="Last updated on Feb 22, 2023, 4:10 PM UTC (6be6b1d)">Diff</a>