### PR TITLE
Correct doAmazingness() example

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2122,6 +2122,8 @@ the following:
  could be as follows:
 
  <ol>
+  <li><p>Let |global| be [=this=]'s [=relevant global object=].
+
   <li><p>Let |p| be [=a new promise=].
 
   <li>
@@ -2149,7 +2151,8 @@ the following:
    <ol>
     <li><p>Let |amazingResult| be the result of doing some amazing things.
 
-    <li><p>[=/Resolve=] |p| with |amazingResult|.
+    <li><p>[=Queue a global task=] on the amazing task source given |global| to [=/resolve=] |p|
+    with |amazingResult|.
    </ol>
 
   <li><p>Return |p|.
@@ -10374,6 +10377,7 @@ Elliott Sprehn,
 Emilio Cobos Álvarez,
 Eric Bidelman,
 Erik Arvidsson,
+François Daoust<!-- tidoust; GitHub -->,
 François Remy<!-- FremyCompany; GitHub -->,
 Gary Kacmarcik,
 Gavin Nicol,


### PR DESCRIPTION
As this is a frequently made error, having it wrong in DOM does the community a disservice.

Fixes #1300.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1305.html" title="Last updated on Aug 13, 2024, 2:04 PM UTC (e1b39e0)">Preview</a> | <a href="https://whatpr.org/dom/1305/809bfa2...e1b39e0.html" title="Last updated on Aug 13, 2024, 2:04 PM UTC (e1b39e0)">Diff</a>