### PR TITLE
A clonable shadow tree is cloned in its entirety

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4517,11 +4517,10 @@ dom-Range-extractContents, dom-Range-cloneContents -->
    <li><p>Set <var>copy</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a>
    to <var>node</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a>.
 
-   <li><p>If the <i>clone children flag</i> is set, then for each <a for=tree>child</a>
-   <var>child</var> of <var>node</var>'s <a for=Element>shadow root</a>, in <a>tree order</a>:
-   <a>append</a> the result of <a lt="clone a node">cloning</a> <var>child</var> with
-   <var>document</var> and the <i>clone children flag</i> set, to <var>copy</var>'s
-   <a for=Element>shadow root</a>.
+   <li><p>For each <a for=tree>child</a> <var>child</var> of <var>node</var>'s
+   <a for=Element>shadow root</a>, in <a>tree order</a>: <a>append</a> the result of
+   <a lt="clone a node">cloning</a> <var>child</var> with <var>document</var> and the
+   <i>clone children flag</i> set, to <var>copy</var>'s <a for=Element>shadow root</a>.
   </ol>
 
  <li><p>Return <var>copy</var>.


### PR DESCRIPTION
Tests: https://github.com/web-platform-tests/wpt/pull/44247.

Fixes #1249.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * Gecko
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * See above.
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: ?
   * WebKit: ?
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
