### PR TITLE
Draft integration with Trusted Types, take 2.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -52,7 +52,8 @@ spec:html; type:element
 <p>This specification depends on the Infra Standard. [[!INFRA]]
 
 <p>Some of the terms used in this specification are defined in <cite>Encoding</cite>,
-<cite>Selectors</cite>, <cite>Trusted Types</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and <cite>Namespaces in XML</cite>.
+<cite>Selectors</cite>, <cite>Trusted Types</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and
+<cite>Namespaces in XML</cite>.
 [[!ENCODING]]
 [[!SELECTORS4]]
 [[!TRUSTED-TYPES]]
@@ -6358,7 +6359,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 <ol>
  <li><p>Let <var>oldValue</var> be <var>attribute</var>'s <a for=Attr>value</a>.</p></li>
 
- <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>, with <var>attribute</var>'s <a for=Attr>element</a>.
+ <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>, with
+ <var>attribute</var>'s <a for=Attr>element</a>.
 
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
  <a for=Attr>element</a>, <var>oldValue</var>, and <var>value</var>.
@@ -6410,13 +6412,17 @@ steps:
  <a for=Attr>value</a>.
 </ol>
 
-<p>To <dfn id=concept-element-attributes-validate-and-set-value>validate and set attribute value</dfn> <var>value</var> for an <a>attribute</a> <var>attribute</var>, with <a>element</a> <var>element</var>, run these steps:
+<p>To <dfn id=concept-element-attributes-validate-and-set-value>validate and set attribute value</dfn>
+<var>value</var> for an <a>attribute</a> <var>attribute</var>, with <a for=/>element</a>
+<var>element</var>, run these steps:
 
- <ol>
- <li><p>Let <var>validValue</var> be the result of calling <a>Get Trusted Types-compliant attribute value</a>
-  for <var>attribute</var>, with <var>element</var> and <var>value</var>.[[!TRUSTED-TYPES]]
+<ol>
+ <li><p>Let <var>validValue</var> be the result of calling
+ <a>Get Trusted Types-compliant attribute value</a> for <var>attribute</var>, with
+ <var>element</var> and <var>value</var>. [[!TRUSTED-TYPES]]
+
  <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>validValue</var>.
- </ol>
+</ol>
 
 <hr>
 
@@ -6480,7 +6486,8 @@ string <var>namespace</var> (default null):</p>
 
  <li><p>If <var>oldAttr</var> is <var>attr</var>, return <var>attr</var>.
 
- <li><p><a>Validate and set attribute value</a> <var>newAttr</var>'s <a for="Attr">value</a> for <var>newAttr</var> with <var>element</var>.
+ <li><p><a>Validate and set attribute value</a> <var>newAttr</var>'s <a for="Attr">value</a> for
+ <var>newAttr</var> with <var>element</var>.
 
  <li><p>If <var>oldAttr</var> is non-null, then <a lt="replace an attribute">replace</a>
  <var>oldAttr</var> with <var>attr</var>.
@@ -6493,9 +6500,9 @@ string <var>namespace</var> (default null):</p>
 
 <div algorithm>
 <p>To <dfn export id=concept-element-attributes-set-value>set an attribute value</dfn> given an
-<a for=/>element</a> <var>element</var>, a string <var>localName</var>, a string or <a>TrustedType</a> <var>value</var>,
-an optional null or string <var>prefix</var> (default null), and an optional null or string
-<var>namespace</var> (default null):
+<a for=/>element</a> <var>element</var>, a string <var>localName</var>, a string or {{TrustedType}}
+<var>value</var>, an optional null or string <var>prefix</var> (default null), and an optional null
+or string <var>namespace</var> (default null):
 
 <ol>
  <li>Let <var>attribute</var> be the result of
@@ -6512,12 +6519,14 @@ an optional null or string <var>prefix</var> (default null), and an optional nul
  <ol>
   <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>namespace</a> is
   <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
