### PR TITLE
Corrected the variable's name from 'element' to 'result'.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6346,7 +6346,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
     catching any exceptions:
 
     <ol>
-     <li><p><a lt="upgrade an element">Upgrade</a> <var>element</var> using <var>definition</var>.
+     <li><p><a lt="upgrade an element">Upgrade</a> <var>result</var> using <var>definition</var>.
     </ol>
 
     <p>If this step threw an exception <var>exception</var>:


### PR DESCRIPTION
Matches the surroundings - there is no variable 'element'.
