### PR TITLE
Add abortSignal.addAbortCallback

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1926,6 +1926,7 @@ interface AbortSignal : EventTarget {
   readonly attribute boolean aborted;
   readonly attribute any reason;
   undefined throwIfAborted();
+  undefined addAbortCallback(VoidFunction callback);
 
   attribute EventHandler onabort;
 };</pre>
@@ -2036,6 +2037,26 @@ is [=AbortSignal/aborted=]; otherwise false.
 
 <p>The <dfn method for=AbortSignal>throwIfAborted()</dfn> method steps are to throw <a>this</a>'s
 <a for=AbortSignal>abort reason</a>, if <a>this</a> is [=AbortSignal/aborted=].
+
+<div algorithm>
+<p>The <dfn method for=AbortSignal><code>addAbortCallback(<var>callback</var>)</code></dfn> method steps are:
+
+ <ol>
+  <li><p>If <a>this</a> is [=AbortSignal/aborted=], then:
+   <ol>
+    <li><p><a spec=webidl>invoke</a> <var>callback</var> with « », and "<code>report</code>".
+
+    <li><p>Return.
+   </ol>
+
+
+  <li>
+   <p>[=AbortSignal/Add|Add the following abort steps=] to [=this=]:</p>
+   <ol>
+    <li><p><a spec=webidl>invoke</a> <var>callback</var> with « », and "<code>report</code>".
+   </ol>
+ </ol>
+</div>
 
 <div class=example id=example-throwifaborted>
  <p>This method is primarily useful for when functions accepting {{AbortSignal}}s want to throw (or


### PR DESCRIPTION
This PR is a discussion starter. The goals:

- Make progress on allowing TC39 able to adopt/use `AbortController` and `AbortSignal` without requiring `Event` and `EventTarget`.
- Provide a system where abort 'listeners' can be GC'd as soon as abort has happened.

The behaviour in this PR means that abort reactions in userland and the web platform interleave. @bakkot is keen on this. I'm a little unsure, so I'm interested in more opinions.

I'm a little worried about:

```js
const controller = new AbortController();
const signal = controller.signal;

let thing;

signal.addAbortCallback(() => {
  console.log(thing.running);
  // The above is unexpectedly true,
  // because the platform's steps to set it to false haven't run yet.
});

thing = doThing(signal);
controller.abort();
```

But maybe this already happens with promises?

---

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1425.html" title="Last updated on Nov 20, 2025, 5:22 AM UTC (3acd735)">Preview</a> | <a href="https://whatpr.org/dom/1425/918ebc0...3acd735.html" title="Last updated on Nov 20, 2025, 5:22 AM UTC (3acd735)">Diff</a>