### PR TITLE
Add serializable to ShadowRoot and "attach a shadow root"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4506,6 +4506,7 @@ dom-Range-extractContents, dom-Range-cloneContents -->
 
    <li><p>Run <a>attach a shadow root</a> with <var>copy</var>, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>mode</a>, true, <var>node</var>'s
+   <a for=Element>shadow root</a>'s <a for=ShadowRoot>serializable</a>, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>delegates focus</a>, and <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>slot assignment</a>.
 
@@ -5884,6 +5885,7 @@ interface ShadowRoot : DocumentFragment {
   readonly attribute boolean delegatesFocus;
   readonly attribute SlotAssignmentMode slotAssignment;
   readonly attribute boolean clonable;
+  readonly attribute boolean serializable;
   readonly attribute Element host;
   attribute EventHandler onslotchange;
 };
@@ -5917,6 +5919,9 @@ It is initially set to false.</p>
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>clonable</dfn> (a boolean).
 It is initially set to false.</p>
 
+<p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>serializable</dfn> (a boolean).
+It is initially set to false.</p>
+
 <p>A <a for=/>shadow root</a>'s <a>get the parent</a> algorithm, given an <var>event</var>, returns
 null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow root</a> is the
 <a for=tree>root</a> of <var>event</var>'s <a for=Event>path</a>'s first struct's
@@ -5934,6 +5939,9 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 
 <p>The <dfn attribute for=ShadowRoot><code>clonable</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>clonable</a>.
+
+<p>The <dfn attribute for=ShadowRoot><code>serializable</code></dfn> getter steps are to return
+<a>this</a>'s <a for=ShadowRoot>serializable</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>host</code></dfn> getter steps are to return
 <a>this</a>'s <a for=DocumentFragment>host</a>.
@@ -6067,6 +6075,7 @@ dictionary ShadowRootInit {
   boolean delegatesFocus = false;
   SlotAssignmentMode slotAssignment = "named";
   boolean clonable = false;
+  boolean serializable = false;
 };
 </pre>
 
@@ -6920,6 +6929,7 @@ are:
 <ol>
  <li><p>Run <a>attach a shadow root</a> with <a>this</a>,
  <var>init</var>["{{ShadowRootInit/mode}}"], <var>init</var>["{{ShadowRootInit/clonable}}"],
+ <var>init</var>["{{ShadowRootInit/serializable}}"],
  <var>init</var>["{{ShadowRootInit/delegatesFocus}}"], and
  <var>init</var>["{{ShadowRootInit/slotAssignment}}"].
 
@@ -6930,7 +6940,8 @@ are:
 <div algorithm>
 <p>To <dfn id=concept-attach-a-shadow-root>attach a shadow root</dfn>, given an
 <a for=/>element</a> <var>element</var>, a string <var>mode</var>, a boolean <var>clonable</var>,
-a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
+a boolean <var>serializable</var>, a boolean <var>delegatesFocus</var>, and a string
+<var>slotAssignment</var>:
 
 <ol>
  <li><p>If <var>element</var>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
@@ -7000,6 +7011,8 @@ a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>declarative</a> to false.
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>clonable</a> to <var>clonable</var>.
+
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>serializable</a> to <var>serializable</var>.
 
  <li><p>Set <var>element</var>'s <a for=Element>shadow root</a> to <var>shadow</var>.
 </ol>


### PR DESCRIPTION
Add `getHTML()` and the `serializable` concept for shadow roots. See https://github.com/whatwg/html/issues/8867#issuecomment-1856696628 for the rough consensus on how this should work, plus the few comments below that with modifications.

- [X] At least two implementers are interested (and none opposed):
   * Chromium
   * [WebKit](https://github.com/whatwg/html/issues/8867#issuecomment-1910624523)
   * 
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/shadow-dom/declarative/gethtml.tentative.html
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/41490936
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1886630
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=271343
- [X] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed:
   * https://github.com/mdn/content/issues/32731
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

See the corresponding HTML spec PR here: https://github.com/whatwg/html/pull/10139


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1256.html" title="Last updated on Mar 20, 2024, 10:42 PM UTC (1dea1bc)">Preview</a> | <a href="https://whatpr.org/dom/1256/68df785...1dea1bc.html" title="Last updated on Mar 20, 2024, 10:42 PM UTC (1dea1bc)">Diff</a>