### PR TITLE
Record timing info for event handling.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1625,13 +1625,13 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
 
      <li><p>If <var>invocationTargetInShadowTree</var> is false, then set <var>global</var>'s
      <a for=Window>current event</a> to <var>event</var>.
-
-     <li><p><a>Record timing info for event listener</a> given <var>event</var> and
-     <var>listener</var>.
     </ol>
 
    <li><p>If <var>listener</var>'s <a for="event listener">passive</a> is true, then set
    <var>event</var>'s <a>in passive listener flag</a>.
+
+   <li><p>If <var>global</var> is a {{Window}} object, then
+   <a>record timing info for event listener</a> given <var>event</var> and <var>listener</var>.
 
    <li>
     <p><a>Call a user object's operation</a> with <var>listener</var>'s

--- a/dom.bs
+++ b/dom.bs
@@ -1625,6 +1625,9 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
 
      <li><p>If <var>invocationTargetInShadowTree</var> is false, then set <var>global</var>'s
      <a for=Window>current event</a> to <var>event</var>.
+
+     <li><p><a>Record timing info for event handler</a> given <var>event</var> and
+     <var>listener</var>.
     </ol>
 
    <li><p>If <var>listener</var>'s <a for="event listener">passive</a> is true, then set

--- a/dom.bs
+++ b/dom.bs
@@ -1626,7 +1626,7 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
      <li><p>If <var>invocationTargetInShadowTree</var> is false, then set <var>global</var>'s
      <a for=Window>current event</a> to <var>event</var>.
 
-     <li><p><a>Record timing info for event handler</a> given <var>event</var> and
+     <li><p><a>Record timing info for event listener</a> given <var>event</var> and
      <var>listener</var>.
     </ol>
 


### PR DESCRIPTION
This feeds into "Long Animation Frame" timing.

- [x] At least two implementers are interested (and none opposed):
   * Chromium (implemented)
   * Gecko (https://github.com/mozilla/standards-positions/issues/929)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * See https://wpt.fyi/results/long-animation-frame/tentative/l
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: already implemented
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1348405
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=270913
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/mdn/issues/535
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1267.html" title="Last updated on Apr 15, 2024, 4:54 PM UTC (6902a5d)">Preview</a> | <a href="https://whatpr.org/dom/1267/68df785...6902a5d.html" title="Last updated on Apr 15, 2024, 4:54 PM UTC (6902a5d)">Diff</a>