### PR TITLE
Fix #1178: Define a document's node document.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4855,6 +4855,8 @@ dictionary ElementCreationOptions {
 <p>{{Document}} <a for=/>nodes</a> are simply
 known as <dfn export id=concept-document lt="document">documents</dfn>.
 
+<p>A <a>document</a>'s <a>node document</a> is itself.
+
 <p>Each <a>document</a> has an associated
 <dfn export for=Document id=concept-document-encoding>encoding</dfn> (an <a for=/>encoding</a>),
 <dfn export for=Document id=concept-document-content-type>content type</dfn> (a string),


### PR DESCRIPTION
This is editorial, and doesn't need the below checks.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
