### PR TITLE
Allow passing null for customElementRegistry

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6598,7 +6598,7 @@ dictionary ShadowRootInit {
   SlotAssignmentMode slotAssignment = "named";
   boolean clonable = false;
   boolean serializable = false;
-  CustomElementRegistry customElementRegistry;
+  CustomElementRegistry customElementRegistry? = null;
 };
 </pre>
 
@@ -7509,8 +7509,8 @@ are:
 <ol>
  <li><p>Let <var>registry</var> be <a>this</a>'s <a for=Element>custom element registry</a>.
 
- <li><p>If <var>init</var>["{{ShadowRootInit/customElementRegistry}}"] <a for=map>exists</a>, then
- set <var>registry</var> to it.
+ <li><p>If <var>init</var>["{{ShadowRootInit/customElementRegistry}}"] is non-null, then set
+ <var>registry</var> to it.
 
  <li><p>Run <a>attach a shadow root</a> with <a>this</a>,
  <var>init</var>["{{ShadowRootInit/mode}}"], <var>init</var>["{{ShadowRootInit/clonable}}"],


### PR DESCRIPTION
Apparently people are passing a ShadowRoot instance as the argument to attachShadow().

Context: https://bugs.webkit.org/show_bug.cgi?id=295174. We'll add tests as part of fixing this in WebKit.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * WebKit
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * See above.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Doesn't have an implementation yet.
   * Gecko: Doesn't have an implementation yet.
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=295174
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
