### PR TITLE
Make DOMTokenList's supported token concept also depend on element

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -10501,7 +10501,7 @@ running <a>get an attribute value</a> given <var>set</var>'s <a for=DOMTokenList
 
 <hr>
 
-<div algorithm>
+<div algorithm="DOMTokenList/attribute change steps">
 <p>A {{DOMTokenList}} object <var>set</var> has these <a>attribute change steps</a> for
 <var>set</var>'s <a for=DOMTokenList>element</a>:
 
@@ -10516,7 +10516,7 @@ running <a>get an attribute value</a> given <var>set</var>'s <a for=DOMTokenList
 </ol>
 </div>
 
-<div algorithm>
+<div algorithm="DOMTokenList/created">
 <p>When a {{DOMTokenList}} object <var>set</var> is created:
 
 <ol>
@@ -10744,7 +10744,7 @@ method steps are:
 result of running <a>this</a>'s <a>serialize steps</a>.
 </div>
 
-<div algorithm>
+<div algorithm="DOMTokenList/value setter">
 <p>The <a attribute for=DOMTokenList><code>value</code></a> setter steps are to
 <a>set an attribute value</a> for <a>this</a>'s <a for=DOMTokenList>element</a> using <a>this</a>'s
 <a for=DOMTokenList>attribute name</a> and the given value.


### PR DESCRIPTION
It makes no sense for it to just depend on the attribute name.

Also modernize this section while here.

(PR template doesn't apply as this is mostly a clarification. The creation steps for this object seem incorrect to me by the way, as I doubt we want to make that result in a mutation record, but that's best solved separately.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1431.html" title="Last updated on Nov 28, 2025, 8:31 AM UTC (d9dd565)">Preview</a> | <a href="https://whatpr.org/dom/1431/9b0f03a...d9dd565.html" title="Last updated on Nov 28, 2025, 8:31 AM UTC (d9dd565)">Diff</a>