### PR TITLE
Stop exporting AbortSignal's signal abort

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1993,8 +1993,8 @@ object <var>signal</var>:
 </div>
 
 <div algorithm>
-<p>To <dfn export for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object
-<var>signal</var> and an optional <var>reason</var>:
+<p>To <dfn for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object <var>signal</var> and
+an optional <var>reason</var>:
 
 <ol>
  <li><p>If <var>signal</var> is [=AbortSignal/aborted=], then return.


### PR DESCRIPTION
For https://github.com/whatwg/dom/issues/1194. Specs have been converted to use AbortController's signal abort (https://dontcallmedom.github.io/webdex/s.html).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1226.html" title="Last updated on Sep 26, 2023, 8:37 PM UTC (e96cebe)">Preview</a> | <a href="https://whatpr.org/dom/1226/2a24a27...e96cebe.html" title="Last updated on Sep 26, 2023, 8:37 PM UTC (e96cebe)">Diff</a>