### PR TITLE
Add definition for composed live range

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -22,6 +22,8 @@ urlPrefix: https://www.w3.org/TR/xml-names/#NT-
   text: QName; url: QName
 url: https://w3c.github.io/DOM-Parsing/#dom-range-createcontextualfragment
  type: method; text: createContextualFragment(); for: Range
+url: https://w3c.github.io/selection-api/#dom-selection-getrangeat
+ type: method; text: getRangeAt(); for: Range
 type: interface
  url: https://w3c.github.io/touch-events/#idl-def-touchevent
   text: TouchEvent
@@ -3027,6 +3029,14 @@ optional <i>suppress observers flag</i>, run these steps:
  <li><p>For each <a>live range</a> whose <a for=range>end node</a> is an <a>inclusive descendant</a>
  of <var>node</var>, set its <a for=range>end</a> to (<var>parent</var>, <var>index</var>).
 
+ <li><p>For each <a>composed live range</a> whose <a for=range>start node</a> is a
+ <a>shadow-including inclusive descendant</a> of <var>node</var>, set its <a for=range>start</a> to
+ (<var>parent</var>, <var>index</var>).
+
+ <li><p>For each <a>composed live range</a> whose <a for=range>end node</a> is an
+ <a>shadow-including inclusive descendant</a> of <var>node</var>, set its <a for=range>end</a> to
+ (<var>parent</var>, <var>index</var>).
+
  <li><p>For each <a>live range</a> whose <a for=range>start node</a> is <var>parent</var> and
  <a for=range>start offset</a> is greater than <var>index</var>, decrease its
  <a for=range>start offset</a> by 1.
@@ -5743,7 +5753,8 @@ are:
 <hr>
 
 <p>The <dfn method for=Document><code>createRange()</code></dfn> method steps are to return a new
-<a>live range</a> with (<a>this</a>, 0) as its <a for=range>start</a> an <a for=range>end</a>.
+{{Range}} <a>live range</a> with (<a>this</a>, 0) as its <a for=range>start</a> and <a
+for=range>end</a>.
 
 <p class=note>The {{Range/Range()}} constructor can be used instead.
 
@@ -7878,11 +7889,11 @@ range.setEnd(secondText, 4)
 <a>node tree</a> above cannot be represented by a <a>range</a>. <a>Ranges</a> are only useful for
 <a for=/>nodes</a>.
 
-<p>{{Range}} objects, unlike {{StaticRange}} objects, are affected by mutations to the
-<a>node tree</a>. Therefore they are also known as <a>live ranges</a>. Such mutations will not
-invalidate them and will try to ensure that it still represents the same piece of content.
-Necessarily, a <a>live range</a> might itself be modified as part of the mutation to the
-<a>node tree</a> when, e.g., part of the content it represents is mutated.
+<p>{{Range}} objects, unlike {{StaticRange}} objects, are affected by mutations to the <a>node
+tree</a>. Therefore they are <a>live ranges</a>. Such mutations will not invalidate them and will
+try to ensure that it still represents the same piece of content. Necessarily, a <a>live range</a>
+might itself be modified as part of the mutation to the <a>node tree</a> when, e.g., part of the
+content it represents is mutated.
 
 <p class=note>See the <a for=/>insert</a> and <a for=/>remove</a> algorithms, the
 {{Node/normalize()}} method, and the <a>replace data</a> and <a lt="split a Text node">split</a>
@@ -8109,12 +8120,22 @@ interface Range : AbstractRange {
 };
 </pre>
 
-<p>Objects implementing the {{Range}} interface are known as
-<dfn export id=concept-live-range>live ranges</dfn>.
+<p>A <dfn export id=concept-live-range>live range</dfn> is a <a>range</a> that is affected by
+mutations to the <a>node tree</a>.</p>
+
+<p>Objects implementing the {{Range}} interface are <a>live ranges</a>.
 
 <p class=note>Algorithms that modify a <a>tree</a> (in particular the <a for=/>insert</a>,
 <a for=/>remove</a>, <a>replace data</a>, and <a lt="split a Text node">split</a> algorithms) modify
-<a>live ranges</a> associated with that <a>tree</a>.
+<a>live ranges</a> associated with that <a>tree</a>.</p>
+
+<p>A <dfn export id=concept-composed-live-range>composed live range</dfn> is a <a>live range</a>
+that has one associated {{Range}} object - <dfn export
+id=concept-composed-live-range-cached-live-range for="composed live range">cached live
+range</dfn>.</p>
+
+<p class=note>The <a>cached live range</a> is used to maintain backward compatibility with the
+{{getRangeAt}} API.</p>
 
 <p>The <dfn export id=concept-range-root for="live range">root</dfn> of a <a>live range</a> is the
 <a for=tree>root</a> of its <a for=range>start node</a>.
@@ -8184,7 +8205,7 @@ but not its <a for=range>end node</a>, or vice versa.
 
 <dl class=domintro>
  <dt><code><var>range</var> = new <a constructor>Range()</a></code>
- <dd>Returns a new <a>live range</a>.
+ <dd>Returns a new {{Range}} <a>live range</a>.
 </dl>
 
 <p>The <dfn constructor for=Range lt="Range()"><code>new Range()</code></dfn> constructor steps are
@@ -8249,6 +8270,10 @@ steps:
 
      <li>Set <var>range</var>'s
      <a for=range>start</a> to <var>bp</var>.
