### PR TITLE
Editorial: clarify document argument of "clone a node"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4611,6 +4611,9 @@ dom-Range-extractContents, dom-Range-cloneContents -->
    <dd><p>Do nothing.
   </dl>
 
+ <li><p>If <var>node</var> is a <a for=/>document</a>, then set <var>document</var> to
+ <var>copy</var>.
+
  <li><p>Set <var>copy</var>'s <a for=Node>node document</a> to <var>document</var>.
 
  <li><p>Run any <a>cloning steps</a> defined for <var>node</var> in


### PR DESCRIPTION
This argument is only passed recursively or from importNode(). And importNode() does not work for documents, so whenever the node argument is a document, the document argument has to be the node argument.

---

(I want to fix the other aspects of this algorithm too. But I thought I'd make this in isolation while I spotted it.)