### PR TITLE
Define 'connected' for all nodes

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2311,10 +2311,10 @@ therefore alone in a <a>tree</a>.
 <p class=note>Per the <a>node tree</a> constraints, there can be only one such
 <a for=/>element</a>.
 
-<p>An <a for=/>element</a> is <dfn export>in a document tree</dfn> if its <a for=tree>root</a> is a
+<p>A <a for=/>node</a> is <dfn export>in a document tree</dfn> if its <a for=tree>root</a> is a
 <a>document</a>.
 
-<p>An <a for=/>element</a> is <dfn export>in a document</dfn> if it is <a>in a document tree</a>.
+<p>A <a for=/>node</a> is <dfn export>in a document</dfn> if it is <a>in a document tree</a>.
 <span class=note>The term <a>in a document</a> is no longer supposed to be used. It indicates that
 the standard using it has not been updated to account for <a>shadow trees</a>.</span>
 
@@ -2332,7 +2332,7 @@ referred to as the <dfn export id=concept-light-tree>light tree</dfn>.</p>
 <p class=note>A <a>shadow tree</a>'s corresponding <a>light tree</a> can be a <a>shadow tree</a>
 itself.</p>
 
-<p id=in-a-shadow-including-document>An <a for=/>element</a> is <dfn export>connected</dfn> if its
+<p id=in-a-shadow-including-document>A <a for=/>node</a> is <dfn export>connected</dfn> if its
 <a>shadow-including root</a> is a <a>document</a>.
 
 <h5 id=shadow-tree-slots>Slots</h5>


### PR DESCRIPTION
Similarly for 'in a document tree' and 'in a document'.

Fixes #1259.

(Omitted the PR template since this is a spec-only bug fix.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1260.html" title="Last updated on Feb 27, 2024, 3:24 PM UTC (6e6406e)">Preview</a> | <a href="https://whatpr.org/dom/1260/73995b1...6e6406e.html" title="Last updated on Feb 27, 2024, 3:24 PM UTC (6e6406e)">Diff</a>