### PR TITLE
Editorial: Split attachShadow element list into separate definition

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6834,7 +6834,6 @@ the following:
   "<code>span</code>"
 </ul>
 
-
 <p>The <dfn method for=Element><code>attachShadow(<var>init</var>)</code></dfn> method steps are:
 
 <ol>

--- a/dom.bs
+++ b/dom.bs
@@ -6809,6 +6809,32 @@ are:
  <a for=/>shadow root</a>'s <a for=ShadowRoot>mode</a> is "<code>open</code>", and null otherwise.
 </dl>
 
+<p>An element's <a for=Element>local name</a> is <dfn>valid for attachShadow</dfn> if it is one of
+the following:
+
+<ul class=brief>
+  <li>a <a>valid custom element name</a>
+  <li>"<code>article</code>",
+  "<code>aside</code>",
+  "<code>blockquote</code>",
+  "<code>body</code>",
+  "<code>div</code>",
+  "<code>footer</code>",
+  "<code>h1</code>",
+  "<code>h2</code>",
+  "<code>h3</code>",
+  "<code>h4</code>",
+  "<code>h5</code>",
+  "<code>h6</code>",
+  "<code>header</code>",
+  "<code>main</code>",
+  "<code>nav</code>",
+  "<code>p</code>",
+  "<code>section</code>", or
+  "<code>span</code>"
+</ul>
+
+
 <p>The <dfn method for=Element><code>attachShadow(<var>init</var>)</code></dfn> method steps are:
 
 <ol>
@@ -6816,31 +6842,8 @@ are:
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
  <li>
-  <p>If <a>this</a>'s <a for=Element>local name</a> is not one of the following:
-
-  <ul class=brief>
-   <li>a <a>valid custom element name</a>
-   <li>"<code>article</code>",
-   "<code>aside</code>",
-   "<code>blockquote</code>",
-   "<code>body</code>",
-   "<code>div</code>",
-   "<code>footer</code>",
-   "<code>h1</code>",
-   "<code>h2</code>",
-   "<code>h3</code>",
-   "<code>h4</code>",
-   "<code>h5</code>",
-   "<code>h6</code>",
-   "<code>header</code>",
-   "<code>main</code>",
-   "<code>nav</code>",
-   "<code>p</code>",
-   "<code>section</code>", or
-   "<code>span</code>"
-  </ul>
-
-  <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
+  <p>If <a>this</a>'s <a for=Element>local name</a> is not <a>valid for attachShadow</a>, then
+  <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
  </li>
 
  <li>

--- a/dom.bs
+++ b/dom.bs
@@ -6809,8 +6809,7 @@ are:
  <a for=/>shadow root</a>'s <a for=ShadowRoot>mode</a> is "<code>open</code>", and null otherwise.
 </dl>
 
-<p>An element's <a for=Element>local name</a> is <dfn>valid for attachShadow</dfn> if it is one of
-the following:
+<p>A <dfn>valid shadow host name</dfn> is:
 
 <ul class=brief>
   <li>a <a>valid custom element name</a>

--- a/dom.bs
+++ b/dom.bs
@@ -6840,7 +6840,7 @@ are:
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
  <li>
-  <p>If <a>this</a>'s <a for=Element>local name</a> is not <a>valid for attachShadow</a>, then
+  <p>If <a>this</a>'s <a for=Element>local name</a> is not a <a>valid shadow host name</a>, then
   <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
  </li>
 

--- a/dom.bs
+++ b/dom.bs
@@ -6809,7 +6809,7 @@ are:
  <a for=/>shadow root</a>'s <a for=ShadowRoot>mode</a> is "<code>open</code>", and null otherwise.
 </dl>
 
-<p>A <dfn>valid shadow host name</dfn> is:
+<p>A <dfn export>valid shadow host name</dfn> is:
 
 <ul class=brief>
   <li>a <a>valid custom element name</a>

--- a/dom.bs
+++ b/dom.bs
@@ -6812,25 +6812,25 @@ are:
 <p>A <dfn export>valid shadow host name</dfn> is:
 
 <ul class=brief>
-  <li>a <a>valid custom element name</a>
-  <li>"<code>article</code>",
-  "<code>aside</code>",
-  "<code>blockquote</code>",
-  "<code>body</code>",
-  "<code>div</code>",
-  "<code>footer</code>",
-  "<code>h1</code>",
-  "<code>h2</code>",
-  "<code>h3</code>",
-  "<code>h4</code>",
-  "<code>h5</code>",
-  "<code>h6</code>",
-  "<code>header</code>",
-  "<code>main</code>",
-  "<code>nav</code>",
-  "<code>p</code>",
-  "<code>section</code>", or
-  "<code>span</code>"
+ <li>a <a>valid custom element name</a>
+ <li>"<code>article</code>",
+ "<code>aside</code>",
+ "<code>blockquote</code>",
+ "<code>body</code>",
+ "<code>div</code>",
+ "<code>footer</code>",
+ "<code>h1</code>",
+ "<code>h2</code>",
+ "<code>h3</code>",
+ "<code>h4</code>",
+ "<code>h5</code>",
+ "<code>h6</code>",
+ "<code>header</code>",
+ "<code>main</code>",
+ "<code>nav</code>",
+ "<code>p</code>",
+ "<code>section</code>", or
+ "<code>span</code>"
 </ul>
 
 <p>The <dfn method for=Element><code>attachShadow(<var>init</var>)</code></dfn> method steps are:
@@ -6839,10 +6839,8 @@ are:
  <li><p>If <a>this</a>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li>
-  <p>If <a>this</a>'s <a for=Element>local name</a> is not a <a>valid shadow host name</a>, then
-  <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
- </li>
+ <li><p>If <a>this</a>'s <a for=Element>local name</a> is not a <a>valid shadow host name</a>, then
+ <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
  <li>
   <p>If <a>this</a>'s <a for=Element>local name</a> is a <a>valid custom element name</a>, or


### PR DESCRIPTION
Split the attachShadow element list into a separate definition so that it can be referenced from the [EditContext spec](https://w3c.github.io/edit-context/#supported-elements).

See https://github.com/w3c/edit-context/issues/19.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1200.html" title="Last updated on May 22, 2023, 7:22 AM UTC (5ee87a7)">Preview</a> | <a href="https://whatpr.org/dom/1200/6c02df2...5ee87a7.html" title="Last updated on May 22, 2023, 7:22 AM UTC (5ee87a7)">Diff</a>