### PR TITLE
Handle old value correctly when changing an attribute.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6297,10 +6297,12 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 <a>attribute</a> <var>attribute</var> to <var>value</var>, run these steps:
 
 <ol>
+ <li><p>Let <var>oldValue</var> be <var>attribute</var>'s <a for=Attr>value</a>.</p></li>
+
  <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>value</var>.
 
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
- <a for=Attr>element</a>, <var>attribute</var>'s <a for=Attr>value</a>, and <var>value</var>.
+ <a for=Attr>element</a>, <var>oldValue</var>, and <var>value</var>.
 </ol>
 
 <p>To <dfn export id=concept-element-attributes-append lt="append an attribute">append</dfn> an


### PR DESCRIPTION
This fixes an error just introduced in
3fb0aa62a96f0b3a8afb016ca95a805ccd3fc5b0; I happened to be reading the text today while working on something else.

cc @josepharhar


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1209.html" title="Last updated on Jun 13, 2023, 2:05 AM UTC (55d4821)">Preview</a> | <a href="https://whatpr.org/dom/1209/3fb0aa6...55d4821.html" title="Last updated on Jun 13, 2023, 2:05 AM UTC (55d4821)">Diff</a>