### PR TITLE
Introduce DOM post-connection steps

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2671,25 +2671,25 @@ do these things asynchronously, however.
  <p>The script in the above example prints <code class=lang-javascript>'rgb(255, 0, 0)'</code>
  because the following happen in order:
 
-  <ol>
-   <li>
-    <p>The <a for=/>insert</a> algorithm runs, which will insert the <{script}> and <code><a element
-    spec=HTML>style</a></code> elements in order.
+ <ol>
+  <li>
+   <p>The <a for=/>insert</a> algorithm runs, which will insert the <{script}> and <code><a element
+   spec=HTML>style</a></code> elements in order.
 
-    <ol>
-     <li>The HTML Standard's <a>insertion steps</a> run for the <{script}> element; they do nothing.
-     [[!HTML]]
+   <ol>
+    <li>The HTML Standard's <a>insertion steps</a> run for the <{script}> element; they do nothing.
+    [[!HTML]]
 
-     <li>The HTML Standard's <a>insertion steps</a> run for the <code><a element
-     spec=HTML>style</a></code> element; they immediately apply its style rules to the document.
-     [[!HTML]]
+    <li>The HTML Standard's <a>insertion steps</a> run for the <code><a element
+    spec=HTML>style</a></code> element; they immediately apply its style rules to the document.
+    [[!HTML]]
 
-     <li>The HTML Standard's <a>post-insertion steps</a> run for the <{script}> element; they run
-     the script, which immediately observes the style rules that were applied in the above step.
-     [[!HTML]]
-    </ol>
-   </li>
-  </ol>
+    <li>The HTML Standard's <a>post-insertion steps</a> run for the <{script}> element; they run
+    the script, which immediately observes the style rules that were applied in the above step.
+    [[!HTML]]
+   </ol>
+  </li>
+ </ol>
 </div>
 
 <!-- See https://github.com/whatwg/dom/issues/34#issuecomment-125571750 for why we might need to

--- a/dom.bs
+++ b/dom.bs
@@ -2706,7 +2706,7 @@ that <var ignore>connectedNode</var> <a>participates</a> in, create <a for=/>bro
 or otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be
 <a for=/>inserted</a> <em>atomically</em> with respect to script, with all major side effects
 occurring <em>after</em> the batch insertions into the <a>node tree</a> is complete. This ensures
-that all pending <a>node tree</a> insertions completely finish before more insertions can occur. 
+that all pending <a>node tree</a> insertions completely finish before more insertions can occur.
 
 <p><a lt="other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-children-changed-ext>children changed steps</dfn> for all or some

