### PR TITLE
Add part attribute and note that part and exportparts are superglobal

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6514,6 +6514,7 @@ interface Element : Node {
   [CEReactions] attribute DOMString className;
   [SameObject, PutForwards=value] readonly attribute DOMTokenList classList;
   [CEReactions, Unscopable] attribute DOMString slot;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList part;
 
   boolean hasAttributes();
   [SameObject] readonly attribute NamedNodeMap attributes;
@@ -7152,6 +7153,10 @@ claims as to whether using them is conforming or not.
  <dt><code><var>element</var> . <a attribute for=Element>slot</a> [ = <var>value</var> ]</code>
  <dd><p>Returns the value of <var>element</var>'s <code>slot</code> content attribute. Can be set to
  change it.
+
+ <dt><code><var>element</var> . <a attribute for=Element>part</a></code>
+ <dd><p>Allows for manipulation of <var>element</var>'s <code>part</code> content attribute as a
+ set of whitespace-separated tokens through a {{DOMTokenList}} object.
 </dl>
 
 <p>IDL attributes that are defined to <dfn for=Attr id=concept-reflect>reflect</dfn> a string
@@ -7182,9 +7187,14 @@ particular {{DOMTokenList}} object are also known as the <a for=/>element</a>'s
 <p>The <dfn attribute for=Element><code>slot</code></dfn> attribute must <a for=Attr>reflect</a>
 "<code>slot</code>".
 
-<p class=note><code>id</code>, <code>class</code>, and <code>slot</code> are effectively
-superglobal attributes as they can appear on any element, regardless of that element's
-namespace.</p>
+<p>The <dfn attribute for=Element><code>part</code></dfn> getter steps are to return a
+{{DOMTokenList}} object whose associated <a for=/>element</a> is <a>this</a> and whose associated
+<a>attribute</a>'s <a for=Attr>local name</a> is <code>part</code>. The <a>token set</a> of this
+particular {{DOMTokenList}} object are also known as the <a for=/>element</a>'s parts.
+
+<p class=note><code>id</code>, <code>class</code>, <code>slot</code>, <code>part</code>, and
+<code>exportparts</code> are effectively superglobal attributes as they can appear on any element,
+regardless of that element's namespace.</p>
 
 <hr>
 
@@ -10836,6 +10846,7 @@ Chris Rebert,
 Cyrille Tuzi,
 Dan Burzo,
 Daniel Clark,
+Daniel Ethridge, <!-- wlib on GitHub -->
 Daniel Glazman,
 Darien Maillet Valentine<!-- bhathos; GitHub -->,
 Darin Fisher,


### PR DESCRIPTION
<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

`part` and `exportparts` were the (I hope) only two attributes that I missed in https://github.com/wlib/html-info due to them not appearing in [the spec](https://dom.spec.whatwg.org/#:~:text=id%2C%20class%2C%20and%20slot%20are%20effectively%20superglobal,.). There was [an issue](https://github.com/w3c/csswg-drafts/issues/3424) filed in 2018 asking to add `part` as a superglobal attribute to the DOM spec. This PR also notes that `exportparts` is a superglobal attribute, but does not make any references to its functionality. I want to ask whether this PR is desirable in the first place because other attributes like those defined in ARIA (e.g. `role` and `aria-label`) also are superglobal with corresponding IDL attributes defined on `Element`. I think that having a table that indexes all of the attributes in one place would be desirable, but it's unclear which spec such an index should live in.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
