### PR TITLE
Pass better parent/root information to (re)moving steps.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3273,9 +3273,9 @@ from a <a for=/>node</a> <var>parent</var>:
 <div algorithm>
 <p><a lt="Other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-remove-ext>removing steps</dfn> for all or some <a for=/>nodes</a>. The
-algorithm is passed a <a for=/>node</a> <var ignore>removedNode</var>, a <a for=/>node</a>
-<var ignore>oldAncestor</var>, and a boolean <var ignore>isSubtreeRoot</var> as indicated in the
-<a for=/>remove</a> algorithm below.
+algorithm is passed a <a for=/>node</a> <var ignore>removedNode</var>, a boolean
+<var ignore>isSubtreeRoot</var>, and a <a for=/>node</a> <var ignore>oldAncestor</var> as indicated
+in the <a for=/>remove</a> algorithm below.
 </div>
 
 <div algorithm=remove>
@@ -3316,7 +3316,7 @@ optional boolean <dfn for=remove><var>suppressObservers</var></dfn> (default fal
    <li><p>Run <a>assign slottables for a tree</a> with <var>node</var>.
   </ol>
 
- <li><p>Run the <a>removing steps</a> with <var>node</var>, <var>parent</var>, and true.
+ <li><p>Run the <a>removing steps</a> with <var>node</var>, true, and <var>parent</var>.
 
  <li><p>Let <var>isParentConnected</var> be <var>parent</var>'s <a>connected</a>.
 
@@ -3333,7 +3333,7 @@ optional boolean <dfn for=remove><var>suppressObservers</var></dfn> (default fal
   <a>shadow-including tree order</a>:
 
   <ol>
-   <li><p>Run the <a>removing steps</a> with <var>descendant</var>, <var>parent</var>, and false.
+   <li><p>Run the <a>removing steps</a> with <var>descendant</var>, false, and <var>parent</var>.
 
    <li><p>If <var>descendant</var> is <a for=Element>custom</a> and <var>isParentConnected</var>
    is true, then <a>enqueue a custom element callback reaction</a> with <var>descendant</var>,


### PR DESCRIPTION
For removing steps and moving steps, instead of passing only oldParent (which is null when the removed node is not the root of the removed subtree), pass both oldAncestor (never null) and isSubtreeRoot.

This is the DOM spec part of the fix for https://github.com/whatwg/html/issues/12098
For the HTML spec change see https://github.com/whatwg/html/pull/12144

- [X] At least two implementers are interested (and none opposed):
   * Chromium
   * Gecko (assuming https://github.com/whatwg/html/issues/12098#issuecomment-3872487261 is sufficient)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * I think this *probably* doesn't need tests since previous implementors and test authors assumed that the spec said what this pair of PRs is updating it to actually say.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A
- [X] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: Not needed.
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
