### PR TITLE
Support markers on shadow roots

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4939,8 +4939,8 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>mode</a>, true, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>serializable</a>, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>delegates focus</a>, <var>node</var>'s
-   <a for=Element>shadow root</a>'s <a for=ShadowRoot>slot assignment</a>, and
-   <var>shadowRootRegistry</var>.
+   <a for=Element>shadow root</a>'s <a for=ShadowRoot>slot assignment</a>, <var>node</var>'s
+   <a for=Element>shadow root</a>'s <a for=ShadowRoot>marker</a>, and <var>shadowRootRegistry</var>.
 
    <li><p>Set <var>copy</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a>
    to <var>node</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a>.
@@ -6555,6 +6555,7 @@ interface ShadowRoot : DocumentFragment {
   readonly attribute SlotAssignmentMode slotAssignment;
   readonly attribute boolean clonable;
   readonly attribute boolean serializable;
+  readonly attribute DOMString marker;
   readonly attribute Element host;
 
   attribute EventHandler onslotchange;
@@ -6593,6 +6594,9 @@ It is initially set to false.</p>
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>serializable</dfn> (a boolean).
 It is initially set to false.</p>
 
+<p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>marker</dfn> (a string). It is
+inititially set to the empty string.</p>
+
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>custom element registry</dfn>
 (null or a {{CustomElementRegistry}} object). It is initially null.</p>
 
@@ -6627,6 +6631,9 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 
 <p>The <dfn attribute for=ShadowRoot><code>serializable</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>serializable</a>.
+
+<p>The <dfn attribute for=ShadowRoot><code>marker</code></dfn> getter steps are to return
+<a>this</a>'s <a for=ShadowRoot>marker</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>host</code></dfn> getter steps are to return
 <a>this</a>'s <a for=DocumentFragment>host</a>.
@@ -6765,6 +6772,7 @@ dictionary ShadowRootInit {
   SlotAssignmentMode slotAssignment = "named";
   boolean clonable = false;
   boolean serializable = false;
+  DOMString marker = "";
   CustomElementRegistry? customElementRegistry;
 };
 </pre>
@@ -7741,7 +7749,8 @@ are:
  <var>init</var>["{{ShadowRootInit/mode}}"], <var>init</var>["{{ShadowRootInit/clonable}}"],
  <var>init</var>["{{ShadowRootInit/serializable}}"],
  <var>init</var>["{{ShadowRootInit/delegatesFocus}}"],
- <var>init</var>["{{ShadowRootInit/slotAssignment}}"], and <var>registry</var>.
+ <var>init</var>["{{ShadowRootInit/slotAssignment}}"],
+ <var>init</var>["{{ShadowRootInit/marker}}"], and <var>registry</var>.
 
  <li><p>Return <a>this</a>'s <a for=Element>shadow root</a>.
 </ol>
@@ -7751,7 +7760,8 @@ are:
 <p>To <dfn id=concept-attach-a-shadow-root>attach a shadow root</dfn>, given an
 <a for=/>element</a> <var>element</var>, a string <var>mode</var>, a boolean <var>clonable</var>,
 a boolean <var>serializable</var>, a boolean <var>delegatesFocus</var>, a string
-<var>slotAssignment</var>, and null or a {{CustomElementRegistry}} object <var>registry</var>:
+<var>slotAssignment</var>, a string <var>marker</var>, and null or a {{CustomElementRegistry}}
+object <var>registry</var>:
 
 <ol>
  <li><p>If <var>element</var>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
@@ -7824,6 +7834,8 @@ a boolean <var>serializable</var>, a boolean <var>delegatesFocus</var>, a string
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>clonable</a> to <var>clonable</var>.
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>serializable</a> to <var>serializable</var>.
+
+  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>marker</a> to <var>marker</var>.
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>custom element registry</a> to
  <var>registry</var>.


### PR DESCRIPTION
This can be set in `attachShadow()` but will also be supported via
`<template marker>`, so that `<template for>` can work inside DSD.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chromium (@foolip + @noamr)
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/blob/master/html/dom/partial-updates/tentative/template-for-shadow-root.html
   * TODO: update test to use new `for="a#b"` syntax and separately create PR to make non-tentative
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
   * Deno (only for aborting and events): …
   * Node.js (only for aborting and events): …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
