### PR TITLE
Editorial: modernize "enqueue a custom element callback reaction"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5614,7 +5614,7 @@ these steps:
    <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
    <a>shadow-including inclusive descendants</a> that is <a for=Element>custom</a>,
    <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>, callback
-   name "<code>adoptedCallback</code>", and « <var>oldDocument</var>, <var>document</var>. »
+   name "<code>adoptedCallback</code>", and « <var>oldDocument</var>, <var>document</var> ».
    <!-- attributeChangedCallback is also old, then new -->
 
    <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s

--- a/dom.bs
+++ b/dom.bs
@@ -195,7 +195,7 @@ run these steps:
  <li><p>Let <var>localName</var> be <var>qualifiedName</var>.
 
  <li>
-  <p>If <var>qualifiedName</var> contains a U+003A (:), then:
+  <p>If <var>qualifiedName</var> contains a U+003A (:):
 
   <ol>
    <li><p>Let <var>splitResult</var> be the result of running <a>strictly split</a> given
@@ -565,8 +565,7 @@ was initialized to. When an <a>event</a> is created the attribute must be initia
    <a for=Event/path>invocation target</a> to <var>composedPath</var>.
 
    <li>
-    <p>If <var>path</var>[<var>index</var>]'s <a for=Event/path>slot-in-closed-tree</a> is true,
-    then:
+    <p>If <var>path</var>[<var>index</var>]'s <a for=Event/path>slot-in-closed-tree</a> is true:
 
     <ol>
      <li><p>Decrease <var>currentHiddenLevel</var> by 1.
@@ -595,8 +594,7 @@ was initialized to. When an <a>event</a> is created the attribute must be initia
    <a for=Event/path>invocation target</a> to <var>composedPath</var>.
 
    <li>
-    <p>If <var>path</var>[<var>index</var>]'s <a for=Event/path>root-of-closed-tree</a> is true,
-    then:
+    <p>If <var>path</var>[<var>index</var>]'s <a for=Event/path>root-of-closed-tree</a> is true:
 
     <ol>
      <li><p>Decrease <var>currentHiddenLevel</var> by 1.
@@ -1067,7 +1065,7 @@ steps:
  <li><p>Let |passive| and |signal| be null.
 
  <li>
-  <p>If |options| is a <a for=/>dictionary</a>, then:
+  <p>If |options| is a <a for=/>dictionary</a>:
 
   <ol>
    <li><p>Set |once| to |options|["{{AddEventListenerOptions/once}}"].
@@ -1309,7 +1307,7 @@ property of the event being dispatched.
 
  <li>
   <p>If <var>target</var> is not <var>relatedTarget</var> or <var>target</var> is <var>event</var>'s
-  <a for=Event>relatedTarget</a>, then:
+  <a for=Event>relatedTarget</a>:
 
   <ol>
    <li><p>Let <var>touchTargets</var> be a new <a for=/>list</a>.
@@ -1368,7 +1366,7 @@ property of the event being dispatched.
      <li>
       <p>If <var>parent</var> is a {{Window}} object, or <var>parent</var> is a <a for=/>node</a>
       and <var>target</var>'s <a for=tree>root</a> is a <a>shadow-including inclusive ancestor</a>
-      of <var>parent</var>, then:
+      of <var>parent</var>:
 
       <ol>
        <li><p>If <var>isActivationEvent</var> is true, <var>event</var>'s {{Event/bubbles}}
@@ -1384,9 +1382,11 @@ property of the event being dispatched.
      to null.
 
      <li>
-      <p>Otherwise, set <var>target</var> to <var>parent</var> and then:
+      <p>Otherwise:
 
       <ol>
+       <li><p>Set <var>target</var> to <var>parent</var>.
+
        <li><p>If <var>isActivationEvent</var> is true, <var>activationTarget</var> is null, and
        <var>target</var> has <a for=EventTarget>activation behavior</a>, then set
        <var>activationTarget</var> to <var>target</var>.
@@ -1462,7 +1462,7 @@ property of the event being dispatched.
  <a>stop immediate propagation flag</a>.
 
  <li>
-  <p>If <var>clearTargets</var>, then:
+  <p>If <var>clearTargets</var> is true:
 
   <ol>
    <li><p>Set <var>event</var>'s <a for=Event>target</a> to null.
@@ -1473,7 +1473,7 @@ property of the event being dispatched.
   </ol>
 
  <li>
-  <p>If <var>activationTarget</var> is non-null, then:
+  <p>If <var>activationTarget</var> is non-null:
 
   <ol>
    <li><p>If <var>event</var>'s <a>canceled flag</a> is unset, then run