-  <a for=Attr>local name</a> is <var>localName</var> and
-  <a for=Node>node document</a> is <var>element</var>'s <a for=Node>node document</a>.
+  <a for=Attr>local name</a> is <var>localName</var> and <a for=Node>node document</a> is
+  <var>element</var>'s <a for=Node>node document</a>.
 
-  <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var> with <var>element</var>.
+  <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var> with
+  <var>element</var>.
 
-  <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <var>element</var>
+  <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <var>element</var>.
+
   <li><p>Return.
  </ol>
 
@@ -6783,13 +6792,19 @@ method steps are:
  <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
 
  <li><p>If <var>attribute</var> is null, then:
-   <ol>
-     <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose
-       <a for=Attr>local name</a> is <var>qualifiedName</var> and <a for=Node>node document</a> is <a>this</a>'s <a for=Node>node document</a>.
-     <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>, with <a>this</a>.
-     <li><a lt="append an attribute">Append</a> <var>attribute</var> to <a>this</a>.
-     <li><p>Return.
-   </ol>
+
+ <ol>
+  <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>local name</a> is
+  <var>qualifiedName</var> and <a for=Node>node document</a> is <a>this</a>'s
+  <a for=Node>node document</a>.
+
+  <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>,
+  with <a>this</a>.
+
+  <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <a>this</a>.
+
+  <li><p>Return.
+ </ol>
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> to <var>value</var>.
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -6356,13 +6356,9 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 <a>attribute</a> <var>attribute</var> to <var>value</var>, run these steps:
 
 <ol>
-<li><p>Set <var>value</var> to the result of calling <a>Get Trusted Types-compliant attribute
- value</a> for <var>attribute</var>, with <var>attribute</var>'s <a for=Attr>element</a> and
- <var>value</var>. [[!TRUSTED-TYPES]]
-
  <li><p>Let <var>oldValue</var> be <var>attribute</var>'s <a for=Attr>value</a>.</p></li>
 
- <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>value</var>.
+ <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>, with <var>attribute</var>'s <a for=Attr>element</a>.
 
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
  <a for=Attr>element</a>, <var>oldValue</var>, and <var>value</var>.
@@ -6373,11 +6369,6 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 steps:
 
 <ol>
-<li><p>Set <var>attribute</var>'s
- <a for=Attr>value</a> to the result of calling <a>Get Trusted Types-compliant attribute value</a>
- for <var>attribute</var>, with <var>element</var> and <var>attribute</var>'s <a for=Attr>value</a>.
- [[!TRUSTED-TYPES]]
-
  <li><p><a for=list>Append</a> <var>attribute</var> to <var>element</var>'s
  <a for=Element>attribute list</a>.
 
@@ -6406,11 +6397,6 @@ steps:
 <a>attribute</a> <var>oldAttr</var> with an <a>attribute</a> <var>newAttr</var>, run these steps:
 
 <ol>
- <li><p>Set <var>newAttr</var>'s
- <a for=Attr>value</a> to the result of calling <a>Get Trusted Types-compliant attribute value</a>
- for <var>newAttr</var>, with <var>oldAttr</var>'s <a for=Attr>element</a> and <var>newAttr</var>'s
- <a for=Attr>value</a>.[[!TRUSTED-TYPES]]
-
  <li><p><a for=list>Replace</a> <var>oldAttr</var> by <var>newAttr</var> in <var>oldAttr</var>'s
  <a for=Attr>element</a>'s <a for=Element>attribute list</a>.
 
@@ -6423,6 +6409,14 @@ steps:
  <a for=Attr>element</a>, <var>oldAttr</var>'s <a for=Attr>value</a>, and <var>newAttr</var>'s
  <a for=Attr>value</a>.
 </ol>
