### PR TITLE
Editorial: unconjugate "pre-insertion" and "pre-removing"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2583,8 +2583,8 @@ steps:
 <h4 id=mutation-algorithms>Mutation algorithms</h4>
 
 <p>To
-<dfn export for=Node id=concept-node-ensure-pre-insertion-validity>ensure pre-insertion validity</dfn>
-of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:
+<dfn export for=Node id=concept-node-ensure-pre-insert-validity>ensure pre-insert validity</dfn> of
+a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:
 
 <ol>
  <li><p>If <var>parent</var> is not a {{Document}}, {{DocumentFragment}}, or {{Element}}
@@ -2638,7 +2638,7 @@ of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run the
 <var>parent</var> before a <var>child</var>, run these steps:
 
 <ol>
- <li><p><a>Ensure pre-insertion validity</a> of <var>node</var> into <var>parent</var> before
+ <li><p><a>Ensure pre-insert validity</a> of <var>node</var> into <var>parent</var> before
  <var>child</var>.
 
  <li><p>Let <var>referenceChild</var> be <var>child</var>.
@@ -3010,7 +3010,7 @@ optional <i>suppress observers flag</i>, run these steps:
 
  <li><p>For each {{NodeIterator}} object <var>iterator</var> whose
  <a for=traversal>root</a>'s <a for=Node>node document</a> is <var>node</var>'s
- <a for=Node>node document</a>, run the <a><code>NodeIterator</code> pre-removing steps</a> given
+ <a for=Node>node document</a>, run the <a><code>NodeIterator</code> pre-remove steps</a> given
  <var>node</var> and <var>iterator</var>.
 
  <li><p>Let <var>oldPreviousSibling</var> be <var>node</var>'s <a>previous sibling</a>.
@@ -3272,8 +3272,7 @@ are:
  <li><p>Let <var>node</var> be the result of <a>converting nodes into a node</a> given <a>this</a>,
  <var>nodes</var>, and <a>this</a>'s <a for=Node>node document</a>.
 
- <li><p><a>Ensure pre-insertion validity</a> of <var>node</var> into <a>this</a> before
- null.
+ <li><p><a>Ensure pre-insert validity</a> of <var>node</var> into <a>this</a> before null.
 
  <li><p><a for=Node>Replace all</a> with <var>node</var> within <a>this</a>.
 </ol>
@@ -9035,12 +9034,12 @@ result of <a for="live range">cloning the contents</a> of <a>this</a>.
  <!-- IE9 and Chrome 12 dev throw an exception before splitting the text
  node if the insertBefore() is going to throw an exception (at least if the
  new node is the parent of the start node, for instance). Firefox 4.0 and
- Opera 11.00 don't.  Now that we have "ensure pre-insertion validity," we go
+ Opera 11.00 don't.  Now that we have "ensure pre-insert validity," we go
  with the IE/Chrome behavior because it's more correct.
 
  IE9 doesn't call splitText() if the offset is 0. This makes sense, but I go
  with what all other browsers do. -->
- <li><a>Ensure pre-insertion validity</a>
+ <li><a>Ensure pre-insert validity</a>
  of <var>node</var> into <var>parent</var> before
  <var>referenceNode</var>.
 
@@ -9380,7 +9379,7 @@ filter matches any <a for=/>node</a>.
 <a for=traversal>active flag</a>, <a for=traversal>root</a>, <a for=traversal>whatToShow</a>, and
 <a for=traversal>filter</a> as well.
 
-<p>The <dfn><code>NodeIterator</code> pre-removing steps</dfn> given a <var>nodeIterator</var> and
+<p>The <dfn><code>NodeIterator</code> pre-remove steps</dfn> given a <var>nodeIterator</var> and
 <var>toBeRemovedNode</var>, are as follows:
 
 <ol>

--- a/dom.bs
+++ b/dom.bs
@@ -2582,9 +2582,8 @@ steps:
 
 <h4 id=mutation-algorithms>Mutation algorithms</h4>
 
