### PR TITLE
Revert "Trusted Types integration for "converting nodes into a node""

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -52,11 +52,9 @@ spec:html; type:element
 <p>This specification depends on the Infra Standard. [[!INFRA]]
 
 <p>Some of the terms used in this specification are defined in <cite>Encoding</cite>,
-<cite>Selectors</cite>, <cite>Trusted Types</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and
-<cite>Namespaces in XML</cite>.
+<cite>Selectors</cite>, <cite>Web IDL</cite>, <cite>XML</cite>, and <cite>Namespaces in XML</cite>.
 [[!ENCODING]]
 [[!SELECTORS4]]
-[[!TRUSTED-TYPES]]
 [[!WEBIDL]]
 [[!XML]]
 [[!XML-NAMES]]
@@ -3120,9 +3118,8 @@ standards that want to define APIs shared between <a for=/>documents</a> and
 
 <h4 id=interface-parentnode>Mixin {{ParentNode}}</h4>
 
-<p>To <dfn export lt="converting nodes into a node">convert nodes into a node</dfn>, given a
-<a for=/>node</a> <var>parent</var>, <a for=/>list</a> of <a for=/>nodes</a> <var>nodes</var>, and
-<a for=/>document</a> <var>document</var>:
+<p>To <dfn export lt="converting nodes into a node">convert nodes into a node</dfn>, given
+<var>nodes</var> and <var>document</var>, run these steps:
 
 <ol>
  <li><p>Let <var>node</var> be null.
@@ -3131,37 +3128,12 @@ standards that want to define APIs shared between <a for=/>documents</a> and
  <a for=CharacterData>data</a> is the string and <a for=Node>node document</a> is
  <var>document</var>.
 
- <li><p>Let <var>isScriptElement</var> be true if <var>parent</var> is an {{HTMLScriptElement}}
- <a for=/>node</a>; otherwise false.
-
- <li><p>Let <var>newNodes</var> be « ».
-
- <li>
-  <p><a for=list>For each</a> <var>value</var> of <var>nodes</var>:
-
-  <ol>
-   <li><p>Let <var>newValue</var> be <var>value</var>.
-
-   <li><p>If <var>value</var> is a {{Text}} <a for=/>node</a> and <var>isScriptElement</var> is
-   true, then set <var>newValue</var> to a new {{Text}} <a for=/>node</a> whose
-   <a for=Node>node document</a> is <var>document</var> and <a for=CharacterData>data</a> is the
-   result of calling <a abstract-op>Get Trusted Type compliant string</a>, with {{TrustedScript}},
-   <var>document</var>'s <a>relevant global object</a>, <var>value</var>'s
-   <a for=CharacterData>data</a>, "<code>HTMLScriptElement text</code>", and "<code>script</code>".
-
-   <li><p>If <var>value</var> is a {{TrustedScript}}, then set <var>newValue</var> to a new {{Text}}
-   <a for=/>node</a> whose <a for=CharacterData>data</a> is <var>value</var>'s
-   <a for=TrustedScript>data</a> and <a for=Node>node document</a> is <var>document</var>.
-
-   <li><p><a for=list>Append</a> <var>newValue</var> to <var>newNodes</var>.
-  </ol>
-
- <li><p>If <var>newNodes</var> contains one <a for=/>node</a>, then set <var>node</var> to
- <var>newNodes</var>[0].
+ <li><p>If <var>nodes</var> contains one <a for=/>node</a>, then set <var>node</var> to
+ <var>nodes</var>[0].
 
  <li><p>Otherwise, set <var>node</var> to a new {{DocumentFragment}} <a for=/>node</a> whose
  <a for=Node>node document</a> is <var>document</var>, and then <a>append</a> each <a for=/>node</a>
- in <var>newNodes</var>, if any, to it.
+ in <var>nodes</var>, if any, to it.
 
  <li><p>Return <var>node</var>.
 </ol>
