### PR TITLE
Link exposed to the WebIDL definition, remove potentially confusing note

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6090,12 +6090,9 @@ are:
   {{DOMException}}.
 
  <li>
-  <p>If the interface indicated by <var>constructor</var> is not exposed on the
-  <a>relevant global object</a> of <a>this</a>, then <a>throw</a> a
+  <p>If the interface indicated by <var>constructor</var> is not <a>exposed</a> on the
+  <a>relevant realm</a> of <a>this</a>, then <a>throw</a> a
   "{{NotSupportedError!!exception}}" {{DOMException}}.
-
-  <p class=note>Typically user agents disable support for touch events in some configurations, in
-  which case this clause would be triggered for the interface {{TouchEvent}}.
 
  <li><p>Let <var>event</var> be the result of <a>creating an event</a> given <var>constructor</var>.
 


### PR DESCRIPTION
I recently implemented this, and noticed that this could be linked, so this does that. However, on deeper investigation, I did notice that browsers didn't behave as I expected for [DeviceMotionEvent](https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion) since that is only exposed in secure contexts.

I expected browsers to throw on `document.createEvent('devicemotionevent')` like they do for `new DeviceMotionEvent('foo')` in non secure contexts, but from some limited testing they seem to not do that.

Since the intent of the spec reads to throw in this situation, I'm just removing the spec note here which seems to indicate it only applies for TouchEvent and will write a corresponding WPT test if this change is fine.

Sidenote: [TouchEvent](https://w3c.github.io/touch-events/#idl-def-touchevent) by strict reading of the IDL is always exposed on window in the IDL definition and the spec instead uses a [separate implementation defined boolean](https://w3c.github.io/touch-events/#conditionally-exposing-legacy-touch-event-apis) which reads to only apply for the mixin, so this wouldn't apply here. But that seems to not reflect with the intent of the touch events spec, and now that specification is unmaintained.

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1391.html" title="Last updated on Jul 19, 2025, 5:11 AM UTC (1165398)">Preview</a> | <a href="https://whatpr.org/dom/1391/1b4bd48...1165398.html" title="Last updated on Jul 19, 2025, 5:11 AM UTC (1165398)">Diff</a>