@@ -1553,8 +1553,7 @@ run these steps:
  <var>legacyOutputDidListenersThrowFlag</var> if given.
 
  <li>
-  <p>If <var>found</var> is false and <var>event</var>'s {{Event/isTrusted}} attribute is true,
-  then:
+  <p>If <var>found</var> is false and <var>event</var>'s {{Event/isTrusted}} attribute is true:
 
   <ol>
    <li><p>Let <var>originalEventType</var> be <var>event</var>'s {{Event/type}} attribute value.
@@ -1617,7 +1616,7 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
    <li><p>Let <var>currentEvent</var> be undefined.
 
    <li>
-    <p>If <var>global</var> is a {{Window}} object, then:
+    <p>If <var>global</var> is a {{Window}} object:
 
     <ol>
      <li><p>Set <var>currentEvent</var> to <var>global</var>'s <a for=Window>current event</a>.
@@ -1636,7 +1635,7 @@ and an optional <var>legacyOutputDidListenersThrowFlag</var>, run these steps:
     <p><a>Call a user object's operation</a> with <var>listener</var>'s
     <a for="event listener">callback</a>, "<code>handleEvent</code>", « <var>event</var> », and
     <var>event</var>'s {{Event/currentTarget}} attribute value. If this throws an exception
-    <var>exception</var>, then:
+    <var>exception</var>:
 
     <ol>
      <li><p><a lt="report an exception">Report</a> <var>exception</var> for <var>listener</var>'s
@@ -2041,7 +2040,7 @@ an optional <var>reason</var>:
 
   <ol>
    <li>
-    <p>If <var>dependentSignal</var> is not [=AbortSignal/aborted=], then:
+    <p>If <var>dependentSignal</var> is not [=AbortSignal/aborted=]:
 
     <ol>
      <li><p>Set <var>dependentSignal</var>'s [=AbortSignal/abort reason=] to <var>signal</var>'s
@@ -2092,7 +2091,7 @@ interface that inherits from it, and a <var>realm</var>:
 
   <ol>
    <li>
-    <p>If <var>signal</var>'s [=AbortSignal/dependent=] is false, then:
+    <p>If <var>signal</var>'s [=AbortSignal/dependent=] is false:
 
     <ol>
      <li><p><a for=set>Append</a> <var>signal</var> to <var>resultSignal</var>'s
@@ -2155,7 +2154,7 @@ the following:
   <li><p>Let |p| be [=a new promise=].
 
   <li>
-   <p>If |options|["<code>signal</code>"] member is present, then:
+   <p>If |options|["<code>signal</code>"] <a for=map>exists</a>:
 
    <ol>
     <li><p>Let |signal| be |options|["<code>signal</code>"].
@@ -2388,7 +2387,7 @@ otherwise it is the empty string.</p>
 <ol>
  <li>
   <p>If <var>element</var> is a <a>slot</a>, <var>localName</var> is <code>name</code>, and
-  <var>namespace</var> is null, then:
+  <var>namespace</var> is null:
 
   <ol>
    <li><p>If <var>value</var> is <var>oldValue</var>, then return.
@@ -2426,7 +2425,7 @@ string). Unless stated otherwise it is the empty string.</p>
 
 <ol>
  <li>
-  <p>If <var>localName</var> is <code>slot</code> and <var>namespace</var> is null, then:
+  <p>If <var>localName</var> is <code>slot</code> and <var>namespace</var> is null:
 
   <ol>
    <li><p>If <var>value</var> is <var>oldValue</var>, then return.
@@ -2499,7 +2498,7 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
  <li><p>Let <var>host</var> be <var>root</var>'s <a for=DocumentFragment>host</a>.
 
  <li>
-  <p>If <var>root</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>", then:
+  <p>If <var>root</var>'s <a for=ShadowRoot>slot assignment</a> is "<code>manual</code>":
 
   <ol>
    <li><p>Let <var>result</var> be « ».
@@ -2546,8 +2545,7 @@ for a given <a>slot</a> <var>slot</var>, run these steps:</p>
 
   <ol>
    <li>
-    <p>If <var>node</var> is a <a>slot</a> whose <a for=tree>root</a> is a <a for=/>shadow root</a>,
-    then:
+    <p>If <var>node</var> is a <a>slot</a> whose <a for=tree>root</a> is a <a for=/>shadow root</a>:
 
     <ol>
      <li><p>Let <var>temporaryResult</var> be the result of <a>finding flattened slottables</a> given
