### PR TITLE
Handle attribute changes after changing attribute

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6185,10 +6185,10 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 <a>attribute</a> <var>attribute</var> to <var>value</var>, run these steps:
 
 <ol>
+ <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>value</var>.
+
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
  <a for=Attr>element</a>, <var>attribute</var>'s <a for=Attr>value</a>, and <var>value</var>.
-
- <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>value</var>.
 </ol>
 
 <p>To <dfn export id=concept-element-attributes-append lt="append an attribute">append</dfn> an

--- a/dom.bs
+++ b/dom.bs
@@ -6209,13 +6209,15 @@ steps:
 <a>attribute</a> <var>attribute</var>, run these steps:
 
 <ol>
- <li><a for=list>Remove</a> <var>attribute</var> from <var>attribute</var>'s
- <a for=Attr>element</a>'s <a for=Element>attribute list</a>.
+ <li><p>Let <var>element</var> be <var>attribute</var>'s <a for=Attr>element</a>.</p></li>
+
+ <li><a for=list>Remove</a> <var>attribute</var> from <var>element</var>'s <a for=Element>attribute
+ list</a>.
 
  <li><p>Set <var>attribute</var>'s <a for=Attr>element</a> to null.
 
- <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
- <a for=Attr>element</a>, <var>attribute</var>'s <a for=Attr>value</a>, and null.
+ <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>,
+ <var>attribute</var>'s <a for=Attr>value</a>, and null.
 </ol>
 
 <p>To <dfn export id=concept-element-attributes-replace lt="replace an attribute">replace</dfn> an

--- a/dom.bs
+++ b/dom.bs
@@ -6196,36 +6196,32 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 steps:
 
 <ol>
- <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>, null, and
- <var>attribute</var>'s <a for=Attr>value</a>.
-
  <li><p><a for=list>Append</a> <var>attribute</var> to <var>element</var>'s
  <a for=Element>attribute list</a>.
 
  <li><p>Set <var>attribute</var>'s <a for=Attr>element</a> to <var>element</var>.
+
+ <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>, null, and
+ <var>attribute</var>'s <a for=Attr>value</a>.
 </ol>
 
 <p>To <dfn export id=concept-element-attributes-remove lt="remove an attribute">remove</dfn> an
 <a>attribute</a> <var>attribute</var>, run these steps:
 
 <ol>
- <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
- <a for=Attr>element</a>, <var>attribute</var>'s <a for=Attr>value</a>, and null.
-
  <li><a for=list>Remove</a> <var>attribute</var> from <var>attribute</var>'s
  <a for=Attr>element</a>'s <a for=Element>attribute list</a>.
 
  <li><p>Set <var>attribute</var>'s <a for=Attr>element</a> to null.
+
+ <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
+ <a for=Attr>element</a>, <var>attribute</var>'s <a for=Attr>value</a>, and null.
 </ol>
 
 <p>To <dfn export id=concept-element-attributes-replace lt="replace an attribute">replace</dfn> an
 <a>attribute</a> <var>oldAttr</var> with an <a>attribute</a> <var>newAttr</var>, run these steps:
 
 <ol>
- <li><p><a>Handle attribute changes</a> for <var>oldAttr</var> with <var>oldAttr</var>'s
- <a for=Attr>element</a>, <var>oldAttr</var>'s <a for=Attr>value</a>, and <var>newAttr</var>'s
- <a for=Attr>value</a>.
-
  <li><p><a for=list>Replace</a> <var>oldAttr</var> by <var>newAttr</var> in <var>oldAttr</var>'s
  <a for=Attr>element</a>'s <a for=Element>attribute list</a>.
 
@@ -6233,6 +6229,10 @@ steps:
  <a for=Attr>element</a>.
 
  <li><p>Set <var>oldAttr</var>'s <a for=Attr>element</a> to null.
+
+ <li><p><a>Handle attribute changes</a> for <var>oldAttr</var> with <var>oldAttr</var>'s
+ <a for=Attr>element</a>, <var>oldAttr</var>'s <a for=Attr>value</a>, and <var>newAttr</var>'s
+ <a for=Attr>value</a>.
 </ol>
 
 <hr>

--- a/dom.bs
+++ b/dom.bs
@@ -6232,7 +6232,7 @@ steps:
 
  <li><p>Set <var>oldAttr</var>'s <a for=Attr>element</a> to null.
 
- <li><p><a>Handle attribute changes</a> for <var>oldAttr</var> with <var>oldAttr</var>'s
+ <li><p><a>Handle attribute changes</a> for <var>oldAttr</var> with <var>newAttr</var>'s
  <a for=Attr>element</a>, <var>oldAttr</var>'s <a for=Attr>value</a>, and <var>newAttr</var>'s
  <a for=Attr>value</a>.
 </ol>


### PR DESCRIPTION
At least in chromium, synchronous internal listeners for attribute changes which are run as "attribute change steps" are run after the attribute is actually changed, not before.

This affects popover attribute related algorithms in HTML: https://github.com/whatwg/html/pull/9048#discussion_r1141122175

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Gecko
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * The tests in this HTML PR effectively test this: https://github.com/whatwg/html/pull/9048
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: N/a


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1176.html" title="Last updated on Jun 8, 2023, 3:38 PM UTC (40d679d)">Preview</a> | <a href="https://whatpr.org/dom/1176/90691ba...40d679d.html" title="Last updated on Jun 8, 2023, 3:38 PM UTC (40d679d)">Diff</a>