### PR TITLE
Collapse range before mutations in deleteContents and extract

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -9283,9 +9283,8 @@ method steps are:
     point.
   </ol>
 
- <li>
-  <p>Set <a>this</a>'s <a for=range>start</a> and <a for=range>end</a> to
-  (<var>newNode</var>, <var>newOffset</var>).
+ <li><p>Set <a>this</a>'s <a for=range>start</a> and <a for=range>end</a> to
+ (<var>newNode</var>, <var>newOffset</var>).
 
  <li><p>If <var>originalStartNode</var> is a {{CharacterData}} <a for=/>node</a>, then
  <a>replace data</a> of <var>originalStartNode</var> with <var>originalStartOffset</var>,
@@ -9415,9 +9414,8 @@ method steps are:
     point.
   </ol>
 
- <li>
-  <p>Set <var>range</var>'s <a for=range>start</a> and <a for=range>end</a> to
-  (<var>newNode</var>, <var>newOffset</var>).
+ <li><p>Set <var>range</var>'s <a for=range>start</a> and <a for=range>end</a> to
+ (<var>newNode</var>, <var>newOffset</var>).
 
  <li>
   <p>If <var>firstPartiallyContainedChild</var> is a {{CharacterData}} <a for=/>node</a>:


### PR DESCRIPTION
Collapse range before mutations in deleteContents and extract

Move the step that sets the range's start and end to (newNode, newOffset) from after DOM mutations to before them, in both `deleteContents()` and the `extract` algorithm. The DOM's built-in live range maintenance mechanisms (`live range pre-remove steps` and `replace data` range adjustments) keep the range valid through subsequent operations. Collapsing after mutations is unreliable because script can run during removal (via removing steps) and modify the DOM, invalidating the pre-computed values.

Fixes #1446.

---

- [x] At least two implementers are interested (and none opposed):
   * Mozilla (smaug----, Mozilla-affiliated GitHub account, opened #1446)
   * Chromium (shipped fix in [CL 7615530](https://chromium-review.googlesource.com/c/chromium/src/+/7615530), WPT tests merged in web-platform-tests/wpt#58132)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/58008
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/486922855
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=2018839
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=308549
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/43230
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)