+
+     <li>If <var>range</var> is the associated <a>cached live range</a> of a <a>composed live
+     range</a> <var>composed live range</var>, set <var>composed live range</var>’s <a
+     for="range">start</a> to <var>bp</var>.
     </ol>
    <dt>If these steps were invoked as "set the end"
    <dd>
@@ -8264,6 +8289,10 @@ steps:
 
      <li>Set <var>range</var>'s
      <a for=range>end</a> to <var>bp</var>.
+
+     <li>If <var>range</var> is the associated <a>cached live range</a> of a <a>composed live range</a>
+     <var>composed live range</var>, set <var>composed live range</var>’s <a for="range">end</a> to
+     <var>bp</var>.
     </ol>
   </dl>
 </ol>
@@ -8544,8 +8573,8 @@ method steps are:
  (<var>new node</var>, <var>new offset</var>).
 </ol>
 
-<p>To <dfn export id=concept-range-extract for="live range">extract</dfn> a <a>live range</a>
-<var>range</var>, run these steps:
+<p>To <dfn export id=concept-range-extract for="live range">extract</dfn> a {{Range}} <a>live
+range</a> <var>range</var>, run these steps:
 
 <ol>
  <li><p>Let <var>fragment</var> be a new {{DocumentFragment}} <a for=/>node</a> whose
@@ -8721,7 +8750,7 @@ method steps are:
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>live range</a>
+   <li>Let <var>subrange</var> be a new {{Range}} <a>live range</a>
    whose <a for=range>start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
    whose <a for=range>end</a> is
@@ -8775,7 +8804,7 @@ method steps are:
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>live range</a>
+   <li>Let <var>subrange</var> be a new {{Range}} <a>live range</a>
    whose <a for=range>start</a> is
    (<var>last partially contained child</var>, 0) and whose
    <a for=range>end</a> is
@@ -8800,7 +8829,7 @@ result of <a for="live range">extracting</a> <a>this</a>.
 
 <p>To
 <dfn export id=concept-range-clone for="live range" lt="clone the contents|cloning the contents">clone the contents</dfn>
-of a <a>live range</a> <var>range</var>, run these steps:
+of a {{Range}} <a>live range</a> <var>range</var>, run these steps:
 
 <ol>
  <li><p>Let <var>fragment</var> be a new {{DocumentFragment}} <a for=/>node</a> whose
@@ -8928,7 +8957,7 @@ of a <a>live range</a> <var>range</var>, run these steps:
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>live range</a>
+   <li>Let <var>subrange</var> be a new {{Range}} <a>live range</a>
    whose <a for=range>start</a> is
    (<var>original start node</var>, <var>original start offset</var>) and
    whose <a for=range>end</a> is
@@ -8986,7 +9015,7 @@ of a <a>live range</a> <var>range</var>, run these steps:
    <li><a>Append</a> <var>clone</var>
    to <var>fragment</var>.
 
-   <li>Let <var>subrange</var> be a new <a>live range</a>
+   <li>Let <var>subrange</var> be a new {{Range}} <a>live range</a>
    whose <a for=range>start</a> is
    (<var>last partially contained child</var>, 0) and whose
    <a for=range>end</a> is
@@ -9006,7 +9035,7 @@ of a <a>live range</a> <var>range</var>, run these steps:
 result of <a for="live range">cloning the contents</a> of <a>this</a>.
 
 <p>To <dfn export id=concept-range-insert for="live range">insert</dfn> a <a for=/>node</a>
-<var>node</var> into a <a>live range</a> <var>range</var>, run these steps:
+<var>node</var> into a {{Range}} <a>live range</a> <var>range</var>, run these steps:
 
 <ol>
  <li>If <var>range</var>'s <a for=range>start node</a> is a {{ProcessingInstruction}} or {{Comment}}
@@ -9156,7 +9185,8 @@ check first thing, which matches everyone but Firefox.
 </ol>
 
 <p>The <dfn method for=Range><code>cloneRange()</code></dfn> method steps are to return a new
-<a>live range</a> with the same <a for=range>start</a> and <a for=range>end</a> as <a>this</a>.
+{{Range}} <a>live range</a> with the same <a for=range>start</a> and <a for=range>end</a> as
+<a>this</a>.
 
 <p>The <dfn method for=Range><code>detach()</code></dfn> method steps are to do nothing.
 <span class=note>Its functionality (disabling a {{Range}} object) was removed, but the method itself
@@ -10408,6 +10438,7 @@ David Håsäther,
 David Hyatt,
 Deepak Sherveghar,
 Dethe Elza,
+Di Zhang,
 Dimitri Glazkov,
 Domenic Denicola,
 Dominic Cooney,


### PR DESCRIPTION
As discussed at TPAC 2024, the specification for the new getComposedRanges() API need the introduction of the new definition "Composed live range" [1], which should react to mutations. This PR attempts to define that new concept. Once landed, we will add the spec language that uses composed live range in the Selection API. An overview of the spec changes necessary can be found at [2].

[1] https://github.com/w3c/selection-api/issues/2#issuecomment-2427784793
[2] https://github.com/dizhang168/shadow-dom-selection/blob/main/selection-api-spec-changes.md

- [x] At least two implementers are interested (and none opposed):
   * Chromium: Positive
   * Webkit: Positive (https://github.com/mozilla/standards-positions/issues/1055)
   * Gecko: Positive (https://github.com/WebKit/standards-positions/issues/376)
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
