### PR TITLE
Correct lookupPrefix() after fourteen years

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4899,23 +4899,39 @@ the interface <var>node</var> <a>implements</a>:
 
   <dl class=switch>
    <dt>{{Element}}
-   <dd><p>Return the result of <a>locating a namespace prefix</a> for it using <var>namespace</var>.
+   <dd><p>Return the result of <a>locating a namespace prefix</a> for <a>this</a> using
+   <var>namespace</var>.
 
    <dt>{{Document}}
-   <dd><p>Return the result of <a>locating a namespace prefix</a> for its <a>document element</a>,
-   if its <a>document element</a> is non-null; otherwise null.
+   <dd>
+    <ol>
+     <li><p>If <a>this</a>'s <a>document element</a> is null, then return null.
+
+     <li><p>Return the result of <a>locating a namespace prefix</a> for <a>this</a>'s
+     <a>document element</a> using <var>namespace</var>.
+    </ol>
 
    <dt>{{DocumentType}}
    <dt>{{DocumentFragment}}
    <dd><p>Return null.
 
    <dt>{{Attr}}
-   <dd><p>Return the result of <a>locating a namespace prefix</a> for its <a for=Attr>element</a>,
-   if its <a for=Attr>element</a> is non-null; otherwise null.
+   <dd>
+    <ol>
+     <li><p>If <a>this</a>'s <a for=Attr>element</a> is null, then return null.
+
+     <li><p>Return the result of <a>locating a namespace prefix</a> for <a>this</a>'s
+     <a for=Attr>element</a> using <var>namespace</var>.
+    </ol>
 
    <dt>Otherwise
-   <dd><p>Return the result of <a>locating a namespace prefix</a> for its <a>parent element</a>, if
-   its <a>parent element</a> is non-null; otherwise null.
+   <dd>
+    <ol>
+     <li><p>If <a>this</a>'s <a>parent element</a> is null, then return null.
+
+     <li><p>Return the result of <a>locating a namespace prefix</a> for <a>this</a>'s
+     <a>parent element</a> using <var>namespace</var>.
+    </ol>
   </dl>
 </ol>
 
@@ -10355,6 +10371,7 @@ Cyrille Tuzi,
 Dan Burzo,
 Daniel Clark,
 Daniel Glazman,
+Darien Maillet Valentine<!-- bhathos; GitHub -->,
 Darin Fisher,
 David Bruant,
 David Flanagan,
@@ -10432,7 +10449,7 @@ Manish Tripathi,
 Marcos Caceres,
 Mark Miller,
 Martijn van der Ven,
-Mason Freed,<!-- mfreed7; GitHub -->
+Mason Freed<!-- mfreed7; GitHub -->,
 Mats Palmgren,
 Mounir Lamouri,
 Michael Stramel,
@@ -10489,7 +10506,7 @@ Tobie Langel,
 Tom Pixley,
 Travis Leithead,
 Trevor Rowbotham,
-<i>triple-underscore</i><!--GitHub-->,
+<i>triple-underscore</i><!-- GitHub -->,
 Tristan Fraipont,
 Veli Şenol,
 Vidur Apparao,


### PR DESCRIPTION
Since it was introduced in https://github.com/whatwg/dom/commit/43213eda4f80407950a897cc0b654ded5615809e we never invoked locating a namespace prefix correctly.

Fixes #1302.

(Skipping the template as this is an obvious bug fix with existing test coverage.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1304.html" title="Last updated on Aug 13, 2024, 1:45 PM UTC (e8e6516)">Preview</a> | <a href="https://whatpr.org/dom/1304/809bfa2...e8e6516.html" title="Last updated on Aug 13, 2024, 1:45 PM UTC (e8e6516)">Diff</a>