### PR TITLE
Record task-like timing in fire an event

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -1748,6 +1748,7 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
 <ol>
  <li><p>Let <var>recordingTimingAsTask</var> be the result of calling <a>start recording task time if
  needed</a> given <var>target</var>'s <a>relevant settings object</a>.
+
  <li><p>If <var>eventConstructor</var> is not given, then let <var>eventConstructor</var> be
  {{Event}}.
 

--- a/dom.bs
+++ b/dom.bs
@@ -1770,7 +1770,7 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
   <p>If <var>recordingTimingAsTask</var> is true:
 
   <ol>
-   <li><p>Assert</a>: <var>target</var>'s <a>relevant settings object</a> is a {{Document}}.
+   <li><a>Assert</a>: <var>target</var>'s <a>relevant settings object</a> is a {{Document}}.
 
    <li><p><a>Record task end time</a> given the <a>unsafe shared current time</a> and <var>target</var>'s
    <a>relevant settings object</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -1746,6 +1746,8 @@ optionally using an <var>eventConstructor</var>, with a description of how IDL a
 initialized, and a <var>legacy target override flag</var>, run these steps:
 
 <ol>
+ <li><p>Let <var>recordingTimingAsTask</var> be the result of calling <a>start recording task time if
+ needed</a> given <var>target</var>'s <a>relevant settings object</a>.
  <li><p>If <var>eventConstructor</var> is not given, then let <var>eventConstructor</var> be
  {{Event}}.
 
@@ -1760,8 +1762,19 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
 
   <p class=note>This also allows for the {{Event/isTrusted}} attribute to be set to false.
 
- <li><p>Return the result of <a>dispatching</a> <var>event</var> at <var>target</var>, with
+ <li><p>Let <var>result</var> be the result of <a>dispatching</a> <var>event</var> at <var>target</var>, with
  <var>legacy target override flag</var> set if set.
+
+ <li><p>If <var>recordingTimingAsTask</var> is true, then:
+
+  <ol>
+   <li><p>Assert</a>: <var>target</var>'s <a>relevant settings object</a> is a {{Document}}.
+
+   <li><p><a>Record task end time</a> given the <a>unsafe shared current time</a> and <var>target</var>'s
+   <a>relevant settings object</a>.
+  </ol>
+
+ <li><p>Return <var>result</var>.
 </ol>
 </div>
 

--- a/dom.bs
+++ b/dom.bs
@@ -1765,7 +1765,8 @@ initialized, and a <var>legacy target override flag</var>, run these steps:
  <li><p>Let <var>result</var> be the result of <a>dispatching</a> <var>event</var> at <var>target</var>, with
  <var>legacy target override flag</var> set if set.
 
- <li><p>If <var>recordingTimingAsTask</var> is true, then:
+ <li>
+  <p>If <var>recordingTimingAsTask</var> is true:
 
   <ol>
    <li><p>Assert</a>: <var>target</var>'s <a>relevant settings object</a> is a {{Document}}.


### PR DESCRIPTION
This allows clustering a "fire an event" timeframe in terms of frame timing monitoring, as opposed to relying on an "implicit document", which is a deprecated and non-interoperable term.

The implication of this is that if this event firing schedules a render that ends up as a long animation frame, the whole event firing duration would be counted towards this performance entry, regardless of "tasks".

This is already how long animation frames behave in the chromium implementation and should be unobservable from the previous spec wording that relied on "implicit document".

See w3c/long-animation-frames#36

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * chromium (matches current implementation)
   * Gecko (see https://github.com/whatwg/dom/pull/1462#pullrequestreview-5100389918)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * This doesn't change current behavior, but rather tightens the spec. current tests are in https://wpt.fyi/results/long-animation-frames?
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A (no behavior change)
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1462.html" title="Last updated on May 21, 2026, 3:36 PM UTC (525c226)">Preview</a> | <a href="https://whatpr.org/dom/1462/2a4363c...525c226.html" title="Last updated on May 21, 2026, 3:36 PM UTC (525c226)">Diff</a>