### PR TITLE
Meta: export "signal abort"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2024,8 +2024,8 @@ object <var>signal</var>:
 </div>
 
 <div algorithm>
-<p>To <dfn for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object <var>signal</var> and
-an optional <var>reason</var>:
+<p>To <dfn export for=AbortSignal>signal abort</dfn>, given an {{AbortSignal}} object
+<var>signal</var> and an optional <var>reason</var>:
 
 <ol>
  <li><p>If <var>signal</var> is [=AbortSignal/aborted=], then return.


### PR DESCRIPTION
I want to use this for a spec which can abort for both internal reasons and from a developer- provided AbortSignal. I create a dependent abort signal from the internal abort signal and the developer-provided one, and "signal abort" on the internal one appropriately. Then the rest of the spec can just worry about the dependent one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1354.html" title="Last updated on Feb 6, 2025, 6:30 AM UTC (cce2430)">Preview</a> | <a href="https://whatpr.org/dom/1354/e6bb175...cce2430.html" title="Last updated on Feb 6, 2025, 6:30 AM UTC (cce2430)">Diff</a>