### PR TITLE
Mark dependent abort signals as aborted before firing events

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2033,16 +2033,42 @@ an optional <var>reason</var>:
  <li><p>Set <var>signal</var>'s [=AbortSignal/abort reason=] to <var>reason</var> if it is given;
  otherwise to a new "{{AbortError!!exception}}" {{DOMException}}.
 
+ <li><p>Let <var>dependentSignalsToAbort</var> be a new <a for=/>list</a>.
+
+ <li>
+  <p><a for=set>For each</a> <var>dependentSignal</var> of <var>signal</var>'s
+  [=AbortSignal/dependent signals=]:
+
+  <ol>
+   <li>
+    <p>If <var>dependentSignal</var> is not [=AbortSignal/aborted=], then:
+
+    <ol>
+     <li><p>Set <var>dependentSignal</var>'s [=AbortSignal/abort reason=] to <var>signal</var>'s
+     [=AbortSignal/abort reason=].
+
+     <li><p><a for=list>Append</a> <var>dependentSignal</var> to
+     <var>dependentSignalsToAbort</var>.
+    </ol>
+  </ol>
+
+ <li><p><a>Run the abort steps</a> for <var>signal</var>.
+
+ <li><p><a for=set>For each</a> <var>dependentSignal</var> of <var>dependentSignalsToAbort</var>,
+ <a>run the abort steps</a> for <var>dependentSignal</var>.
+</ol>
+</div>
+
+<div algorithm>
+<p>To <dfn>run the abort steps</dfn> for an {{AbortSignal}} <var>signal</var>:
+
+<ol>
  <li><p><a for=set>For each</a> <var>algorithm</var> of <var>signal</var>'s
  [=AbortSignal/abort algorithms=]: run <var>algorithm</var>.
 
  <li><p><a for=set>Empty</a> <var>signal</var>'s <a for=AbortSignal>abort algorithms</a>.
 
  <li><p>[=Fire an event=] named {{AbortSignal/abort}} at <var>signal</var>.
-
- <li><p><a for=set>For each</a> <var>dependentSignal</var> of <var>signal</var>'s
- [=AbortSignal/dependent signals=], [=AbortSignal/signal abort=] on <var>dependentSignal</var> with
- <var>signal</var>'s [=AbortSignal/abort reason=].
 </ol>
 </div>
 


### PR DESCRIPTION
The assert in 4.2.1 of "create a dependent abort signal" fails when creating a dependent signal while dispatching abort events or running abort algorithms if abort had not yet been propagated to one of the sources.

This fix splits "signal abort" into two phases: first, set the abort reason on the signal being aborted and all of its unaborted dependents; next, run the abort algorithms and dispatch events for the signal and those same dependents. Note that:
 1. Dependent signals do not themselves have dependent signals, which means it's unnecessary to recursively call "signal abort"
 2. This approach retains the existing event dispatch order, while ensuring the abort state is synced before any JS runs

This fixes #1293.

---

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at: https://github.com/web-platform-tests/wpt/pull/47653
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/361129283
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1903676
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=278159
   * Deno (only for aborting and events): https://github.com/denoland/deno/issues/25118
   * Node.js (only for aborting and events): https://github.com/nodejs/node/issues/54466
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A, bug fix
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1295.html" title="Last updated on Aug 20, 2024, 8:57 PM UTC (0d05525)">Preview</a> | <a href="https://whatpr.org/dom/1295/7c494e5...0d05525.html" title="Last updated on Aug 20, 2024, 8:57 PM UTC (0d05525)">Diff</a>