@@ -2763,7 +2761,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
  <li><p>If <var>count</var> is 0, then return.
 
  <li>
-  <p>If <var>node</var> is a {{DocumentFragment}} <a for=/>node</a>, then:
+  <p>If <var>node</var> is a {{DocumentFragment}} <a for=/>node</a>:
 
   <ol>
    <li><p><a for=/>Remove</a> its <a for=tree>children</a> with the <i>suppress observers flag</i>
@@ -2778,7 +2776,7 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
   </ol>
 
  <li>
-  <p>If <var>child</var> is non-null, then:
+  <p>If <var>child</var> is non-null:
 
   <ol>
    <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>parent</var> and
@@ -2823,12 +2821,12 @@ before a <var>child</var>, with an optional <i>suppress observers flag</i>, run 
      <li><p>Run the <a>insertion steps</a> with <var>inclusiveDescendant</var>.
 
      <li>
-      <p>If <var>inclusiveDescendant</var> is <a>connected</a>, then:
+      <p>If <var>inclusiveDescendant</var> is <a>connected</a>:
 
       <ol>
        <li><p>If <var>inclusiveDescendant</var> is <a for=Element>custom</a>, then
        <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>,
-       callback name "<code>connectedCallback</code>", and an empty argument list.
+       callback name "<code>connectedCallback</code>", and « ».
 
        <li>
         <p>Otherwise, <a lt="try to upgrade an element">try to upgrade</a>
@@ -2939,7 +2937,7 @@ within a <var>parent</var>, run these steps:
  <li><p>Let <var>removedNodes</var> be the empty set.
 
  <li>
-  <p>If <var>child</var>'s <a for=tree>parent</a> is non-null, then:
+  <p>If <var>child</var>'s <a for=tree>parent</a> is non-null:
 
   <ol>
    <li><p>Set <var>removedNodes</var> to « <var>child</var> ».
@@ -3056,7 +3054,7 @@ optional <i>suppress observers flag</i>, run these steps:
  then run <a>signal a slot change</a> for <var>parent</var>.
 
  <li>
-  <p>If <var>node</var> has an <a>inclusive descendant</a> that is a <a>slot</a>, then:
+  <p>If <var>node</var> has an <a>inclusive descendant</a> that is a <a>slot</a>:
 
   <ol>
    <li><p>Run <a>assign slottables for a tree</a> with <var>parent</var>'s <a for=tree>root</a>.
@@ -3071,21 +3069,21 @@ optional <i>suppress observers flag</i>, run these steps:
  <li>
   <p>If <var>node</var> is <a for=Element>custom</a> and <var>isParentConnected</var> is true, then
   <a>enqueue a custom element callback reaction</a> with <var>node</var>, callback name
-  "<code>disconnectedCallback</code>", and an empty argument list.
+  "<code>disconnectedCallback</code>", and « ».
 
   <p class=note>It is intentional for now that <a for=Element>custom</a> <a for=/>elements</a> do
   not get <var>parent</var> passed. This might change in the future if there is a need.
 
  <li>
   <p>For each <a>shadow-including descendant</a> <var>descendant</var> of <var>node</var>, in
-  <a>shadow-including tree order</a>, then:
+  <a>shadow-including tree order</a>:
 
   <ol>
    <li><p>Run the <a>removing steps</a> with <var>descendant</var> and null.
 
    <li><p>If <var>descendant</var> is <a for=Element>custom</a> and <var>isParentConnected</var>
    is true, then <a>enqueue a custom element callback reaction</a> with <var>descendant</var>,
-   callback name "<code>disconnectedCallback</code>", and an empty argument list.
+   callback name "<code>disconnectedCallback</code>", and « ».
   </ol>
  </li>
 
@@ -4554,7 +4552,7 @@ dom-Range-extractContents, dom-Range-cloneContents -->
  <a for=Node>node document</a>.
 
  <li>
-  <p>If <var>node</var> is an <a for=/>element</a>, then:
+  <p>If <var>node</var> is an <a for=/>element</a>:
 
   <ol>
    <li><p>Let <var>copy</var> be the result of <a>creating an element</a>, given
@@ -4765,7 +4763,7 @@ steps are:
  and <var>node1</var> to <var>attr1</var>'s <a for=Attr>element</a>.
 
  <li>
-  <p>If <var>node2</var> is an <a>attribute</a>, then:
+  <p>If <var>node2</var> is an <a>attribute</a>:
 
   <ol>
    <li><p>Set <var>attr2</var> to <var>node2</var> and <var>node2</var> to <var>attr2</var>'s