+
+<p>To <dfn id=concept-element-attributes-validate-and-set-value>validate and set attribute value</dfn> <var>value</var> for an <a>attribute</a> <var>attribute</var>, with <a>element</a> <var>element</var>, run these steps:
+
+ <ol>
+ <li><p>Let <var>validValue</var> be the result of calling <a>Get Trusted Types-compliant attribute value</a>
+  for <var>attribute</var>, with <var>element</var> and <var>value</var>.[[!TRUSTED-TYPES]]
+ <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>validValue</var>.
+ </ol>
 
 <hr>
 
@@ -6486,6 +6480,8 @@ string <var>namespace</var> (default null):</p>
 
  <li><p>If <var>oldAttr</var> is <var>attr</var>, return <var>attr</var>.
 
+ <li><p><a>Validate and set attribute value</a> <var>newAttr</var>'s <a for="Attr">value</a> for <var>newAttr</var> with <var>element</var>.
+
  <li><p>If <var>oldAttr</var> is non-null, then <a lt="replace an attribute">replace</a>
  <var>oldAttr</var> with <var>attr</var>.
 
@@ -6506,7 +6502,12 @@ an optional null or string <var>prefix</var> (default null), and an optional nul
  <a lt="get an attribute by namespace and local name">getting an attribute</a> given
  <var>namespace</var>, <var>localName</var>, and <var>element</var>.
 
- <li><p>If <var>attribute</var> is null, then:
+ <li>If <var>attribute</var> is null, create an <a>attribute</a> whose <a for=Attr>namespace</a> is
+ <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
+ <a for=Attr>local name</a> is <var>localName</var>, <a for=Attr>value</a> is <var>value</var>, and
+ <a for=Node>node document</a> is <var>element</var>'s <a for=Node>node document</a>, then
+ <a lt="append an attribute">append</a> this <a>attribute</a> to <var>element</var>, and then
+ return.
 
  <ol>
   <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>namespace</a> is
@@ -6514,18 +6515,10 @@ an optional null or string <var>prefix</var> (default null), and an optional nul
   <a for=Attr>local name</a> is <var>localName</var> and
   <a for=Node>node document</a> is <var>element</var>'s <a for=Node>node document</a>.
 
-  <li><p>Set <a>attribute</a>'s <var>value</var> to the result of calling <a>Get Trusted Types-compliant attribute
- value</a> for <var>attribute</var>, with <var>element</var> and
- <var>value</var>. [[!TRUSTED-TYPES]]
+  <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var> with <var>element</var>.
 
- <li><p><a for=list>Append</a> <var>attribute</var> to <var>element</var>'s
- <a for=Element>attribute list</a>.
-
- <li><p>Set <var>attribute</var>'s <a for=Attr>element</a> to <var>element</var>.
-
- <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>, null, and
- <var>attribute</var>'s <a for=Attr>value</a>.
- <li><p>Return.
+  <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <var>element</var>
+  <li><p>Return.
  </ol>
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> to <var>value</var>.
@@ -6789,10 +6782,14 @@ method steps are:
  and null otherwise.
  <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
 
- <li><p>If <var>attribute</var> is null, create an <a>attribute</a> whose
- <a for=Attr>local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is
- stringified <var>value</var>, and <a for=Node>node document</a> is <a>this</a>'s <a for=Node>node document</a>,
- then <a lt="append an attribute">append</a> this <a>attribute</a> to <a>this</a>, and then return.
+ <li><p>If <var>attribute</var> is null, then:
+   <ol>
+     <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose
+       <a for=Attr>local name</a> is <var>qualifiedName</var> and <a for=Node>node document</a> is <a>this</a>'s <a for=Node>node document</a>.
+     <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>, with <a>this</a>.
+     <li><a lt="append an attribute">Append</a> <var>attribute</var> to <a>this</a>.
+     <li><p>Return.
+   </ol>
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> to <var>value</var>.
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -6418,7 +6418,7 @@ steps:
 
 <ol>
  <li><p>Let <var>validValue</var> be the result of calling
