### PR TITLE
Enforce same parameters for attachShadow on declarative shadow root

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6933,10 +6933,6 @@ are:
 <a for=/>element</a> <var>element</var>, a string <var>mode</var>, a boolean <var>clonable</var>,
 a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
 
-<!-- Any new parameters added to <a>attach a shadow root</a> should be
-     added to the list of parameter-match tests under "If one of the
-     following is true" below. -->
-
 <ol>
  <li><p>If <var>element</var>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
@@ -6974,16 +6970,7 @@ a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
      <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false,
 
      <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>mode</a> does not match
-     <var>mode</var>,
-
-     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>delegates focus</a> does
-     not match <var>delegatesFocus</var>,
-
-     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>slot assignment</a> does
-     not match <var>slotAssignment</var>, or
-
-     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>clonable</a> does
-     not match <var>clonable</var>,
+     <var>mode</var>, or
     </ul>
 
     <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.

--- a/dom.bs
+++ b/dom.bs
@@ -4502,7 +4502,7 @@ dom-Range-extractContents, dom-Range-cloneContents -->
   <a for=ShadowRoot>clonable</a> is true:
 
   <ol>
-   <li><p>Assert: <var>copy</var> is not a <span>shadow host</span>.
+   <li><p>Assert: <var>copy</var> is not a <a for=Element>shadow host</a>.
 
    <li><p>Run <a>attach a shadow root</a> with <var>copy</var>, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>mode</a>, true, <var>node</var>'s
@@ -6960,14 +6960,31 @@ a boolean <var>delegatesFocus</var>, and a boolean <var>slotAssignment</var>:
   <p>If <var>element</var> is a <a for=Element>shadow host</a>, then:
 
   <ol>
-   <li><p>Let <var>existing root</var> be <var>element</var>'s <a for=Element>shadow root</a>.
+   <li><p>Let <var>currentShadowRoot</var> be <var>element</var>'s
+   <a for=Element>shadow root</a>.
 
-   <li><p>If <var>existing root</var>'s <a for=ShadowRoot>declarative</a>
-   is false, or <var>existing root</var>'s <a for=ShadowRoot>mode</a> does not match
-   <var>mode</var>, or <var>existing root</var>'s <a for=ShadowRoot>delegates focus</a> does
-   not match <var>delegatesFocus</var>, or <var>existing root</var>'s
-   <a for=ShadowRoot>slot assignment</a> does not match <var>slotAssignment</var>,
-   then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
+   <li><p>If one of the following is true:
+
+   <ul>
+    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false,
+
+    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>mode</a> does not match
+    <var>mode</var>,
+
+    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>delegates focus</a> does
+    not match <var>delegatesFocus</var>,
+
+    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>slot assignment</a> does
+    not match <var>slotAssignment</var>,
+
+    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>clonable</a> does
+    not match <var>clonable</var>,
+   </ul>
+
+   <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
+
+   <p class=note>Any new parameters added to <a>attach a shadow root</a> should be
+   added to the list of tests above.
 
    <li>
     <p>Otherwise:

--- a/dom.bs
+++ b/dom.bs
@@ -6960,17 +6960,15 @@ a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
   <p>If <var>element</var> is a <a for=Element>shadow host</a>, then:
 
   <ol>
-   <li><p>Let <var>currentShadowRoot</var> be <var>element</var>'s
-   <a for=Element>shadow root</a>.
+   <li><p>Let <var>currentShadowRoot</var> be <var>element</var>'s <a for=Element>shadow root</a>.
 
    <li>
-    <p>If one of the following is true:
+    <p>If any of the following are true:
 
     <ul>
-     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false; or
 
-     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>mode</a> does not match
-     <var>mode</var>
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>mode</a> is not <var>mode</var>,
     </ul>
 
     <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
@@ -6979,16 +6977,13 @@ a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
     <p>Otherwise:
 
     <ol>
-     <li><p><a for=/>Remove</a> all of <var>currentShadowRoot</var>'s
-     <a for=tree>children</a>, in <a>tree order</a>.
+     <li><p><a for=/>Remove</a> all of <var>currentShadowRoot</var>'s <a for=tree>children</a>, in
+     <a>tree order</a>.
 
      <li><p>Set <var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> to false.
 
      <li><p>Return.
     </ol>
-
-    <p class=note>This means that if multiple declarative shadow roots are contained within a single
-    shadow host, only the last one will remain.
   </ol>
 
  <li><p>Let <var>shadow</var> be a new <a for=/>shadow root</a> whose <a for=Node>node document</a>

--- a/dom.bs
+++ b/dom.bs
@@ -4502,6 +4502,8 @@ dom-Range-extractContents, dom-Range-cloneContents -->
   <a for=ShadowRoot>clonable</a> is true:
 
   <ol>
+   <li><p>Assert: <var>copy</var> is not a <span>shadow host</span>.
+
    <li><p>Run <a>attach a shadow root</a> with <var>copy</var>, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>mode</a>, true, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>delegates focus</a>, and <var>node</var>'s

--- a/dom.bs
+++ b/dom.bs
@@ -6933,6 +6933,10 @@ are:
 <a for=/>element</a> <var>element</var>, a string <var>mode</var>, a boolean <var>clonable</var>,
 a boolean <var>delegatesFocus</var>, and a boolean <var>slotAssignment</var>:
 
