### PR TITLE
Update to use new "report an exception" algorithm in HTML

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1643,8 +1643,8 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
 
     <ol>
      <li><p><a lt="report an exception">Report</a> <var>exception</var> for <var>listener</var>'s
-     <a for="event listener">callback</a>'s corresponding JavaScript object's <a>associated
-     realm</a>'s <a for="realm">global object</a>.
+     <a for="event listener">callback</a>'s corresponding JavaScript object's
+     <a>associated realm</a>'s <a for="realm">global object</a>.
 
      <li>
       <p>Set <var>legacyOutputDidListenersThrowFlag</var> if given.
@@ -6332,7 +6332,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <li><p><a lt="upgrade an element">Upgrade</a> <var>element</var> using <var>definition</var>.
     </ol>
 
-    <p>If this step threw an exception <var>exception</var>, then:</p>
+    <p>If this step threw an exception <var>exception</var>:
 
     <ol>
      <li><p><a lt="report an exception">Report</a> <var>exception</var> for <var>definition</var>'s
@@ -6350,7 +6350,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
  </li>
 
  <li>
-  <p>Otherwise, if <var>definition</var> is non-null, then:
+  <p>Otherwise, if <var>definition</var> is non-null:
 
   <ol>
    <li>
@@ -6393,7 +6393,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <li><p>Set <var>result</var>'s <a for=Element><code>is</code> value</a> to null.
     </ol>
 
-    <p>If any of these steps threw an exception <var>exception</var>, then:</p>
+    <p>If any of these steps threw an exception <var>exception</var>:
 
     <ol>
      <li><p><a lt="report an exception">Report</a> <var>exception</var> for <var>definition</var>'s

--- a/dom.bs
+++ b/dom.bs
@@ -1638,10 +1638,13 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
    <li>
     <p><a>Call a user object's operation</a> with <var>listener</var>'s
     <a for="event listener">callback</a>, "<code>handleEvent</code>", « <var>event</var> », and
-    <var>event</var>'s {{Event/currentTarget}} attribute value. If this throws an exception, then:
+    <var>event</var>'s {{Event/currentTarget}} attribute value. If this throws an exception
+    <var>exception</var>, then:
 
     <ol>
-     <li><p><a>Report the exception</a>.
+     <li><p><a lt="report an exception">Report</a> <var>exception</var> for <var>listener</var>'s
+     <a for="event listener">callback</a>'s corresponding JavaScript object's <a>associated
+     realm</a>'s <a for="realm">global object</a>.
 
      <li>
       <p>Set <var>legacyOutputDidListenersThrowFlag</var> if given.
@@ -6329,10 +6332,12 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <li><p><a lt="upgrade an element">Upgrade</a> <var>element</var> using <var>definition</var>.
     </ol>
 
-    <p>If this step threw an exception, then:</p>
+    <p>If this step threw an exception <var>exception</var>, then:</p>
 
     <ol>
-     <li><p><a>Report the exception</a>.
+     <li><p><a lt="report an exception">Report</a> <var>exception</var> for <var>definition</var>'s
+     <a for="custom element definition">constructor</a>'s corresponding JavaScript object's
+     <a>associated realm</a>'s <a for="realm">global object</a>.
 
      <li><p>Set <var>result</var>'s <a for=Element>custom element state</a> to
      "<code>failed</code>".
@@ -6388,10 +6393,12 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
      <li><p>Set <var>result</var>'s <a for=Element><code>is</code> value</a> to null.
     </ol>
 
-    <p>If any of these steps threw an exception, then:</p>
+    <p>If any of these steps threw an exception <var>exception</var>, then:</p>
 
     <ol>
-     <li><p><a>Report the exception</a>.
+     <li><p><a lt="report an exception">Report</a> <var>exception</var> for <var>definition</var>'s
+     <a for="custom element definition">constructor</a>'s corresponding JavaScript object's
+     <a>associated realm</a>'s <a for="realm">global object</a>.
 
      <li><p>Set <var>result</var> to a new <a for=/>element</a> that implements the
      {{HTMLUnknownElement}} interface, with no attributes, <a for=Element>namespace</a> set to the


### PR DESCRIPTION
It's necessary to specify which global these are reported to. This seems to be the event listener callback's realm's global in the event listener case, and the custom element constructor's realm, based on a combination of consistency with the related sites in HTML and browser behavior -- though browser behavior for custom elements isn't consistent in the (unusual) case of custom elements across realms.

Part of whatwg/html#10516.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed): Chrome, WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/5789341 (custom element upgrade)
   * https://chromium-review.googlesource.com/c/chromium/src/+/5784046 (event dispatch)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/359909516
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1378265
   * WebKit: n/a (WPTs seem to pass, except for customized built-in elements, which WebKit does not support)
   * Deno (only for aborting and events): n/a (I think)
   * Node.js (only for aborting and events): n/a (I think)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: n/a (this is a very nerdy detail, even for MDN)
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1303.html" title="Last updated on Aug 15, 2024, 3:11 PM UTC (e4d660b)">Preview</a> | <a href="https://whatpr.org/dom/1303/c499e71...e4d660b.html" title="Last updated on Aug 15, 2024, 3:11 PM UTC (e4d660b)">Diff</a>