### PR TITLE
Editorial: break from the inner invoke loop rather than returning

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1655,8 +1655,8 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
    <li><p>If <var>global</var> is a {{Window}} object, then set <var>global</var>'s
    <a for=Window>current event</a> to <var>currentEvent</var>.
 
-   <li><p>If <var>event</var>'s <a>stop immediate propagation flag</a> is set, then return
-   <var>found</var>.
+   <li><p>If <var>event</var>'s <a>stop immediate propagation flag</a> is set, then
+   <a for=iteration>break</a>.
   </ol>
 
  <li><p>Return <var>found</var>.


### PR DESCRIPTION
This is slightly cleaner and less confusing (to me anyway).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1325.html" title="Last updated on Nov 18, 2024, 11:00 AM UTC (08c84c0)">Preview</a> | <a href="https://whatpr.org/dom/1325/c2d5aa3...08c84c0.html" title="Last updated on Nov 18, 2024, 11:00 AM UTC (08c84c0)">Diff</a>