@@ -3173,9 +3145,9 @@ interface mixin ParentNode {
   readonly attribute Element? lastElementChild;
   readonly attribute unsigned long childElementCount;
 
-  [CEReactions, Unscopable] undefined prepend((Node or TrustedScript or DOMString)... nodes);
-  [CEReactions, Unscopable] undefined append((Node or TrustedScript or DOMString)... nodes);
-  [CEReactions, Unscopable] undefined replaceChildren((Node or TrustedScript or DOMString)... nodes);
+  [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
 
   Element? querySelector(DOMString selectors);
   [NewObject] NodeList querySelectorAll(DOMString selectors);
@@ -3249,8 +3221,8 @@ the number of <a for=tree>children</a> of <a>this</a> that are <a for=/>elements
 <p>The <dfn method for=ParentNode><code>prepend(<var>nodes</var>)</code></dfn> method steps are:
 
 <ol>
- <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given <a>this</a>,
- <var>nodes</var>, and <a>this</a>'s <a for=Node>node document</a>.
+ <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
+ <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
  <li><p><a>Pre-insert</a> <var>node</var> into <a>this</a> before <a>this</a>'s
  <a for=tree>first child</a>.
@@ -3259,8 +3231,8 @@ the number of <a for=tree>children</a> of <a>this</a> that are <a for=/>elements
 <p>The <dfn method for=ParentNode><code>append(<var>nodes</var>)</code></dfn> method steps are:
 
 <ol>
- <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given <a>this</a>,
- <var>nodes</var>, and <a>this</a>'s <a for=Node>node document</a>.
+ <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
+ <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
  <li><p><a>Append</a> <var>node</var> to <a>this</a>.
 </ol>
@@ -3269,8 +3241,8 @@ the number of <a for=tree>children</a> of <a>this</a> that are <a for=/>elements
 are:
 
 <ol>
- <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given <a>this</a>,
- <var>nodes</var>, and <a>this</a>'s <a for=Node>node document</a>.
+ <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given
+ <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
  <li><p><a>Ensure pre-insertion validity</a> of <var>node</var> into <a>this</a> before
  null.
@@ -3325,9 +3297,9 @@ steps are to return the first <a>following</a> <a for=tree>sibling</a> that is a
 
 <pre class=idl>
 interface mixin ChildNode {
-  [CEReactions, Unscopable] undefined before((Node or TrustedScript or DOMString)... nodes);
-  [CEReactions, Unscopable] undefined after((Node or TrustedScript or DOMString)... nodes);
-  [CEReactions, Unscopable] undefined replaceWith((Node or TrustedScript or DOMString)... nodes);
+  [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
+  [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
   [CEReactions, Unscopable] undefined remove();
 };
 DocumentType includes ChildNode;
@@ -3375,7 +3347,7 @@ CharacterData includes ChildNode;
  <a for=tree>sibling</a> not in <var>nodes</var>; otherwise null.
 
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a>, given
- <var>parent</var>, <var>nodes</var>, and <a>this</a>'s <a for=Node>node document</a>.
+ <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
  <li><p>If <var>viablePreviousSibling</var> is null, then set it to <var>parent</var>'s
  <a for=tree>first child</a>; otherwise to <var>viablePreviousSibling</var>'s
@@ -3396,7 +3368,7 @@ CharacterData includes ChildNode;
  <a for=tree>sibling</a> not in <var>nodes</var>; otherwise null.
 
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a>, given
- <var>parent</var>, <var>nodes</var>, and <a>this</a>'s <a for=Node>node document</a>.
+ <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
  <li><p><a>Pre-insert</a> <var>node</var> into <var>parent</var> before
  <var>viableNextSibling</var>.
@@ -3413,7 +3385,7 @@ CharacterData includes ChildNode;
  <a for=tree>sibling</a> not in <var>nodes</var>; otherwise null.
 
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a>, given
- <var>parent</var>, <var>nodes</var>, and <a>this</a>'s <a for=Node>node document</a>.
+ <var>nodes</var> and <a>this</a>'s <a for=Node>node document</a>.
 
  <li>
   <p>If <a>this</a>'s <a for=tree>parent</a> is <var>parent</var>, <a>replace</a> <a>this</a> with


### PR DESCRIPTION
This reverts commit 720a4fc20f0c7d9aa430ed418db92e474fdcf185.

These changes aren't needed given the current protection model used for script elements. See https://github.com/w3c/trusted-types/issues/537

- [ ] At least two implementers are interested (and none opposed):
   * …
   * WebKit (https://github.com/WebKit/WebKit/pull/31058)
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1299.html" title="Last updated on Jul 24, 2024, 1:36 PM UTC (561e804)">Preview</a> | <a href="https://whatpr.org/dom/1299/7c494e5...561e804.html" title="Last updated on Jul 24, 2024, 1:36 PM UTC (561e804)">Diff</a>