### PR TITLE
Restore missing word in `attach a shadow root`

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6941,8 +6941,9 @@ a boolean <var>delegatesFocus</var>, and a string <var>slotAssignment</var>:
  <li><p>If <var>element</var>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
  then <a>throw</a> a "{{NotSupportedError!!exception}}" {{DOMException}}.
 
- <li><p>If <var>element</var>'s is not a <a>valid shadow host name</a>, then <a>throw</a> a
- "{{NotSupportedError!!exception}}" {{DOMException}}.
+ <li><p>If <var>element</var>'s <a for=Element>local name</a> is not a
+ <a>valid shadow host name</a>, then <a>throw</a> a "{{NotSupportedError!!exception}}"
+ {{DOMException}}.
 
  <li>
   <p>If <var>element</var>'s <a for=Element>local name</a> is a <a>valid custom element name</a>, or


### PR DESCRIPTION
<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

Restore a term that was accidentally removed from step 2 of https://dom.spec.whatwg.org/#concept-attach-a-shadow-root in https://github.com/whatwg/dom/pull/892.
