### PR TITLE
Fix typo AbortSignal _any -> any

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1822,7 +1822,7 @@ to <a for=AbortController>signal abort</a> on <a>this</a> with <var>reason</var>
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort(optional any reason);
   [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
-  [NewObject] static AbortSignal _any(sequence&lt;AbortSignal> signals);
+  [NewObject] static AbortSignal any(sequence&lt;AbortSignal> signals);
 
   readonly attribute boolean aborted;
   readonly attribute any reason;


### PR DESCRIPTION
This is just a typo in the IDL, everywhere else in the spec refers to the method as `any` as it should be.
