### PR TITLE
Export AbortController's signal

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1766,7 +1766,7 @@ interface AbortController {
  will be stored.
 </dl>
 
-<p>An {{AbortController}} object has an associated <dfn for=AbortController>signal</dfn> (an
+<p>An {{AbortController}} object has an associated <dfn export for=AbortController>signal</dfn> (an
 {{AbortSignal}} object).
 
 <div algorithm>


### PR DESCRIPTION
For https://github.com/whatwg/dom/issues/1194, so specs can use an AbortController and its signal rather than signaling abort directly on an AbortSignal.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1202.html" title="Last updated on May 25, 2023, 5:13 PM UTC (6110e11)">Preview</a> | <a href="https://whatpr.org/dom/1202/4b15d1f...6110e11.html" title="Last updated on May 25, 2023, 5:13 PM UTC (6110e11)">Diff</a>