### PR TITLE
Remove mentions of XSLT from the DOM spec

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -11295,34 +11295,6 @@ methods on {{Document}}.
 
 
 
-<h2 id=xslt>XSLT</h2>
-
-<p class=XXX><cite>XSL Transformations (XSLT)</cite> is a language for transforming XML documents
-into other XML documents. The APIs defined in this section have been widely implemented, and are
-maintained here so that they can be updated when <cite>Web IDL</cite> changes. Complete definitions
-of these APIs remain necessary and such work is tracked and can be contributed to in
-<a href="https://github.com/whatwg/dom/issues/181">whatwg/dom#181</a>. [[XSLT]]
-
-
-<h3 id=interface-xsltprocessor>Interface {{XSLTProcessor}}</h3>
-
-<pre class=idl>
-[Exposed=Window]
-interface XSLTProcessor {
-  constructor();
-  undefined importStylesheet(Node style);
-  [CEReactions] DocumentFragment transformToFragment(Node source, Document output);
-  [CEReactions] Document transformToDocument(Node source);
-  undefined setParameter([LegacyNullToEmptyString] DOMString namespaceURI, DOMString localName, any value);
-  any getParameter([LegacyNullToEmptyString] DOMString namespaceURI, DOMString localName);
-  undefined removeParameter([LegacyNullToEmptyString] DOMString namespaceURI, DOMString localName);
-  undefined clearParameters();
-  undefined reset();
-};
-</pre>
-
-
-
 <h2 id=security-and-privacy>Security and privacy considerations</h2>
 
 <p>There are no known security or privacy considerations for this standard.
@@ -11353,6 +11325,7 @@ interface XSLTProcessor {
  <li><dfn><code>RangeException</code></dfn>
  <li><dfn><code>TypeInfo</code></dfn>
  <li><dfn><code>UserDataHandler</code></dfn>
+ <li><dfn><code>XSLTProcessor</code></dfn>
 </ul>
 
 <p>And these interface members have been removed:


### PR DESCRIPTION
This goes along with https://github.com/whatwg/html/pull/11563.

Closes https://github.com/whatwg/dom/issues/181.

- [X] At least two implementers are interested (and none opposed):
   * Chromium - supportive
   * Gecko - supportive
   * WebKit - supportive
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://chromium-review.googlesource.com/c/chromium/src/+/7027778
- [X] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/435623334
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1990759
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=300785
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. 

Corresponding HTML spec PR: https://github.com/whatwg/html/pull/11563

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 3, 2026, 8:46 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmfreed7%2Fdom%2F1ffe24652d958826688f45b7caa614127a2395f5%2Fdom.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%201400)

**Error output:**

```json
[
    {
        "lineNum": null,
        "messageType": "warning",
        "text": "Skipped generating some MDN panels, because the following IDs weren't present in the document. Use `Ignore MDN Failure` if this is expected.\n  #dom-xsltprocessor-xsltprocessor\n  #dom-xsltprocessor-clearparameters\n  #dom-xsltprocessor-getparameter\n  #dom-xsltprocessor-importstylesheet\n  #dom-xsltprocessor-removeparameter\n  #dom-xsltprocessor-reset\n  #dom-xsltprocessor-setparameter\n  #dom-xsltprocessor-transformtodocument\n  #dom-xsltprocessor-transformtofragment\n  #interface-xsltprocessor"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/dom%231400.)._

</details>