@@ -4773,7 +4771,7 @@ steps are:
 
    <li>
     <p>If <var>attr1</var> and <var>node1</var> are non-null, and <var>node2</var> is
-    <var>node1</var>, then:
+    <var>node1</var>:
 
     <ol>
      <li>
@@ -5598,7 +5596,7 @@ these steps:
  <var>node</var>.
 
  <li>
-  <p>If <var>document</var> is not <var>oldDocument</var>, then:
+  <p>If <var>document</var> is not <var>oldDocument</var>:
 
   <ol>
    <li>
@@ -5616,8 +5614,8 @@ these steps:
    <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
    <a>shadow-including inclusive descendants</a> that is <a for=Element>custom</a>,
    <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>, callback
-   name "<code>adoptedCallback</code>", and an argument list containing <var>oldDocument</var> and
-   <var>document</var>. <!-- attributeChangedCallback is also old, then new -->
+   name "<code>adoptedCallback</code>", and « <var>oldDocument</var>, <var>document</var>. »
+   <!-- attributeChangedCallback is also old, then new -->
 
    <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
    <a>shadow-including inclusive descendants</a>, in <a>shadow-including tree order</a>, run the
@@ -6325,7 +6323,7 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
   <p>If <var>definition</var> is non-null, and <var>definition</var>'s
   <a for="custom element definition">name</a> is not equal to its
   <a for="custom element definition">local name</a> (i.e., <var>definition</var> represents a
-  <a>customized built-in element</a>), then:
+  <a>customized built-in element</a>):
 
   <ol>
    <li><p>Let <var>interface</var> be the <a>element interface</a> for <var>localName</var> and the
@@ -6493,9 +6491,8 @@ given a <var>document</var>, <var>localName</var>, <var>namespace</var>, and opt
 
  <li><p>If <var>element</var> is <a for=Element>custom</a>, then
  <a>enqueue a custom element callback reaction</a> with <var>element</var>, callback name
- "<code>attributeChangedCallback</code>", and an argument list containing <var>attribute</var>'s
- <a for=Attr>local name</a>, <var>oldValue</var>, <var>newValue</var>, and <var>attribute</var>'s
- <a for=Attr>namespace</a>.
+ "<code>attributeChangedCallback</code>", and « <var>attribute</var>'s <a for=Attr>local name</a>,
+ <var>oldValue</var>, <var>newValue</var>, <var>attribute</var>'s <a for=Attr>namespace</a> ».
 
  <li><p>Run the <a>attribute change steps</a> with <var>element</var>, <var>attribute</var>'s
  <a for=Attr>local name</a>, <var>oldValue</var>, <var>newValue</var>, and <var>attribute</var>'s
@@ -6970,7 +6967,7 @@ method steps are:
  <!-- This is step 2 of "get an attribute by name", modified as appropriate -->
 
  <li>
-  <p>If <var>attribute</var> is null, then:
+  <p>If <var>attribute</var> is null:
 
   <ol>
    <li><p>If <var>force</var> is not given or is true, create an <a>attribute</a> whose
@@ -7095,7 +7092,7 @@ a boolean <var>serializable</var>, a boolean <var>delegatesFocus</var>, and a st
 
  <li>
   <p>If <var>element</var>'s <a for=Element>local name</a> is a <a>valid custom element name</a>, or
-  <var>element</var>'s <a for=Element><code>is</code> value</a> is non-null, then:
+  <var>element</var>'s <a for=Element><code>is</code> value</a> is non-null:
 
   <ol>
    <li><p>Let <var>definition</var> be the result of
@@ -7110,7 +7107,7 @@ a boolean <var>serializable</var>, a boolean <var>delegatesFocus</var>, and a st
  </li>
 
  <li>
-  <p>If <var>element</var> is a <a for=Element>shadow host</a>, then:
+  <p>If <var>element</var> is a <a for=Element>shadow host</a>:
 
   <ol>
    <li><p>Let <var>currentShadowRoot</var> be <var>element</var>'s <a for=Element>shadow root</a>.
@@ -7747,7 +7744,7 @@ constructor steps are to set <a>this</a>'s <a for=CharacterData>data</a> to <var
  <a for=tree>parent</a>.
 
  <li>
-  <p>If <var>parent</var> is not null, then:
+  <p>If <var>parent</var> is not null:
 
   <ol>
    <li><p><a for=/>Insert</a> <var>new node</var> into <var>parent</var> before <var>node</var>'s
@@ -8573,8 +8570,8 @@ method steps are:
  <a for=range>end offset</a>, respectively.
 
  <li>
