### PR TITLE
Reset declarative to false when calling attachShadow

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6965,8 +6965,16 @@ a boolean <var>delegatesFocus</var>, and a boolean <var>slotAssignment</var>:
    is false, then <a>throw</a> an "{{NotSupportedError!!exception}}" {{DOMException}}.
 
    <li>
-    <p>Otherwise, <a for=/>remove</a> all of <var>element</var>'s <a for=Element>shadow root</a>'s
-    <a for=tree>children</a>, in <a>tree order</a>, and return.
+    <p>Otherwise:
+
+    <ol>
+      <li><p><a for=/>Remove</a> all of <var>element</var>'s <a for=Element>shadow root</a>'s
+      <a for=tree>children</a>, in <a>tree order</a>.
+
+      <li><p>Set <var>element</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a> to false.
+
+      <li><p>Return.
+    </ol>
 
     <p class=note>This means that if multiple declarative shadow roots are contained within a single
     shadow host, only the last one will remain.

--- a/dom.bs
+++ b/dom.bs
@@ -6968,12 +6968,13 @@ a boolean <var>delegatesFocus</var>, and a boolean <var>slotAssignment</var>:
     <p>Otherwise:
 
     <ol>
-      <li><p><a for=/>Remove</a> all of <var>element</var>'s <a for=Element>shadow root</a>'s
-      <a for=tree>children</a>, in <a>tree order</a>.
+     <li><p><a for=/>Remove</a> all of <var>element</var>'s <a for=Element>shadow root</a>'s
+     <a for=tree>children</a>, in <a>tree order</a>.
 
-      <li><p>Set <var>element</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a> to false.
+     <li><p>Set <var>element</var>'s <a for=Element>shadow root</a>'s
+     <a for=ShadowRoot>declarative</a> to false.
 
-      <li><p>Return.
+     <li><p>Return.
     </ol>
 
     <p class=note>This means that if multiple declarative shadow roots are contained within a single


### PR DESCRIPTION
This was an oversight in the spec, and this matches browser behavior. This makes a second call to `attachShadow()` throw.

This test already tests this condition: shadow-dom/declarative/declarative-shadow-dom-attachment.html

Closes https://github.com/whatwg/dom/issues/1234

@emilio


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 12, 2024, 7:32 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmfreed7%2Fdom%2F7e051b162485c97ce16f2f6168bcbaaf15a9e093%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201245)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20whatwg/dom%231245.)._
</details>
