### PR TITLE
Update an attribute's node document

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6553,6 +6553,9 @@ steps:
 
  <li><p>Set <var>attribute</var>'s <a for=Attr>element</a> to <var>element</var>.
 
+ <li><p>Set <var>attribute</var>'s <a for=Node>node document</a> to <var>element</var>'s
+ <a for=Node>node document</a>.
+
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>, null, and
  <var>attribute</var>'s <a for=Attr>value</a>.
 </ol>
@@ -6581,6 +6584,9 @@ steps:
 
  <li><p>Set <var>newAttr</var>'s <a for=Attr>element</a> to <var>oldAttr</var>'s
  <a for=Attr>element</a>.
+
+ <li><p>Set <var>newAttr</var>'s <a for=Node>node document</a> to <var>oldAttr</var>'s
+ <a for=Attr>element</a>'s <a for=Node>node document</a>.
 
  <li><p>Set <var>oldAttr</var>'s <a for=Attr>element</a> to null.
 
@@ -7473,7 +7479,7 @@ to as <em>content attributes</em> to avoid confusion with IDL attributes.
 
 <p class=note>User agents could have this as an internal slot as an optimization.
 
-When an <a>attribute</a> is created, its
+<p>When an <a>attribute</a> is created, its
 <a for=Attr>local name</a> is given. Unless explicitly
 given when an <a>attribute</a> is created, its
 <a for=Attr>namespace</a>,
@@ -7481,7 +7487,7 @@ given when an <a>attribute</a> is created, its
 <a for=Attr>element</a> are set to null, and its
 <a for=Attr>value</a> is set to the empty string.
 
-An
+<p>An
 <dfn export id=concept-named-attribute lt="named attribute"><code><var>A</var></code> attribute</dfn>
 is an <a>attribute</a> whose
 <a for=Attr>local name</a> is

--- a/dom.bs
+++ b/dom.bs
@@ -6576,22 +6576,23 @@ steps:
 </ol>
 
 <p>To <dfn export id=concept-element-attributes-replace lt="replace an attribute">replace</dfn> an
-<a>attribute</a> <var>oldAttr</var> with an <a>attribute</a> <var>newAttr</var>, run these steps:
+<a>attribute</a> <var>oldAttribute</var> with an <a>attribute</a> <var>newAttribute</var>:
 
 <ol>
- <li><p><a for=list>Replace</a> <var>oldAttr</var> by <var>newAttr</var> in <var>oldAttr</var>'s
- <a for=Attr>element</a>'s <a for=Element>attribute list</a>.
+ <li><p>Let <var>element</var> be <var>oldAttribute</var>'s <a for=Attr>element</a>.</p></li>
 
- <li><p>Set <var>newAttr</var>'s <a for=Attr>element</a> to <var>oldAttr</var>'s
- <a for=Attr>element</a>.
+ <li><p><a for=list>Replace</a> <var>oldAttribute</var> by <var>newAttribute</var> in
+ <var>element</var>'s <a for=Element>attribute list</a>.
 
- <li><p>Set <var>newAttr</var>'s <a for=Node>node document</a> to <var>oldAttr</var>'s
- <a for=Attr>element</a>'s <a for=Node>node document</a>.
+ <li><p>Set <var>newAttribute</var>'s <a for=Attr>element</a> to <var>element</var>.
 
- <li><p>Set <var>oldAttr</var>'s <a for=Attr>element</a> to null.
+ <li><p>Set <var>newAttribute</var>'s <a for=Node>node document</a> to <var>element</var>'s
+ <a for=Node>node document</a>.
 
- <li><p><a>Handle attribute changes</a> for <var>oldAttr</var> with <var>newAttr</var>'s
- <a for=Attr>element</a>, <var>oldAttr</var>'s <a for=Attr>value</a>, and <var>newAttr</var>'s
+ <li><p>Set <var>oldAttribute</var>'s <a for=Attr>element</a> to null.
+
+ <li><p><a>Handle attribute changes</a> for <var>oldAttribute</var> with <var>element</var>,
+ <var>oldAttribute</var>'s <a for=Attr>value</a>, and <var>newAttribute</var>'s
  <a for=Attr>value</a>.
 </ol>
 


### PR DESCRIPTION
When an attribute is appended to an element or is replacing an existing attribute, we need to ensure that its node document remains accurate.

Fixes #1359.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1360.html" title="Last updated on Feb 20, 2025, 4:19 PM UTC (1a6322c)">Preview</a> | <a href="https://whatpr.org/dom/1360/cbf4c0d...1a6322c.html" title="Last updated on Feb 20, 2025, 4:19 PM UTC (1a6322c)">Diff</a>