### PR TITLE
Stop using “strictly split” in “validate and extract”

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -254,12 +254,9 @@ U+0000 NULL, or U+003E (>).
   <p>If <var>qualifiedName</var> contains a U+003A (:):
 
   <ol>
-   <li><p>Let <var>splitResult</var> be the result of running <a>strictly split</a> given
-   <var>qualifiedName</var> and U+003A (:).
+   <li><p>Set <var>prefix</var> to the part of <var>qualifiedName</var> before the first U+003A (:).
 
-   <li><p>Set <var>prefix</var> to <var>splitResult</var>[0].
-
-   <li><p>Set <var>localName</var> to <var>splitResult</var>[1].
+   <li><p>Set <var>localName</var> to the part of <var>qualifiedName</var> after the first U+003A (:).
 
    <li><p>If <var>prefix</var> is not a [=valid namespace prefix=], then [=throw=] an
    "{{InvalidCharacterError}}" {{DOMException}}.


### PR DESCRIPTION
The _“validate and extract”_ algorithm currently uses _“strictly split”_ to split the qualified name on U+003A (:), which splits on every colon into an array, and takes only the first and second elements from the array. For a qualified name like `foo:bar:baz`, that produces the prefix `foo` and the local name `bar` — silently discarding the `:baz` part.

This change splits on the first colon only instead, so the local name is `bar:baz`.

This came up in https://github.com/WICG/sanitizer-api/issues/373. Fixes #1453.

- [x] At least two implementers are interested (and none opposed):
   * WebKit ✅
   * Gecko
   * Chromium
- [X] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/58331
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:

   | Engine            |  Bug |
   | ------------- | ----------------------------------------------- |
   | Chromium     | https://issues.chromium.org/issues/490251709   |
   | Gecko            | https://bugzilla.mozilla.org/show_bug.cgi?id=2021558 |
   | WebKit          | [already implemented in `https://github.com/WebKit/WebKit/pull/56000`] |
   
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [X] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.