### PR TITLE
Set registry on null registry element on adopt instead of on insert

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6016,8 +6016,8 @@ algorithm is passed <var ignore>node</var> and <var ignore>oldDocument</var>, as
 </div>
 
 <div algorithm>
-<p>To <dfn export id=concept-node-adopt>adopt</dfn> a <var>node</var> into a <var>document</var>, run
-these steps:
+<p>To <dfn export id=concept-node-adopt>adopt</dfn> a <a for=/>node</a> <var>node</var> into a
+<a for=/>document</a> <var>document</var>:
 
 <ol>
  <li><p>Let <var>oldDocument</var> be <var>node</var>'s <a for=Node>node document</a>.
@@ -6030,8 +6030,8 @@ these steps:
 
   <ol>
    <li>
-    <p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
-    <a>shadow-including inclusive descendants</a>:
+    <p>For each <var>inclusiveDescendant</var> of <var>node</var>'s
+    <a>shadow-including inclusive descendants</a>, in <a>shadow-including tree order</a>:
 
     <ol>
      <li><p>Set <var>inclusiveDescendant</var>'s <a for=Node>node document</a> to <var>document</var>.
@@ -6067,14 +6067,15 @@ these steps:
       </ol>
     </ol>
 
-   <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
-   <a>shadow-including inclusive descendants</a> that is <a for=Element>custom</a>,
-   <a>enqueue a custom element callback reaction</a> with <var>inclusiveDescendant</var>, callback
-   name "<code>adoptedCallback</code>", and « <var>oldDocument</var>, <var>document</var> ».
+   <li><p>For each <var>inclusiveDescendant</var> of <var>node</var>'s
+   <a>shadow-including inclusive descendants</a> that is <a for=Element>custom</a>, in
+   <a>shadow-including tree order</a>: <a>enqueue a custom element callback reaction</a> with
+   <var>inclusiveDescendant</var>, callback name "<code>adoptedCallback</code>", and
+   « <var>oldDocument</var>, <var>document</var> ».
    <!-- attributeChangedCallback is also old, then new -->
 
-   <li><p>For each <var>inclusiveDescendant</var> in <var>node</var>'s
-   <a>shadow-including inclusive descendants</a>, in <a>shadow-including tree order</a>, run the
+   <li><p>For each <var>inclusiveDescendant</var> of <var>node</var>'s
+   <a>shadow-including inclusive descendants</a>, in <a>shadow-including tree order</a>: run the
    <a>adopting steps</a> with <var>inclusiveDescendant</var> and <var>oldDocument</var>.
   </ol>
 </ol>


### PR DESCRIPTION
<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

In order to support scenarios for elements with a null custom element registry without shadow DOM, we decided to modify the behavior when it comes to setting registry on null registry element. By setting the registry on adopt instead of on insert allows us to have null registry element in light DOM while being backwards-compatible.

Fixes #1413 partially. There are two more spec changes expected to add element attribute and allow null registry option during element creation and shadow attachment as mentioned in https://github.com/whatwg/dom/issues/1413#issuecomment-3530198733



- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/commit/cc1c056521abd0ff97456455dbebe113617a2bc1
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/399124619
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1874414
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=302970
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1423.html" title="Last updated on Nov 25, 2025, 10:29 AM UTC (9821f8a)">Preview</a> | <a href="https://whatpr.org/dom/1423/3fbec78...9821f8a.html" title="Last updated on Nov 25, 2025, 10:29 AM UTC (9821f8a)">Diff</a>