### PR TITLE
Editorial: correct misleading node equals sentence

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5090,8 +5090,8 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
   </dl>
 
  <li><p>If <var>A</var> is an <a for=/>element</a>, each <a>attribute</a> in its
- <a for=Element>attribute list</a> has an <a>attribute</a> that <a for=Node>equals</a> an
- <a>attribute</a> in <var>B</var>'s <a for=Element>attribute list</a>.
+ <a for=Element>attribute list</a> <a for=Node>equals</a> an <a>attribute</a> in <var>B</var>'s
+ <a for=Element>attribute list</a>.
 
  <li><p><var>A</var> and <var>B</var> have the same number of <a for=tree>children</a>.
 
@@ -11170,6 +11170,7 @@ Elliott Sprehn,
 Emilio Cobos Álvarez,
 Eric Bidelman,
 Erik Arvidsson,
+Evgeny Kapun<!-- abacabadabacaba; GitHub -->,
 François Daoust<!-- tidoust; GitHub -->,
 François Remy<!-- FremyCompany; GitHub -->,
 Gary Kacmarcik,


### PR DESCRIPTION
Closes #1443.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1444.html" title="Last updated on Jan 7, 2026, 1:38 PM UTC (05b7b30)">Preview</a> | <a href="https://whatpr.org/dom/1444/8c4de13...05b7b30.html" title="Last updated on Jan 7, 2026, 1:38 PM UTC (05b7b30)">Diff</a>