--- a/dom.bs
+++ b/dom.bs
@@ -2652,8 +2652,8 @@ events</a>, or otherwise execute JavaScript. These steps may [=queue a global ta
 do these things asynchronously, however.
 
 <div class=example id=example-foo-what-do-i-put-here>
- <p>While the <a>insertion steps</a> cannot execute JavaScript (among other things), it is expected
- that they will indeed have script-observable consequences. Consider the below example:
+ <p>While the <a>insertion steps</a> cannot execute JavaScript (among other things), they will
+ indeed have script-observable consequences. Consider the below example:
 
  <pre class=lang-javascript><code>
  const h1 = document.querySelector('h1');
@@ -2706,9 +2706,8 @@ for=/>nodes</a> to perform any insertion-related operations that modify the <a>n
 <var ignore>insertedNode</var> <a>participates</a> in, create <a for=/>browsing contexts</a>, or
 otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be <a for=/>inserted</a>
 <i>atomically</i> with respect to script, with all major side effects occurring <i>after</i> the
-batch insertions into the <a>node tree</a> is complete, but before <a lt="notify mutation
-observers"><code>MutationObserver</code>s are notified</a>. This ensures that all pending <a>node
-tree</a> insertions completely finish before more insertions can occurr.
+batch insertions into the <a>node tree</a> is complete. This ensures that all pending <a>node
+tree</a> insertions completely finish before more insertions can occur.
 
 
 <p><a lt="other applicable specifications">Specifications</a> may define
@@ -2784,25 +2783,26 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
     <p>For each <a>shadow-including inclusive descendant</a> <var>inclusiveDescendant</var> of
     <var>node</var>, in <a>shadow-including tree order</a>:
 
-    <ol>
-     <li><p>Run the <a>insertion steps</a> with <var>inclusiveDescendant</var>.
+     <ol>
+      <li><p>Run the <a>insertion steps</a> with <var>inclusiveDescendant</var>.
 
-     <li>
-      <p>If <var>inclusiveDescendant</var> is <a>connected</a>, then:
+      <li>
+       <p>If <var>inclusiveDescendant</var> is <a>connected</a>, then:
 
-      <ol>
-       <li><p>If <var>inclusiveDescendant</var> is <a for=Element>custom</a>, then
-       <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>,
-       callback name "<code>connectedCallback</code>", and an empty argument list.
+       <ol>
+        <li><p>If <var>inclusiveDescendant</var> is <a for=Element>custom</a>, then
+        <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>,
+        callback name "<code>connectedCallback</code>", and an empty argument list.
 
-       <li>
-        <p>Otherwise, <a lt="try to upgrade an element">try to upgrade</a>
-        <var>inclusiveDescendant</var>.
+        <li>
+         <p>Otherwise, <a lt="try to upgrade an element">try to upgrade</a>
+         <var>inclusiveDescendant</var>.
 
-        <p class=note>If this successfully upgrades <var>inclusiveDescendant</var>, its
-        <code>connectedCallback</code> will be enqueued automatically during the
-        <a>upgrade an element</a> algorithm.
-      </ol>
+         <p class=note>If this successfully upgrades <var>inclusiveDescendant</var>, its
+         <code>connectedCallback</code> will be enqueued automatically during the
+         <a>upgrade an element</a> algorithm.
+       </ol>
+      </p>
      </li>
     </ol>
    </li>

--- a/dom.bs
+++ b/dom.bs
@@ -2648,7 +2648,8 @@ of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run the
 algorithm is passed <var>insertedNode</var>, as indicated in the <a for=/>insert</a> algorithm
 below. These steps must not modify the <a>node tree</a> that <var>insertedNode</var>
 <a>participates</a> in, create <a for=/>browsing contexts</a>, <a lt="fire an event">fire
-events</a>, or otherwise execute JavaScript.
+events</a>, or otherwise execute JavaScript. These steps may [=queue a global task|queue tasks=] to
+do these things asynchronously, however.
 
 <div class=example id=example-foo-what-do-i-put-here>
  <p>While the <a>insertion steps</a> cannot execute JavaScript (among other things), it is expected
@@ -2703,9 +2704,10 @@ for=/>insert</a> algorithm below.
 <p class=note>The purpose of the <a>post-insertion steps</a> is to provide an opportunity for <a
 for=/>nodes</a> to perform any insertion-related operations that modify the <a>node tree</a> that
 <var ignore>insertedNode</var> <a>participates</a> in, create <a for=/>browsing contexts</a>, or
-otherwise execute JavaScript. These steps allow all nodes that will be inserted by a given <a
-for=/>insert</a> operation to by inserted <i>atomically</i>, with all major side effects occurring
-<i>after</i> <a>node tree</a> insertion is complete.
+otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be <a for=/>inserted</a>
+<i>atomically</i> with respect to script, with all major side effects occurring <i>after</i> the
+batch insertions into the <a>node tree</a> is complete, but before <a lt="notify mutation
+observers"><code>MutationObserver</code>s are notified</a>.
 
 
 <p><a lt="other applicable specifications">Specifications</a> may define

--- a/dom.bs
+++ b/dom.bs
@@ -2647,9 +2647,9 @@ of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run the
 <dfn export id=concept-node-insert-ext>insertion steps</dfn> for all or some <a for=/>nodes</a>. The
 algorithm is passed <var>insertedNode</var>, as indicated in the <a for=/>insert</a> algorithm
 below. These steps must not modify the <a>node tree</a> that <var>insertedNode</var>
-<a>participates</a> in, create <a for=/>browsing contexts</a>, <a lt="fire an event">fire
-events</a>, or otherwise execute JavaScript. These steps may [=queue a global task|queue tasks=] to
-do these things asynchronously, however.
+<a>participates</a> in, create <a for=/>browsing contexts</a>,
+<a lt="fire an event">fire events</a>, or otherwise execute JavaScript. These steps may
+[=queue a global task|queue tasks=] to do these things asynchronously, however.
 
 <div class=example id=example-foo-what-do-i-put-here>
  <p>While the <a>insertion steps</a> cannot execute JavaScript (among other things), they will
@@ -2695,18 +2695,18 @@ do these things asynchronously, however.
      adjust this further based on the requirements of the script element. There might be other ways
      to define that though as Olli suggests, so leaving that out for now. -->
 
-<p><a lt="Other applicable specifications">Specifications</a> may also define <dfn export
-id=concept-node-post-connection-ext>post-connection steps</dfn> for all or some <a for=/>nodes</a>.
-The algorithm is passed <var ignore>connectedNode</var>, as indicated in the <a for=/>insert</a>
-algorithm below.
+<p><a lt="Other applicable specifications">Specifications</a> may also define
+<dfn export id=concept-node-post-connection-ext>post-connection steps</dfn> for all or some
+<a for=/>nodes</a>. The algorithm is passed <var ignore>connectedNode</var>, as indicated in the
+<a for=/>insert</a> algorithm below.
 
-<p class=note>The purpose of the <a>post-connection steps</a> is to provide an opportunity for <a
-for=/>nodes</a> to perform any connection-related operations that modify the <a>node tree</a> that
-<var ignore>connectedNode</var> <a>participates</a> in, create <a for=/>browsing contexts</a>, or
-otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be <a for=/>inserted</a>
-<em>atomically</em> with respect to script, with all major side effects occurring <em>after</em> the
-batch insertions into the <a>node tree</a> is complete. This ensures that all pending <a>node
-tree</a> insertions completely finish before more insertions can occur.
+<p class=note>The purpose of the <a>post-connection steps</a> is to provide an opportunity for
+<a for=/>nodes</a> to perform any connection-related operations that modify the <a>node tree</a>
+that <var ignore>connectedNode</var> <a>participates</a> in, create <a for=/>browsing contexts</a>,
+or otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be
+<a for=/>inserted</a> <em>atomically</em> with respect to script, with all major side effects
+occurring <em>after</em> the batch insertions into the <a>node tree</a> is complete. This ensures
+that all pending <a>node tree</a> insertions completely finish before more insertions can occur. 
 
 <p><a lt="other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-children-changed-ext>children changed steps</dfn> for all or some
@@ -2813,11 +2813,12 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  <li>
   <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially « ».</p>
 
-  <p class="note">We collect all <a for=/>nodes</a> <em>before</em> calling the <a>post-connection
-  steps</a> on any one of them, instead of calling the <a>post-connection steps</a> <em>while</em>
-  we're traversing the <a>node tree</a>. This is because the <a>post-connection steps</a> can modify
-  the tree's structure, making live traversal unsafe, possibly leading to the <a>post-connection
-  steps</a> being called multiple times on the same <a>node</a>.</p>
+  <p class="note">We collect all <a for=/>nodes</a> <em>before</em> calling the
+  <a>post-connection steps</a> on any one of them, instead of calling the
+  <a>post-connection steps</a> <em>while</em> we're traversing the <a>node tree</a>. This is because
+  the <a>post-connection steps</a> can modify the tree's structure, making live traversal unsafe,
+  possibly leading to the <a>post-connection steps</a> being called multiple times on the same
+  <a>node</a>.</p>
  </li>
 
  <li>

--- a/dom.bs
+++ b/dom.bs
@@ -2822,7 +2822,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  </li>
 
  <li>
-  <p>For each <var>node</var> in <var>nodes</var>, in <a>tree order</a>:
+  <p>For each <var>node</var> of <var>nodes</var>, in <a>tree order</a>:
 
   <ol>
    <li><p>For each <a>shadow-including inclusive descendant</a> <var>inclusiveDescendant</var> of

--- a/dom.bs
+++ b/dom.bs
@@ -2812,14 +2812,28 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  <li><p>Run the <a>children changed steps</a> for <var>parent</var>.
 
  <li>
+  <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially
+  empty.</p>
+
+  <p class="note">We collect all <a for=/>nodes</a> <i>before</i> calling the <a>post-insertion
+  steps</a> on any one of them, instead of calling the <a>post-insertion steps</a> <i>while</i>
+  we're traversing the <a>node tree</a>. This is because the <a>post-insertion steps</a> can
+  modify the tree's structure, making live traversal unsafe, possibly leading to the
+  <a>post-insertion steps</a> being called multiple times on the same <a>node</a>.</p>
+ </li>
+
+ <li>
   <p>For each <var>node</var> in <var>nodes</var>, in <a>tree order</a>:
 
   <ol>
    <li><p>For each <a>shadow-including inclusive descendant</a> <var>inclusiveDescendant</var> of
-   <var>node</var>, in <a>shadow-including tree order</a>, run the <a>post-insertion steps</a> with
-   <var>inclusiveDescendant</var>.
+   <var>node</var>, in <a>shadow-including tree order</a>, <a for=list>append</a>
+   <var>inclusiveDescendant</var> to <var>staticNodeList</var>.
   </ol>
  </li>
+
+ <li><p><a for=list>For each</a> <var>node</var> in <var>staticNodeList</var>, run the
+ <a>post-insertion steps</a> with <var>node</var>.
 </ol>
 
 

--- a/dom.bs
+++ b/dom.bs
@@ -2662,30 +2662,29 @@ do these things asynchronously, however.
  const script = fragment.appendChild(document.createElement('script'));
  const style = fragment.appendChild(document.createElement('style'));
 
- script.innerText= 'console.log(getComputedStyle(h1).color)'; // Prints 'rgb(255, 0, 0)'
+ script.innerText= 'console.log(getComputedStyle(h1).color)'; // Logs 'rgb(255, 0, 0)'
  style.innerText = 'h1 {color: rgb(255, 0, 0);}';
 
  document.body.append(fragment);
  </code></pre>
 
- <p>The script in the above example prints <code class=lang-javascript>'rgb(255, 0, 0)'</code>
- because the following happen in order:
+ <p>The script in the above example logs <code class=lang-javascript>'rgb(255, 0, 0)'</code> because
+ the following happen in order:
 
  <ol>
-  <li>
-   <p>The <a for=/>insert</a> algorithm runs, which will insert the <{script}> and <code><a element
-   spec=HTML>style</a></code> elements in order.
+  <li><p>The <a for=/>insert</a> algorithm runs, which will insert the <{script}> and <code>
+  <a element spec=HTML>style</a></code> elements in order.
 
    <ol>
-    <li>The HTML Standard's <a>insertion steps</a> run for the <{script}> element; they do nothing.
-    [[!HTML]]
+    <li><p>The HTML Standard's <a>insertion steps</a> run for the <{script}> element; they do
+    nothing. [[!HTML]]
 
-    <li>The HTML Standard's <a>insertion steps</a> run for the <code><a element
-    spec=HTML>style</a></code> element; they immediately apply its style rules to the document.
-    [[!HTML]]
+    <li><p>The HTML Standard's <a>insertion steps</a> run for the <code>
+    <a element spec=HTML>style</a></code> element; they immediately apply its style rules to the
+    document. [[!HTML]]
 
-    <li>The HTML Standard's <a>post-connection steps</a> run for the <{script}> element; they run the
-    script, which immediately observes the style rules that were applied in the above step.
+    <li><p>The HTML Standard's <a>post-connection steps</a> run for the <{script}> element; they run
+    the script, which immediately observes the style rules that were applied in the above step.
     [[!HTML]]
    </ol>
   </li>
@@ -2812,8 +2811,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  <li><p>Run the <a>children changed steps</a> for <var>parent</var>.
 
  <li>
-  <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially
-  empty.</p>
+  <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially « ».</p>
 
   <p class="note">We collect all <a for=/>nodes</a> <em>before</em> calling the <a>post-connection
   steps</a> on any one of them, instead of calling the <a>post-connection steps</a> <em>while</em>
@@ -2832,7 +2830,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   </ol>
  </li>
 
- <li><p><a for=list>For each</a> <var>node</var> in <var>staticNodeList</var>, if <var>node</var> is
+ <li><p><a for=list>For each</a> <var>node</var> of <var>staticNodeList</var>, if <var>node</var> is
  <a>connected</a>, then run the <a>post-connection steps</a> with <var>node</var>.
 </ol>
 

--- a/dom.bs
+++ b/dom.bs
@@ -2645,11 +2645,68 @@ of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run the
 
 <p><a lt="Other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-insert-ext>insertion steps</dfn> for all or some <a for=/>nodes</a>. The
-algorithm is passed <var ignore>insertedNode</var>, as indicated in the <a for=/>insert</a>
-algorithm below.
+algorithm is passed <var>insertedNode</var>, as indicated in the <a for=/>insert</a> algorithm
+below. These steps must not modify the <a>node tree</a> that <var>insertedNode</var>
+<a>participates</a> in, create <a for=/>browsing contexts</a>, <a lt="fire an event">fire
+events</a>, or otherwise execute JavaScript.
+
+<div class=example id=example-foo-what-do-i-put-here>
+ <p>While the <a>insertion steps</a> cannot execute JavaScript (among other things), it is expected
+ that they will indeed have script-observable consequences. Consider the below example:
+
+ <pre class=lang-javascript><code>
+ const h1 = document.querySelector('h1');
+
+ const fragment = new DocumentFragment();
+ const script = fragment.appendChild(document.createElement('script'));
+ const style = fragment.appendChild(document.createElement('style'));
+
+ script.innerText= 'console.log(getComputedStyle(h1).color)'; // Prints 'rgb(255, 0, 0)'
+ style.innerText = 'h1 {color: rgb(255, 0, 0);}';
+
+ document.body.append(fragment);
+ </code></pre>
+
+ <p>The script in the above example prints <code class=lang-javascript>'rgb(255, 0, 0)'</code>
+ because the following happen in order:
+
+  <ol>
+   <li>
+    <p>The <a for=/>insert</a> algorithm runs, which will insert the <{script}> and <code><a element
+    spec=HTML>style</a></code> elements in order.
+
+    <ol>
+     <li>The HTML Standard's <a>insertion steps</a> run for the <{script}> element; they do nothing.
+     [[!HTML]]
+
+     <li>The HTML Standard's <a>insertion steps</a> run for the <code><a element
+     spec=HTML>style</a></code> element; they immediately apply its style rules to the document.
+     [[!HTML]]
+
+     <li>The HTML Standard's <a>post-insertion steps</a> run for the <{script}> element; they run
+     the script, which immediately observes the style rules that were applied in the above step.
+     [[!HTML]]
+    </ol>
+   </li>
+  </ol>
+</div>
+
 <!-- See https://github.com/whatwg/dom/issues/34#issuecomment-125571750 for why we might need to
      adjust this further based on the requirements of the script element. There might be other ways
      to define that though as Olli suggests, so leaving that out for now. -->
+
+<p><a lt="Other applicable specifications">Specifications</a> may also define <dfn export
+id=concept-node-post-insert-ext>post-insertion steps</dfn> for all or some <a for=/>nodes</a>. The
+algorithm is passed <var ignore>insertedNode</var>, as indicated in the <a
+for=/>insert</a> algorithm below.
+
+<p class=note>The purpose of the <a>post-insertion steps</a> is to provide an opportunity for <a
+for=/>nodes</a> to perform any insertion-related operations that modify the <a>node tree</a> that
+<var ignore>insertedNode</var> <a>participates</a> in, create <a for=/>browsing contexts</a>, or
+otherwise execute JavaScript. These steps allow all nodes that will be inserted by a given <a
+for=/>insert</a> operation to by inserted <i>atomically</i>, with all major side effects occurring
+<i>after</i> <a>node tree</a> insertion is complete.
+
 
 <p><a lt="other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-children-changed-ext>children changed steps</dfn> for all or some
@@ -2752,6 +2809,16 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  <var>parent</var> with <var>nodes</var>, « », <var>previousSibling</var>, and <var>child</var>.
 
  <li><p>Run the <a>children changed steps</a> for <var>parent</var>.
+
+ <li>
+  <p>For each <var>node</var> in <var>nodes</var>, in <a>tree order</a>:
+
+  <ol>
+   <li><p>For each <a>shadow-including inclusive descendant</a> <var>inclusiveDescendant</var> of
+   <var>node</var>, in <a>shadow-including tree order</a>, run the <a>post-insertion steps</a> with
+   <var>inclusiveDescendant</var>.
+  </ol>
+ </li>
 </ol>
 
 

--- a/dom.bs
+++ b/dom.bs
@@ -2707,7 +2707,8 @@ for=/>nodes</a> to perform any insertion-related operations that modify the <a>n
 otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be <a for=/>inserted</a>
 <i>atomically</i> with respect to script, with all major side effects occurring <i>after</i> the
 batch insertions into the <a>node tree</a> is complete, but before <a lt="notify mutation
-observers"><code>MutationObserver</code>s are notified</a>.
+observers"><code>MutationObserver</code>s are notified</a>. This ensures that all pending <a>node
+tree</a> insertions completely finish before more insertions can occurr.
 
 
 <p><a lt="other applicable specifications">Specifications</a> may define

--- a/dom.bs
+++ b/dom.bs
@@ -2684,8 +2684,8 @@ do these things asynchronously, however.
     spec=HTML>style</a></code> element; they immediately apply its style rules to the document.
     [[!HTML]]
 
-    <li>The HTML Standard's <a>post-insertion steps</a> run for the <{script}> element; they run
-    the script, which immediately observes the style rules that were applied in the above step.
+    <li>The HTML Standard's <a>post-connection steps</a> run for the <{script}> element; they run the
+    script, which immediately observes the style rules that were applied in the above step.
     [[!HTML]]
    </ol>
   </li>
@@ -2697,15 +2697,15 @@ do these things asynchronously, however.
      to define that though as Olli suggests, so leaving that out for now. -->
 
 <p><a lt="Other applicable specifications">Specifications</a> may also define <dfn export
-id=concept-node-post-insert-ext>post-insertion steps</dfn> for all or some <a for=/>nodes</a>. The
-algorithm is passed <var ignore>insertedNode</var>, as indicated in the <a
-for=/>insert</a> algorithm below.
+id=concept-node-post-connection-ext>post-connection steps</dfn> for all or some <a for=/>nodes</a>.
+The algorithm is passed <var ignore>connectedNode</var>, as indicated in the <a for=/>insert</a>
+algorithm below.
 
-<p class=note>The purpose of the <a>post-insertion steps</a> is to provide an opportunity for <a
-for=/>nodes</a> to perform any insertion-related operations that modify the <a>node tree</a> that
-<var ignore>insertedNode</var> <a>participates</a> in, create <a for=/>browsing contexts</a>, or
+<p class=note>The purpose of the <a>post-connection steps</a> is to provide an opportunity for <a
+for=/>nodes</a> to perform any connection-related operations that modify the <a>node tree</a> that
+<var ignore>connectedNode</var> <a>participates</a> in, create <a for=/>browsing contexts</a>, or
 otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be <a for=/>inserted</a>
-<i>atomically</i> with respect to script, with all major side effects occurring <i>after</i> the
+<em>atomically</em> with respect to script, with all major side effects occurring <em>after</em> the
 batch insertions into the <a>node tree</a> is complete. This ensures that all pending <a>node
 tree</a> insertions completely finish before more insertions can occur.
 
@@ -2815,11 +2815,11 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially
   empty.</p>
 
-  <p class="note">We collect all <a for=/>nodes</a> <i>before</i> calling the <a>post-insertion
-  steps</a> on any one of them, instead of calling the <a>post-insertion steps</a> <i>while</i>
-  we're traversing the <a>node tree</a>. This is because the <a>post-insertion steps</a> can
-  modify the tree's structure, making live traversal unsafe, possibly leading to the
-  <a>post-insertion steps</a> being called multiple times on the same <a>node</a>.</p>
+  <p class="note">We collect all <a for=/>nodes</a> <em>before</em> calling the <a>post-connection
+  steps</a> on any one of them, instead of calling the <a>post-connection steps</a> <em>while</em>
+  we're traversing the <a>node tree</a>. This is because the <a>post-connection steps</a> can modify
+  the tree's structure, making live traversal unsafe, possibly leading to the <a>post-connection
+  steps</a> being called multiple times on the same <a>node</a>.</p>
  </li>
 
  <li>
@@ -2833,7 +2833,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  </li>
 
  <li><p><a for=list>For each</a> <var>node</var> in <var>staticNodeList</var>, if <var>node</var> is
- <a>connected</a>, then run the <a>post-insertion steps</a> with <var>node</var>.
+ <a>connected</a>, then run the <a>post-connection steps</a> with <var>node</var>.
 </ol>
 
 

--- a/dom.bs
+++ b/dom.bs
@@ -2709,7 +2709,6 @@ otherwise execute JavaScript. These steps allow a batch of <a>nodes</a> to be <a
 batch insertions into the <a>node tree</a> is complete. This ensures that all pending <a>node
 tree</a> insertions completely finish before more insertions can occur.
 
-
 <p><a lt="other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-children-changed-ext>children changed steps</dfn> for all or some
 <a for=/>nodes</a>. The algorithm is passed no argument and is called from <a for=/>insert</a>,

--- a/dom.bs
+++ b/dom.bs
@@ -2832,8 +2832,8 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   </ol>
  </li>
 
- <li><p><a for=list>For each</a> <var>node</var> in <var>staticNodeList</var>, run the
- <a>post-insertion steps</a> with <var>node</var>.
+ <li><p><a for=list>For each</a> <var>node</var> in <var>staticNodeList</var>, if <var>node</var> is
+ <a>connected</a>, then run the <a>post-insertion steps</a> with <var>node</var>.
 </ol>
 
 

--- a/dom.bs
+++ b/dom.bs
@@ -2783,26 +2783,25 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
     <p>For each <a>shadow-including inclusive descendant</a> <var>inclusiveDescendant</var> of
     <var>node</var>, in <a>shadow-including tree order</a>:
 
-     <ol>
-      <li><p>Run the <a>insertion steps</a> with <var>inclusiveDescendant</var>.
+    <ol>
+     <li><p>Run the <a>insertion steps</a> with <var>inclusiveDescendant</var>.
 
-      <li>
-       <p>If <var>inclusiveDescendant</var> is <a>connected</a>, then:
+     <li>
+      <p>If <var>inclusiveDescendant</var> is <a>connected</a>, then:
 
-       <ol>
-        <li><p>If <var>inclusiveDescendant</var> is <a for=Element>custom</a>, then
-        <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>,
-        callback name "<code>connectedCallback</code>", and an empty argument list.
+      <ol>
+       <li><p>If <var>inclusiveDescendant</var> is <a for=Element>custom</a>, then
+       <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>,
+       callback name "<code>connectedCallback</code>", and an empty argument list.
 
-        <li>
-         <p>Otherwise, <a lt="try to upgrade an element">try to upgrade</a>
-         <var>inclusiveDescendant</var>.
+       <li>
+        <p>Otherwise, <a lt="try to upgrade an element">try to upgrade</a>
+        <var>inclusiveDescendant</var>.
 
-         <p class=note>If this successfully upgrades <var>inclusiveDescendant</var>, its
-         <code>connectedCallback</code> will be enqueued automatically during the
-         <a>upgrade an element</a> algorithm.
-       </ol>
-      </p>
+        <p class=note>If this successfully upgrades <var>inclusiveDescendant</var>, its
+        <code>connectedCallback</code> will be enqueued automatically during the
+        <a>upgrade an element</a> algorithm.
+      </ol>
      </li>
     </ol>
    </li>


### PR DESCRIPTION
This PR introduces a node's set of _post-connection steps_. For any given [#concept-node-insert](https://dom.spec.whatwg.org/#concept-node-insert) operation, these steps run for each inserted node synchronously _after_ all DOM insertions are complete. This PR is meant to supersede the similar https://github.com/whatwg/dom/pull/732.

The goal here is to separate the following:
 1. Script-observable but not-script-executing insertion side effects
    - This includes synchronously applying styles to the document, etc...
 2. Script-executing insertion side effects
    - This includes creating an iframe's document and [synchronously firing its load event](https://html.spec.whatwg.org/C#the-iframe-element:iframe-load-event-steps)

For any given call to [#concept-node-insert](https://dom.spec.whatwg.org/#concept-node-insert), the above model allows us to keep all of (1) running synchronously after each node's insertion (as part of its [_insertion steps_](https://dom.spec.whatwg.org/#concept-node-insert-ext)), while pushing all script-executing (or DOM tree-modifying or frame tree-modifying etc.) side effects to the new set of post-connection steps, which run synchronously during insertion, but _after all_ nodes finish their insertion.

This essentially makes insertions "atomic" from the perspective of script, since script will not run until a given batch of DOM insertions are complete. This two-stage approach aligns the spec with a model most similar to [Blink](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/node.h;l=782-812;drc=f4a00cc248dd2dc8ec8759fb51620d47b5114090) & Gecko's implementation, and fixes https://github.com/whatwg/dom/issues/808. This PR also helps out with https://github.com/whatwg/html/issues/1127 and https://github.com/whatwg/dom/issues/575 (per https://github.com/whatwg/dom/pull/732#issuecomment-467403090).

To accomplish, this we audited all insertion side effects on the web platform in https://docs.google.com/document/d/1Fu_pgSBziVIBG4MLjorpfkLTpPD6-XI3dTVrx4CZoqY/edit#heading=h.q06t2gg4vpw, and catalogued whether they have script-observable side-effects, whether they invoke script, whether we have tests for them, and how each implementation handles them. This gave us a list of present "insertion steps" that should move to the "post-connection steps", because they invoke script and therefore prevent insertions from being "atomic". This PR is powerless without counterpart changes to HTML, which will actually _use_ the post-connection steps for all current insertion steps that invoke script or modify the frame tree. The follow-up HTML work is tracked, at the time of writing this:

 - https://github.com/whatwg/html/pull/10188
 - https://github.com/whatwg/html/issues/10241
 - `<another incoming PR will be made for iframes>`

- [x] At least two implementers are interested (and none opposed):
   * ✅ Chrome (mostly implements this model; fails at least one ["nested `script` ordering" test](https://wpt.live/dom/nodes/insertion-removing-steps/Node-appendChild-script-in-script.tentative.html))
   * ✅ Firefox (mostly implements this model; fails a few tests that rely on iframe `load` event being fired synchronously, since I guess it fires this event asynchronously..)
   * 🟠 Safari: @annevk would you be able to provide a WebKit signal here or should I file a standards position issue?
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * [WPT results can be seen here](https://wpt.fyi/results/dom/nodes/insertion-removing-steps?label=master&label=experimental&aligned)
   * https://github.com/web-platform-tests/wpt/pull/44308
   * https://github.com/web-platform-tests/wpt/pull/44658
   * https://github.com/web-platform-tests/wpt/pull/44774
   * https://github.com/web-platform-tests/wpt/pull/44906
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: N/A given https://github.com/whatwg/dom/pull/1261#issuecomment-2037596814.
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

----

Two things need more discussion:
 - **Script child element mutation**:
    - https://github.com/whatwg/dom/pull/732#pullrequestreview-328249015 and https://github.com/whatwg/html/pull/4354#issuecomment-476038918 discuss Chromium _& WebKit's_ model of not executing scripts when their children are modified except for insertion.
        - **Regarding insertion only**: All browsers are aligned on executing a script (that hasn't ["already started"](https://html.spec.whatwg.org/C#script-processing-model:already-started-3)) when a single child node is inserted. For insertion multiple child nodes atomically, see [this WPT](https://wpt.fyi/results/dom/nodes/insertion-removing-steps/Node-appendChild-text-in-script.tentative.html) which Chrome & Firefox pass, and WebKit barely misses due to the post-connection steps[^1]. (Related: _all_ browsers are consistent (see [this test case](https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=12435)) about _not_ executing newly-inserted text nodes in a script that has "already started")
        - **Regarding child removal/change**: As a follow-up to https://github.com/whatwg/dom/pull/732#pullrequestreview-328249015 and https://github.com/whatwg/html/pull/4354#issuecomment-476038918, I've investigated this a little more and found that actually _all_ browsers follow the Chromium behavior here. See [**this WPT**](https://wpt.fyi/results/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.html?label=pr_head&max-count=1&pr=45085) (from https://github.com/web-platform-tests/wpt/pull/45085), where all browsers never trigger the execution of a script when a child node is removed. To accomplish this with the spec, we should probably just add an argument to the child changed steps, but that can be done in a follow-up PR to https://github.com/whatwg/html/pull/10188, since it is _slightly_ orthogonal
    - The only oddity I can find with scripts in Chromium's model is that we don't follow [this rule exactly](https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element:~:text=after%20any%20script%20elements%20inserted%20at%20that%20time), which mandates that when a script (that hasn't already started yet) gets a child `<script>` inserted into it, it must execute _after_ that child script does. Chromium does not do that; the child mutation of the outer script (that inserts the inner `<script>`) triggers the execution of the outer script in its post-connection steps, and then after, the execution of the inner script during _its_ post-connection steps. WebKit is aligned with Chrome on this and Firefox is the odd one out. Maybe we're OK aligning with Chrome/Firefox in this case?
 - **Dealing with "removal" steps**
    - In general, removal is distinct from insertion, and I think has no bearing on the decisions we make in this PR and its corresponding HTML one. However, through some offline discussion, we didn't want to commit to this insertion model without having done some investigation into the removal side of things. I've started this in [this doc](https://docs.google.com/document/d/1Fu_pgSBziVIBG4MLjorpfkLTpPD6-XI3dTVrx4CZoqY/edit#heading=h.n7us367xam1v), but see [**the summary here**](https://gist.github.com/domfarolino/94167cef258c7de96b933ac9b825cfd9). Basically there are only **two** places during Node removal where browsers ever synchronously execute script: (1) `pagehide` which all browsers do on same-origin iframes, and (2) `blur` events (only Chrome does this).
    - Chrome is committed to experimenting with *not* firing in either of these scenarios. Along with the deprecation of mutation events, this should mark the end of all synchronous script execution on Node removal

[^1]: The only reason WebKit fails this is because due to the lack of post-connection steps, the script executes after the first text node is appended, so by the time the second text node gets attached, the script is [already started](https://html.spec.whatwg.org/C#script-processing-model:already-started-3)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1261.html" title="Last updated on Jun 3, 2024, 10:26 AM UTC (fb21a6d)">Preview</a> | <a href="https://whatpr.org/dom/1261/68df785...fb21a6d.html" title="Last updated on Jun 3, 2024, 10:26 AM UTC (fb21a6d)">Diff</a>