### PR TITLE
Correct undefined variable in add an event listener

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1168,9 +1168,9 @@ method steps are:
 <ol>
  <li><p>If <var>eventTarget</var> is a {{ServiceWorkerGlobalScope}} object and its
  <a for="ServiceWorkerGlobalScope">service worker</a>'s
- <a for="service worker">set of event types to handle</a> contains <var>type</var>, then
- <a>report a warning to the console</a> that this might not give the expected results.
- [[!SERVICE-WORKERS]]
+ <a for="service worker">set of event types to handle</a> <a for=set>contains</a>
+ <var>listener</var>'s <a for="event listener">type</a>, then <a>report a warning to the console</a>
+ that this might not give the expected results. [[!SERVICE-WORKERS]]
 
  <li><p>Set <var>listener</var>'s <a for="event listener">removed</a> to true and
  <a for=list>remove</a> <var>listener</var> from <var>eventTarget</var>'s

--- a/dom.bs
+++ b/dom.bs
@@ -1029,6 +1029,7 @@ are not to be used for anything else. [[!HTML]]
  {{Event/preventDefault()}} method was not invoked; otherwise false.
 </dl>
 
+<div algorithm>
 <p>To <dfn export for=Event id=concept-flatten-options>flatten</dfn> <var>options</var>, run these
 steps:
 
@@ -1037,7 +1038,9 @@ steps:
 
  <li><p>Return |options|["{{EventListenerOptions/capture}}"].
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export for=Event>flatten more</dfn><!-- sorry --> <var>options</var>, run these
 steps:
 
@@ -1063,6 +1066,7 @@ steps:
 
  <li><p>Return <var>capture</var>, <var>passive</var>, <var>once</var>, and <var>signal</var>.
 </ol>
+</div>
 
 <p>The <dfn constructor for=EventTarget lt=EventTarget()><code>new EventTarget()</code></dfn>
 constructor steps are to do nothing.
@@ -1076,6 +1080,7 @@ or <a for=EventTarget>legacy-canceled-activation behavior</a>.
 if this would be useful for your programs. For now, all author-created {{EventTarget}}s do not
 participate in a tree structure.</p>
 
+<div algorithm>
 <p>The <dfn>default passive value</dfn>, given an event type |type| and an {{EventTarget}}
 |eventTarget|, is determined as follows:
 
@@ -1095,7 +1100,9 @@ participate in a tree structure.</p>
 
  <li><p>Return false.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export>add an event listener</dfn>, given an {{EventTarget}} object
 <var>eventTarget</var> and an <a>event listener</a> <var>listener</var>, run these steps:
 
@@ -1114,7 +1121,8 @@ participate in a tree structure.</p>
  <li><p>If <var>listener</var>'s <a for="event listener">callback</a> is null, then return.
 
  <li><p>If <var>listener</var>'s <a for="event listener">passive</a> is null, then set it to the
- <a>default passive value</a> given |type| and |eventTarget|.
+ <a>default passive value</a> given <var>listener</var>'s <a for="event listener">type</a> and
+ <var>eventTarget</var>.
 
  <li><p>If <var>eventTarget</var>'s <a>event listener list</a> does not <a for=list>contain</a> an
  <a>event listener</a> whose <a for="event listener">type</a> is <var>listener</var>'s
@@ -1134,7 +1142,9 @@ participate in a tree structure.</p>
 
 <p class=note>The <a>add an event listener</a> concept exists to ensure <a>event handlers</a> use
 the same code path. [[HTML]]
+</div>
 
+<div algorithm>
 <p>The
 <dfn method for=EventTarget><code>addEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
 method steps are:
@@ -1149,7 +1159,9 @@ method steps are:
  <a for="event listener">passive</a> is <var>passive</var>, <a for="event listener">once</a> is
  <var>once</var>, and <a for="event listener">signal</a> is <var>signal</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export>remove an event listener</dfn>, given an {{EventTarget}} object
 <var>eventTarget</var> and an <a>event listener</a> <var>listener</var>, run these steps:
 
@@ -1166,14 +1178,18 @@ method steps are:
 </ol>
 
 <p class=note>HTML needs this to define event handlers. [[HTML]]
+</div>
 
+<div algorithm>
 <p>To <dfn export>remove all event listeners</dfn>, given an {{EventTarget}} object
 <var>eventTarget</var>, <a for=list>for each</a> <var>listener</var> of <var>eventTarget</var>'s
 <a for=EventTarget>event listener list</a>, <a>remove an event listener</a> with
 <var>eventTarget</var> and <var>listener</var>.
 
 <p class=note>HTML needs this to define <code>document.open()</code>. [[HTML]]
+</div>
 
+<div algorithm>
 <p>The
 <dfn method for=EventTarget><code>removeEventListener(<var>type</var>, <var>callback</var>, <var>options</var>)</code></dfn>
 method steps are:
@@ -1191,7 +1207,9 @@ method steps are:
 <p class=note>The event listener list will not contain multiple event listeners with equal
 <var>type</var>, <var>callback</var>, and <var>capture</var>, as <a>add an event listener</a>
 prevents that.
+</div>
 
+<div algorithm>
 <p>The <dfn method for=EventTarget><code>dispatchEvent(<var>event</var>)</code></dfn> method steps
 are:
 
@@ -1203,6 +1221,7 @@ are:
 
  <li><p>Return the result of <a>dispatching</a> <var>event</var> to <a>this</a>.
 </ol>
+</div>
 
 
 <h3 id=observing-event-listeners>Observing event listeners</h3>
@@ -10165,6 +10184,7 @@ James M Snell,
 James Robinson,
 Jeffrey Yasskin,
 Jens Lindström,
+Jeremy Davis<!-- jeremydavis519; GitHub -->,
 Jesse McCarthy,
 Jinho Bang,
 João Eiras,


### PR DESCRIPTION
Also add `<div algorithm>` wrappers to make this problem less likely to reoccur in this section.

Fixes #1203.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1204.html" title="Last updated on May 31, 2023, 10:39 AM UTC (68924eb)">Preview</a> | <a href="https://whatpr.org/dom/1204/8602242...68924eb.html" title="Last updated on May 31, 2023, 10:39 AM UTC (68924eb)">Diff</a>