### PR TITLE
Allow the creation of null registry element and shadow root

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5856,18 +5856,24 @@ dictionary <var>options</var> and a <a for=/>document</a> <var>document</var>:
   <p>If <var>options</var> is a dictionary:
 
   <ol>
-   <li><p>If <var>options</var>["{{ElementCreationOptions/customElementRegistry}}"]
-   <a for=map>exists</a>, then set <var>registry</var> to it.
-
-   <li><p>If <var>registry</var> is non-null, and <var>registry</var>'s
-   <a for=CustomElementRegistry>is scoped</a> is false, and <var>registry</var> is not
-   <var>document</var>'s <a for=Document>custom element registry</a>, then <a>throw</a> a
-   "{{NotSupportedError!!exception}}" {{DOMException}}.
-
    <li><p>If <var>options</var>["{{ElementCreationOptions/is}}"] <a for=map>exists</a>, then set
    <var>is</var> to it.
 
-   <li><p>If <var>registry</var> is non-null and <var>is</var> is non-null, then <a>throw</a> a
+   <li>
+    <p>If <var>options</var>["{{ElementCreationOptions/customElementRegistry}}"]
+    <a for=map>exists</a>:
+
+    <ol>
+     <li><p>If <var>is</var> is non-null, then <a>throw</a> a "{{NotSupportedError!!exception}}"
+     {{DOMException}}.
+
+     <li><p>Set <var>registry</var> to
+     <var>options</var>["{{ElementCreationOptions/customElementRegistry}}"].
+    </ol>
+
+   <li><p>If <var>registry</var> is non-null, <var>registry</var>'s
+   <a for=CustomElementRegistry>is scoped</a> is false, and <var>registry</var> is not
+   <var>document</var>'s <a for=Document>custom element registry</a>, then <a>throw</a> a
    "{{NotSupportedError!!exception}}" {{DOMException}}.
   </ol>
 
@@ -7606,7 +7612,7 @@ are:
  <li><p>If <var>init</var>["{{ShadowRootInit/customElementRegistry}}"] <a for=map>exists</a>, then
  set <var>registry</var> to it.
 
- <li><p>If <var>registry</var> is non-null, and <var>registry</var>'s
+ <li><p>If <var>registry</var> is non-null, <var>registry</var>'s
  <a for=CustomElementRegistry>is scoped</a> is false, and <var>registry</var> is not <a>this</a>'s
  <a>node document</a>'s <a for=Document>custom element registry</a>, then <a>throw</a> a
  "{{NotSupportedError!!exception}}" {{DOMException}}.


### PR DESCRIPTION
<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

As part of the effort to support null custom element registry elements without shadow DOM, we're updating the spec to allow the creation of element and shadowroot to use null as a valid argument and create null registry element and shadowroot.

Fixes #1413 partially. We need another PR to support element attribute for null custom element registry in addition to #1423.


- [x] At least two implementers are interested (and none opposed):
   * webkit
   * chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/56108
   * https://github.com/web-platform-tests/wpt/pull/56176
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/399124619
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1874414
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=302583
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1424.html" title="Last updated on Nov 24, 2025, 8:37 AM UTC (48ff4a0)">Preview</a> | <a href="https://whatpr.org/dom/1424/918ebc0...48ff4a0.html" title="Last updated on Nov 24, 2025, 8:37 AM UTC (48ff4a0)">Diff</a>