### PR TITLE
Editorial: Update use of WebIDL "invoke a callback function"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3658,8 +3658,8 @@ run these steps:
    <var>mo</var> from <var>node</var>'s <a>registered observer list</a>.
 
    <li><p>If <var>records</var> <a for=queue>is not empty</a>, then <a spec=webidl>invoke</a>
-   <var>mo</var>'s <a for=MutationObserver>callback</a> with « <var>records</var>, <var>mo</var> »,
-   and <var>mo</var>. If this throws an exception, catch it, and <a>report the exception</a>.
+   <var>mo</var>'s <a for=MutationObserver>callback</a> with « <var>records</var>, <var>mo</var> »
+   and "<code>report</code>", and with <a>callback this value</a> <var>mo</var>.
   </ol>
 
  <li><p><a for=set>For each</a> <var>slot</var> of <var>signalSet</var>, <a>fire an event</a> named


### PR DESCRIPTION
The single use, in mutation observers, no longer needs to deal with reporting the exception itself, but simply request that WebIDL do so.

Part of whatwg/webidl#1425.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed): n/a (no normative change)
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed: n/a (no normative change)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (no normative change)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
