### PR TITLE
Differentiate between "children change" steps and "children inserted" steps

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -2843,7 +2843,7 @@ that all pending <a>node tree</a> insertions completely finish before more inser
 <div algorithm>
 <p><a lt="other applicable specifications">Specifications</a> may define
 <dfn export id=concept-node-children-inserted-ext>children inserted steps</dfn> for all or some
-<a for=/>nodes</a>. The algorithm is passed no argument and is called from <a for=/>insert</a.
+<a for=/>nodes</a>. The algorithm is passed no argument and is called from <a for=/>insert</a>.
 </div>
 
 <div algorithm=insert>

--- a/dom.bs
+++ b/dom.bs
@@ -2840,6 +2840,12 @@ that all pending <a>node tree</a> insertions completely finish before more inser
 <a for=/>remove</a>, and <a for=/>replace data</a>.
 </div>
 
+<div algorithm>
+<p><a lt="other applicable specifications">Specifications</a> may define
+<dfn export id=concept-node-children-inserted-ext>children inserted steps</dfn> for all or some
+<a for=/>nodes</a>. The algorithm is passed no argument and is called from <a for=/>insert</a.
+</div>
+
 <div algorithm=insert>
 <p>To <dfn export id=concept-node-insert>insert</dfn> a <a for=/>node</a> <var>node</var> into a
 <a for=/>node</a> <var>parent</var> before null or a <a for=/>node</a> <var>child</var>, with an
@@ -2952,7 +2958,8 @@ optional boolean <dfn for="insert"><var>suppressObservers</var></dfn> (default f
  <li><p>If <var>suppressObservers</var> is false, then <a>queue a tree mutation record</a> for
  <var>parent</var> with <var>nodes</var>, « », <var>previousSibling</var>, and <var>child</var>.
 
- <li><p>Run the <a>children changed steps</a> for <var>parent</var>.
+ <li><p>Run the <a>children inserted steps</a> for <var>parent</var>. If those are not defined, run
+ the <a>children changed steps</a> for <var>parent</var>.
 
  <li>
   <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially « ».</p>


### PR DESCRIPTION
See https://github.com/whatwg/html/issues/12279

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * This is already implemented and was in the spec before
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/dom/nodes/insertion-removing-steps/script-does-not-run-on-child-removal.window.html?label=master&label=experimental&aligned&q=script-does-not-run-on-child-removal
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