- <a>Get Trusted Types-compliant attribute value</a> for <var>attribute</var>, with
+ <a abstract-op>get Trusted Types-compliant attribute value</a> for <var>attribute</var>, with
  <var>element</var> and <var>value</var>. [[!TRUSTED-TYPES]]
 
  <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>validValue</var>.

--- a/dom.bs
+++ b/dom.bs
@@ -52,9 +52,10 @@ spec:html; type:element
 <p>This specification depends on the Infra Standard. [[!INFRA]]
 
 <p>Some of the terms used in this specification are defined in <cite>Encoding</cite>,
-<cite>Selectors</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and <cite>Namespaces in XML</cite>.
+<cite>Selectors</cite>, <cite>Trusted Types</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and <cite>Namespaces in XML</cite>.
 [[!ENCODING]]
 [[!SELECTORS4]]
+[[!TRUSTED-TYPES]]
 [[!WEBIDL]]
 [[!XML]]
 [[!XML-NAMES]]
@@ -6033,8 +6034,8 @@ interface Element : Node {
   sequence&lt;DOMString> getAttributeNames();
   DOMString? getAttribute(DOMString qualifiedName);
   DOMString? getAttributeNS(DOMString? namespace, DOMString localName);
-  [CEReactions] undefined setAttribute(DOMString qualifiedName, DOMString value);
-  [CEReactions] undefined setAttributeNS(DOMString? namespace, DOMString qualifiedName, DOMString value);
+  [CEReactions] undefined setAttribute(DOMString qualifiedName, (TrustedType or DOMString) value);
+  [CEReactions] undefined setAttributeNS(DOMString? namespace, DOMString qualifiedName, (TrustedType or DOMString) value);
   [CEReactions] undefined removeAttribute(DOMString qualifiedName);
   [CEReactions] undefined removeAttributeNS(DOMString? namespace, DOMString localName);
   [CEReactions] boolean toggleAttribute(DOMString qualifiedName, optional boolean force);
@@ -6355,6 +6356,10 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 <a>attribute</a> <var>attribute</var> to <var>value</var>, run these steps:
 
 <ol>
+<li><p>Set <var>value</var> to the result of calling <a>Get Trusted Types-compliant attribute
+ value</a> for <var>attribute</var>, with <var>attribute</var>'s <a for=Attr>element</a> and
+ <var>value</var>. [[!TRUSTED-TYPES]]
+
  <li><p>Let <var>oldValue</var> be <var>attribute</var>'s <a for=Attr>value</a>.</p></li>
 
  <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>value</var>.
@@ -6368,6 +6373,11 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 steps:
 
 <ol>
+<li><p>Set <var>attribute</var>'s
+ <a for=Attr>value</a> to the result of calling <a>Get Trusted Types-compliant attribute value</a>
+ for <var>attribute</var>, with <var>element</var> and <var>attribute</var>'s <a for=Attr>value</a>.
+ [[!TRUSTED-TYPES]]
+
  <li><p><a for=list>Append</a> <var>attribute</var> to <var>element</var>'s
  <a for=Element>attribute list</a>.
 
@@ -6396,6 +6406,11 @@ steps:
 <a>attribute</a> <var>oldAttr</var> with an <a>attribute</a> <var>newAttr</var>, run these steps:
 
 <ol>
+ <li><p>Set <var>newAttr</var>'s
+ <a for=Attr>value</a> to the result of calling <a>Get Trusted Types-compliant attribute value</a>
+ for <var>newAttr</var>, with <var>oldAttr</var>'s <a for=Attr>element</a> and <var>newAttr</var>'s
+ <a for=Attr>value</a>.[[!TRUSTED-TYPES]]
+
  <li><p><a for=list>Replace</a> <var>oldAttr</var> by <var>newAttr</var> in <var>oldAttr</var>'s
  <a for=Attr>element</a>'s <a for=Element>attribute list</a>.
 
@@ -6482,7 +6497,7 @@ string <var>namespace</var> (default null):</p>
 
 <div algorithm>
 <p>To <dfn export id=concept-element-attributes-set-value>set an attribute value</dfn> given an
-<a for=/>element</a> <var>element</var>, a string <var>localName</var>, a string <var>value</var>,
+<a for=/>element</a> <var>element</var>, a string <var>localName</var>, a string or <a>TrustedType</a> <var>value</var>,
 an optional null or string <var>prefix</var> (default null), and an optional null or string
 <var>namespace</var> (default null):
 
@@ -6493,7 +6508,7 @@ an optional null or string <var>prefix</var> (default null), and an optional nul
 
  <li>If <var>attribute</var> is null, create an <a>attribute</a> whose <a for=Attr>namespace</a> is
  <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
- <a for=Attr>local name</a> is <var>localName</var>, <a for=Attr>value</a> is <var>value</var>, and
+ <a for=Attr>local name</a> is <var>localName</var>, <a for=Attr>value</a> is stringified <var>value</var>, and
  <a for=Node>node document</a> is <var>element</var>'s <a for=Node>node document</a>, then
  <a lt="append an attribute">append</a> this <a>attribute</a> to <var>element</var>, and then
  return.
@@ -6761,7 +6776,7 @@ method steps are:
 
  <li><p>If <var>attribute</var> is null, create an <a>attribute</a> whose
  <a for=Attr>local name</a> is <var>qualifiedName</var>, <a for=Attr>value</a> is
- <var>value</var>, and <a for=Node>node document</a> is <a>this</a>'s <a for=Node>node document</a>,
+ stringified <var>value</var>, and <a for=Node>node document</a> is <a>this</a>'s <a for=Node>node document</a>,
  then <a lt="append an attribute">append</a> this <a>attribute</a> to <a>this</a>, and then return.
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> to <var>value</var>.

--- a/dom.bs
+++ b/dom.bs
@@ -6413,8 +6413,8 @@ steps:
 </ol>
 
 <p>To <dfn id=concept-element-attributes-validate-and-set-value>validate and set attribute value</dfn>
-<var>value</var> for an <a>attribute</a> <var>attribute</var>, with <a for=/>element</a>
-<var>element</var>, run these steps:
+{{TrustedType}} or a string <var>value</var> for an <a>attribute</a> <var>attribute</var>, with
+<a for=/>element</a> <var>element</var>:
 
 <ol>
  <li><p>Let <var>validValue</var> be the result of calling
@@ -6509,26 +6509,21 @@ or string <var>namespace</var> (default null):
  <a lt="get an attribute by namespace and local name">getting an attribute</a> given
  <var>namespace</var>, <var>localName</var>, and <var>element</var>.
 
- <li>If <var>attribute</var> is null, create an <a>attribute</a> whose <a for=Attr>namespace</a> is
- <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
- <a for=Attr>local name</a> is <var>localName</var>, <a for=Attr>value</a> is <var>value</var>, and
- <a for=Node>node document</a> is <var>element</var>'s <a for=Node>node document</a>, then
- <a lt="append an attribute">append</a> this <a>attribute</a> to <var>element</var>, and then
- return.
+ <li>
+  <p>If <var>attribute</var> is null, then:
+  <ol>
+    <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>namespace</a> is
+    <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
+    <a for=Attr>local name</a> is <var>localName</var> and <a for=Node>node document</a> is
+    <var>element</var>'s <a for=Node>node document</a>.
 
- <ol>
-  <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>namespace</a> is
-  <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
-  <a for=Attr>local name</a> is <var>localName</var> and <a for=Node>node document</a> is
-  <var>element</var>'s <a for=Node>node document</a>.
+    <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var> with
+    <var>element</var>.
 
-  <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var> with
-  <var>element</var>.
+    <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <var>element</var>.
 
-  <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <var>element</var>.
-
-  <li><p>Return.
- </ol>
+    <li><p>Return.
+  </ol>
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> to <var>value</var>.
 </ol>
@@ -6791,20 +6786,21 @@ method steps are:
  and null otherwise.
  <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
 
- <li><p>If <var>attribute</var> is null, then:
+ <li>
+  <p>If <var>attribute</var> is null, then:
 
- <ol>
-  <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>local name</a> is
-  <var>qualifiedName</var> and <a for=Node>node document</a> is <a>this</a>'s
-  <a for=Node>node document</a>.
+  <ol>
+   <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>local name</a> is
+   <var>qualifiedName</var> and <a for=Node>node document</a> is <a>this</a>'s
+   <a for=Node>node document</a>.
 
-  <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>,
-  with <a>this</a>.
+   <li><p><a>Validate and set attribute value</a> <var>value</var> for <var>attribute</var>,
+   with <a>this</a>.
 
-  <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <a>this</a>.
+   <li><p><a lt="append an attribute">Append</a> <var>attribute</var> to <a>this</a>.
 
-  <li><p>Return.
- </ol>
+   <li><p>Return.
+  </ol>
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> to <var>value</var>.
 </ol>

--- a/dom.bs
+++ b/dom.bs
@@ -6506,12 +6506,27 @@ an optional null or string <var>prefix</var> (default null), and an optional nul
  <a lt="get an attribute by namespace and local name">getting an attribute</a> given
  <var>namespace</var>, <var>localName</var>, and <var>element</var>.
 
- <li>If <var>attribute</var> is null, create an <a>attribute</a> whose <a for=Attr>namespace</a> is
- <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
- <a for=Attr>local name</a> is <var>localName</var>, <a for=Attr>value</a> is stringified <var>value</var>, and
- <a for=Node>node document</a> is <var>element</var>'s <a for=Node>node document</a>, then
- <a lt="append an attribute">append</a> this <a>attribute</a> to <var>element</var>, and then
- return.
+ <li><p>If <var>attribute</var> is null, then:
+
+ <ol>
+  <li><p>Set <var>attribute</var> to a new <a>attribute</a> whose <a for=Attr>namespace</a> is
+  <var>namespace</var>, <a for=Attr>namespace prefix</a> is <var>prefix</var>,
+  <a for=Attr>local name</a> is <var>localName</var> and
+  <a for=Node>node document</a> is <var>element</var>'s <a for=Node>node document</a>.
+
+  <li><p>Set <a>attribute</a>'s <var>value</var> to the result of calling <a>Get Trusted Types-compliant attribute
+ value</a> for <var>attribute</var>, with <var>element</var> and
+ <var>value</var>. [[!TRUSTED-TYPES]]
+
+ <li><p><a for=list>Append</a> <var>attribute</var> to <var>element</var>'s
+ <a for=Element>attribute list</a>.
+
+ <li><p>Set <var>attribute</var>'s <a for=Attr>element</a> to <var>element</var>.
+
+ <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>, null, and
+ <var>attribute</var>'s <a for=Attr>value</a>.
+ <li><p>Return.
+ </ol>
 
  <li><p><a lt="change an attribute">Change</a> <var>attribute</var> to <var>value</var>.
 </ol>


### PR DESCRIPTION
This calls the get Trusted Types-compliant attribute value algorithm from Trusted Types (https://github.com/w3c/trusted-types/pull/418) from attribute's change, append, and replace.

Changed the signature of `setAttribute` and `setAttributeNS` to accept Trusted Types as values. The underlying Attr node's values continue to be `DOMString`, so moving nodes across elements or adding standalone attributes to elements can cause TT violations. This matches WPT tests and the Chromium's implementation.

See  and #789. Supercedes PR #809.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko
   * Chromium (already implemented)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/tree/master/trusted-types
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=739170
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1508286
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1247.html" title="Last updated on Feb 26, 2024, 4:21 PM UTC (10ce041)">Preview</a> | <a href="https://whatpr.org/dom/1247/6a9b5a2...10ce041.html" title="Last updated on Feb 26, 2024, 4:21 PM UTC (10ce041)">Diff</a>