-  <p>If <var>original start node</var> is <var>original end node</var> and it is a
-  {{CharacterData}} <a for=/>node</a>, then:
+  <p>If <var>original start node</var> is <var>original end node</var> and it is a {{CharacterData}}
+  <a for=/>node</a>:
 
   <ol>
    <li>Let <var>clone</var> be a
@@ -8693,7 +8690,7 @@ method steps are:
   how it will have mutated. -->
 
  <li>
-  <p>If <var>first partially contained child</var> is a {{CharacterData}} <a for=/>node</a>, then:
+  <p>If <var>first partially contained child</var> is a {{CharacterData}} <a for=/>node</a>:
 
   <p class=note>In this case, <var>first partially contained child</var> is
   <var>original start node</var>.
@@ -8745,7 +8742,7 @@ method steps are:
  <var>fragment</var>.
 
  <li>
-  <p>If <var>last partially contained child</var> is a {{CharacterData}} <a for=/>node</a>, then:
+  <p>If <var>last partially contained child</var> is a {{CharacterData}} <a for=/>node</a>:
 
   <p class=note>In this case, <var>last partially contained child</var> is
   <var>original end node</var>.
@@ -8828,8 +8825,8 @@ of a <a>live range</a> <var>range</var>, run these steps:
  <a for=range>end offset</a>, respectively.
 
  <li>
-  <p>If <var>original start node</var> is <var>original end node</var> and it is a
-  {{CharacterData}} <a for=/>node</a>, then:
+  <p>If <var>original start node</var> is <var>original end node</var> and it is a {{CharacterData}}
+  <a for=/>node</a>:
 
   <ol>
    <li>Let <var>clone</var> be a <a lt="clone a node">clone</a> of
@@ -8904,7 +8901,7 @@ of a <a>live range</a> <var>range</var>, run these steps:
   cannot be the ancestor of anything.
 
  <li>
-  <p>If <var>first partially contained child</var> is a {{CharacterData}} <a for=/>node</a>, then:
+  <p>If <var>first partially contained child</var> is a {{CharacterData}} <a for=/>node</a>:
 
   <p class=note>In this case, <var>first partially contained child</var> is
   <var>original start node</var>.
@@ -8960,7 +8957,7 @@ of a <a>live range</a> <var>range</var>, run these steps:
   </ol>
 
  <li>
-  <p>If <var>last partially contained child</var> is a {{CharacterData}} <a for=/>node</a>, then:
+  <p>If <var>last partially contained child</var> is a {{CharacterData}} <a for=/>node</a>:
 
   <p class=note>In this case, <var>last partially contained child</var> is
   <var>original end node</var>.
@@ -9410,7 +9407,7 @@ given a <var>nodeIterator</var> and <var>toBeRemovedNode</var>, are as follows:
  <var>nodeIterator</var>'s <a for=traversal>root</a>, then return.
 
  <li>
-  <p>If <var>nodeIterator</var>'s <a for=NodeIterator>pointer before reference</a> is true, then:
+  <p>If <var>nodeIterator</var>'s <a for=NodeIterator>pointer before reference</a> is true:
 
   <ol>
    <li><p>Let <var>next</var> be <var>toBeRemovedNode</var>'s first <a>following</a>
@@ -9598,7 +9595,7 @@ method on {{Document}} objects.
    <a for=TreeWalker>current</a> to <var>node</var> and return <var>node</var>.
 
    <li>
-    <p>If <var>result</var> is {{NodeFilter/FILTER_SKIP}}, then:
+    <p>If <var>result</var> is {{NodeFilter/FILTER_SKIP}}:
 
     <ol>
      <li><p>Let <var>child</var> be <var>node</var>'s <a for=tree>first child</a> if <var>type</var>
@@ -10078,7 +10075,7 @@ method steps are:
  "{{InvalidCharacterError!!exception}}" {{DOMException}}.
 
  <li>
-  <p>If <a>this</a>'s <a>token set</a>[<var>token</var>] <a for=set>exists</a>, then:
+  <p>If <a>this</a>'s <a>token set</a>[<var>token</var>] <a for=set>exists</a>:
 
   <ol>
    <li><p>If <var>force</var> is either not given or is false, then <a for=set>remove</a>


### PR DESCRIPTION
Also no need for a trailing "then" when there are nested steps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1333.html" title="Last updated on Dec 12, 2024, 3:46 PM UTC (46470fc)">Preview</a> | <a href="https://whatpr.org/dom/1333/37fb987...46470fc.html" title="Last updated on Dec 12, 2024, 3:46 PM UTC (46470fc)">Diff</a>