### PR TITLE
Add before removing steps

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2754,10 +2754,11 @@ within a <var>parent</var>, run these steps:
 </ol>
 
 
-<p><a lt="Other applicable specifications">Specifications</a> may define
-<dfn export id=concept-node-remove-ext>removing steps</dfn> for all or some <a for=/>nodes</a>. The
-algorithm is passed <var ignore>removedNode</var>, and optionally <var ignore>oldParent</var>, as
-indicated in the <a for=/>remove</a> algorithm below.
+<p><a lt="Other applicable specifications">Specifications</a> may define <dfn export
+id=concept-node-remove-ext>removing steps</dfn> and <dfn export
+id-concept-node-before-remove-ext>before removing steps</dfn> for all or some <a for=/>nodes</a>.
+These algorithms are passed <var ignore>removedNode</var>, and optionally <var
+ignore>oldParent</var>, as indicated in the <a for=/>remove</a> algorithm below.
 
 <p>To <dfn export id=concept-node-remove>remove</dfn> a <var>node</var>, with an optional
 <i>suppress observers flag</i>, run these steps:
@@ -2766,6 +2767,12 @@ indicated in the <a for=/>remove</a> algorithm below.
  <li><p>Let <var>parent</var> be <var>node</var>'s <a for=tree>parent</a>.
 
  <li><p>Assert: <var>parent</var> is non-null.
+
+ <li><p>Run the <a>before removing steps</a> with <var>node</var> and <var>parent</var>.
+
+ <li><p>For each <a>shadow-including descendant</a> <var>descendant</var> of <var>node</var>, in
+ <a>shadow-including tree order</a>, run the <a>before removing steps</a> with
+ <var>descendant</var>.</p></li>
 
  <li><p>Let <var>index</var> be <var>node</var>'s <a for=tree>index</a>.
 


### PR DESCRIPTION
The existing "removing steps" allow other specs to run algorithms after a node has been removed from the tree, but there is no way to run steps before a node has been removed from the tree.

This patch adds new "before removing steps" to allow other specs to run algorithms before the node has been removed.

This is needed for this HTML issue:
https://github.com/whatwg/html/issues/9161

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
