### PR TITLE
Editorial: remove redundant contains check in AbortSignal.any()

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2079,9 +2079,6 @@ interface that inherits from it, and a <var>realm</var>:
      <li><p>Assert: <var>sourceSignal</var> is not [=AbortSignal/aborted=] and not
      [=AbortSignal/dependent=].
 
-     <li><p>If <var>resultSignal</var>'s [=AbortSignal/source signals=] <a for=set>contains</a>
-     <var>sourceSignal</var>, then <a for=iteration>continue</a>.
-
      <li><p><a for=set>Append</a> <var>sourceSignal</var> to <var>resultSignal</var>'s
      [=AbortSignal/source signals=].
 


### PR DESCRIPTION
Step 4.2.2. of [create a dependent abort signal](https://dom.spec.whatwg.org/#create-a-dependent-abort-signal) prevents duplicated signals in [source signals](https://dom.spec.whatwg.org/#abortsignal-source-signals) for example in the following snippet
```
const controller = new AbortController();
const signal = AbortSignal.any([ controller.signal, AbortSignal.any([controller.signal]) ]);
```
so maybe the same should hold for 
```
const signal2 = AbortSignal.any([ AbortSignal.any([controller.signal]), controller.signal ]);
const signal2 = AbortSignal.any([ controller.signal, controller.signal ]);
```
To my knowledge, duplicated signals in source signals should not have any impact due to step 1 of [signal abort](https://dom.spec.whatwg.org/#abortsignal-signal-abort) ensuring signals are only aborted once. So this change should cause no behavior change.

### PR Questions

- [ ] At least two implementers are interested (and none opposed):
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt):
   * There already is https://github.com/web-platform-tests/wpt/blob/2fcb60d7e9f294400c6274d964428621ca6cd3d2/dom/abort/resources/abort-signal-any-tests.js#L81C1-L88C72
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1244.html" title="Last updated on Jan 16, 2024, 8:52 AM UTC (c79e137)">Preview</a> | <a href="https://whatpr.org/dom/1244/da484da...c79e137.html" title="Last updated on Jan 16, 2024, 8:52 AM UTC (c79e137)">Diff</a>