### PR TITLE
Expose AbortSignal.timeout on all globals

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1847,7 +1847,7 @@ to <a for=AbortController>signal abort</a> on <a>this</a> with <var>reason</var>
 [Exposed=*]
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort(optional any reason);
-  [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+  [NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
   [NewObject] static AbortSignal _any(sequence&lt;AbortSignal> signals);
 
   readonly attribute boolean aborted;


### PR DESCRIPTION
Delete the Exposed attribute from AbortSignal.timeout, letting it inherit [Exposed=*] from AbortSignal.

Cf. https://github.com/whatwg/html/pull/9893 where other timers are being exposed in ShadowRealm global contexts.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * T.B.D.
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * T.B.D.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: T.B.D.
   * Gecko: T.B.D.
   * WebKit: T.B.D.
   * Deno (only for aborting and events): T.B.D.
   * Node.js (only for aborting and events): T.B.D.
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: T.B.D.
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/whatwg-dom/1253.html" title="Last updated on Feb 7, 2024, 6:54 PM UTC (789e223)">Preview</a> | <a href="https://whatpr.org/dom/1253/e1c9b00...789e223.html" title="Last updated on Feb 7, 2024, 6:54 PM UTC (789e223)">Diff</a>