-<p>To
-<dfn export for=Node id=concept-node-ensure-pre-insertion-validity>ensure pre-insert validity</dfn>
-of a <a for=/>node</a> <var>node</var> into a <a for=/>node</a> <var>parent</var> before a
+<p>To <dfn id=concept-node-ensure-pre-insertion-validity>ensure pre-insert validity</dfn> of a
+<a for=/>node</a> <var>node</var> into a <a for=/>node</a> <var>parent</var> before a
 <a for=/>node</a> <var>child</var>:
 
 <ol>

--- a/dom.bs
+++ b/dom.bs
@@ -9379,8 +9379,8 @@ filter matches any <a for=/>node</a>.
 <a for=traversal>active flag</a>, <a for=traversal>root</a>, <a for=traversal>whatToShow</a>, and
 <a for=traversal>filter</a> as well.
 
-<p>The <dfn id=nodeiterator-pre-removing-steps><code>NodeIterator</code> pre-remove steps</dfn> given a <var>nodeIterator</var> and
-<var>toBeRemovedNode</var>, are as follows:
+<p>The <dfn id=nodeiterator-pre-removing-steps><code>NodeIterator</code> pre-remove steps</dfn>
+given a <var>nodeIterator</var> and <var>toBeRemovedNode</var>, are as follows:
 
 <ol>
  <li><p>If <var>toBeRemovedNode</var> is not an <a for=tree>inclusive ancestor</a> of

--- a/dom.bs
+++ b/dom.bs
@@ -2584,7 +2584,8 @@ steps:
 
 <p>To
 <dfn export for=Node id=concept-node-ensure-pre-insertion-validity>ensure pre-insert validity</dfn>
-of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:
+of a <a for=/>node</a> <var>node</var> into a <a for=/>node</a> <var>parent</var> before a
+<a for=/>node</a> <var>child</var>:
 
 <ol>
  <li><p>If <var>parent</var> is not a {{Document}}, {{DocumentFragment}}, or {{Element}}
@@ -9039,8 +9040,7 @@ result of <a for="live range">cloning the contents</a> of <a>this</a>.
 
  IE9 doesn't call splitText() if the offset is 0. This makes sense, but I go
  with what all other browsers do. -->
- <li><a>Ensure pre-insert validity</a>
- of <var>node</var> into <var>parent</var> before
+ <li><a>Ensure pre-insert validity</a> of <var>node</var> into <var>parent</var> before
  <var>referenceNode</var>.
 
  <li>If <var>range</var>'s <a for=range>start node</a> is a {{Text}} <a for=/>node</a>, set

--- a/dom.bs
+++ b/dom.bs
@@ -2583,8 +2583,8 @@ steps:
 <h4 id=mutation-algorithms>Mutation algorithms</h4>
 
 <p>To
-<dfn export for=Node id=concept-node-ensure-pre-insert-validity>ensure pre-insert validity</dfn> of
-a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:
+<dfn export for=Node id=concept-node-ensure-pre-insertion-validity>ensure pre-insert validity</dfn>
+of a <var>node</var> into a <var>parent</var> before a <var>child</var>, run these steps:
 
 <ol>
  <li><p>If <var>parent</var> is not a {{Document}}, {{DocumentFragment}}, or {{Element}}

--- a/dom.bs
+++ b/dom.bs
@@ -9379,7 +9379,7 @@ filter matches any <a for=/>node</a>.
 <a for=traversal>active flag</a>, <a for=traversal>root</a>, <a for=traversal>whatToShow</a>, and
 <a for=traversal>filter</a> as well.
 
-<p>The <dfn><code>NodeIterator</code> pre-remove steps</dfn> given a <var>nodeIterator</var> and
+<p>The <dfn id=nodeiterator-pre-removing-steps><code>NodeIterator</code> pre-remove steps</dfn> given a <var>nodeIterator</var> and
 <var>toBeRemovedNode</var>, are as follows:
 
 <ol>


### PR DESCRIPTION
This PR is a follow-up that was identified from discussion in https://github.com/whatwg/dom/pull/1307.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1330.html" title="Last updated on Dec 12, 2024, 2:03 PM UTC (d7fb531)">Preview</a> | <a href="https://whatpr.org/dom/1330/7c494e5...d7fb531.html" title="Last updated on Dec 12, 2024, 2:03 PM UTC (d7fb531)">Diff</a>