+<!-- Any new parameters added to <a>attach a shadow root</a> should be
+     added to the list of parameter-match tests under "If one of the
+     following is true" below. -->
+
 <ol>
  <li><p>If <var>element</var>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
@@ -6963,28 +6967,26 @@ a boolean <var>delegatesFocus</var>, and a boolean <var>slotAssignment</var>:
    <li><p>Let <var>currentShadowRoot</var> be <var>element</var>'s
    <a for=Element>shadow root</a>.
 
-   <li><p>If one of the following is true:
+   <li>
+    <p>If one of the following is true:
 
-   <ul>
-    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false,
+    <ul>
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false,
 
-    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>mode</a> does not match
-    <var>mode</var>,
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>mode</a> does not match
+     <var>mode</var>,
 
-    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>delegates focus</a> does
-    not match <var>delegatesFocus</var>,
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>delegates focus</a> does
+     not match <var>delegatesFocus</var>,
 
-    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>slot assignment</a> does
-    not match <var>slotAssignment</var>,
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>slot assignment</a> does
+     not match <var>slotAssignment</var>, or
 
-    <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>clonable</a> does
-    not match <var>clonable</var>,
-   </ul>
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>clonable</a> does
+     not match <var>clonable</var>,
+    </ul>
 
-   <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
-
-   <p class=note>Any new parameters added to <a>attach a shadow root</a> should be
-   added to the list of tests above.
+    <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
    <li>
     <p>Otherwise:

--- a/dom.bs
+++ b/dom.bs
@@ -6967,10 +6967,10 @@ a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
     <p>If one of the following is true:
 
     <ul>
-     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false,
+     <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> is false
 
      <li><p><var>currentShadowRoot</var>'s <a for=ShadowRoot>mode</a> does not match
-     <var>mode</var>, or
+     <var>mode</var>
     </ul>
 
     <p>then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
@@ -6979,11 +6979,10 @@ a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
     <p>Otherwise:
 
     <ol>
-     <li><p><a for=/>Remove</a> all of <var>element</var>'s <a for=Element>shadow root</a>'s
+     <li><p><a for=/>Remove</a> all of <var>currentShadowRoot</var>'s
      <a for=tree>children</a>, in <a>tree order</a>.
 
-     <li><p>Set <var>element</var>'s <a for=Element>shadow root</a>'s
-     <a for=ShadowRoot>declarative</a> to false.
+     <li><p>Set <var>currentShadowRoot</var>'s <a for=ShadowRoot>declarative</a> to false.
 
      <li><p>Return.
     </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -6960,8 +6960,14 @@ a boolean <var>delegatesFocus</var>, and a boolean <var>slotAssignment</var>:
   <p>If <var>element</var> is a <a for=Element>shadow host</a>, then:
 
   <ol>
-   <li><p>If <var>element</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a>
-   is false, then <a>throw</a> an "{{NotSupportedError!!exception}}" {{DOMException}}.
+   <li><p>Let <var>existing root</var> be <var>element</var>'s <a for=Element>shadow root</a>.
+
+   <li><p>If <var>existing root</var>'s <a for=ShadowRoot>declarative</a>
+   is false, or <var>existing root</var>'s <a for=ShadowRoot>mode</a> does not match
+   <var>mode</var>, or <var>existing root</var>'s <a for=ShadowRoot>delegates focus</a> does
+   not match <var>delegatesFocus</var>, or <var>existing root</var>'s
+   <a for=ShadowRoot>slot assignment</a> does not match <var>slotAssignment</var>,
+   then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
    <li>
     <p>Otherwise:

--- a/dom.bs
+++ b/dom.bs
@@ -6931,7 +6931,7 @@ are:
 <div algorithm>
 <p>To <dfn id=concept-attach-a-shadow-root>attach a shadow root</dfn>, given an
 <a for=/>element</a> <var>element</var>, a string <var>mode</var>, a boolean <var>clonable</var>,
-a boolean <var>delegatesFocus</var>, and a boolean <var>slotAssignment</var>:
+a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
 
 <!-- Any new parameters added to <a>attach a shadow root</a> should be
      added to the list of parameter-match tests under "If one of the


### PR DESCRIPTION
Per the discussion at https://github.com/whatwg/dom/issues/1235, this PR changes the behavior when calling `attachShadow()` on a node with an existing declarative shadow root. Now, if the `mode` does not match between the arguments to `attachShadow()` and the existing root, throw an exception. Prior behavior was to silently return the declarative root as-is, with mismatched `mode`s.

See also, https://github.com/whatwg/html/pull/10069.

@emilio @annevk @rniwa

Closes https://github.com/whatwg/dom/issues/1235

- [X] At least two implementers are interested (and none opposed):
   * Chromium (me)
   * WebKit [sounds supportive](https://github.com/whatwg/dom/issues/1235#issuecomment-1900422398)
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/shadow-dom/declarative/declarative-shadow-dom-repeats.html
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/1379513
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1876885
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=268208
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/32289
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1246.html" title="Last updated on Feb 15, 2024, 12:51 PM UTC (30a0f3b)">Preview</a> | <a href="https://whatpr.org/dom/1246/e1c9b00...30a0f3b.html" title="Last updated on Feb 15, 2024, 12:51 PM UTC (30a0f3b)">Diff</a>