### PR TITLE
Export "event listener/type".

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -959,7 +959,7 @@ when something has occurred.
 <a>event</a> and consists of:
 
 <ul class=brief>
- <li><dfn for="event listener">type</dfn> (a string)
+ <li><dfn export for="event listener">type</dfn> (a string)
  <li><dfn for="event listener">callback</dfn> (null or an {{EventListener}} object)
  <li><dfn for="event listener">capture</dfn> (a boolean, initially false)
  <li><dfn for="event listener">passive</dfn> (null or a boolean, initially null)


### PR DESCRIPTION
To be used in the service worker specification, let me export "event listener/type".
This is not a significant specification change but just export a term to be used from other specifications.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom_standard/1169.html" title="Last updated on Mar 17, 2023, 9:53 AM UTC (c18e7aa)">Preview</a> | <a href="https://whatpr.org/dom/1169/4db09dd...c18e7aa.html" title="Last updated on Mar 17, 2023, 9:53 AM UTC (c18e7aa)">Diff</a>