### PR TITLE
Editorial: Remove optional closing </p> and </li> tags

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -463,7 +463,7 @@ dictionary EventInit {
 </pre>
 
 <p>An {{Event}} object is simply named an <dfn export id=concept-event>event</dfn>. It allows for
-signaling that something has occurred, e.g., that an image has completed downloading.</p>
+signaling that something has occurred, e.g., that an image has completed downloading.
 
 <p>A <dfn export>potential event target</dfn> is null or an {{EventTarget}} object.
 
@@ -492,7 +492,7 @@ empty list.
 <a>potential event target</a>), a <dfn for=Event/path>touch target list</dfn> (a <a for=/>list</a>
 of <a>potential event targets</a>), a <dfn for=Event/path>root-of-closed-tree</dfn> (a boolean), and
 a <dfn for=Event/path>slot-in-closed-tree</dfn> (a boolean). A <a for=Event>path</a> is initially
-the empty list.</p>
+the empty list.
 
 <dl class=domintro>
  <dt><code><var>event</var> = new <a constructor lt="Event()">Event</a>(<var>type</var> [, <var>eventInitDict</var>])</code>
@@ -726,7 +726,7 @@ initialized to, which must be one of the following:
 </ul>
 
 <p>The <dfn method for=Event><code>stopPropagation()</code></dfn> method steps are to set
-<a>this</a>'s <a>stop propagation flag</a>.</p>
+<a>this</a>'s <a>stop propagation flag</a>.
 
 <p>The <dfn attribute for=Event><code>cancelBubble</code></dfn> getter steps are to return true if
 <a>this</a>'s <a>stop propagation flag</a> is set; otherwise false.
@@ -920,7 +920,7 @@ must be run, given the arguments <var>type</var> and <var>eventInitDict</var>:
 <p>To
 <dfn export id=concept-event-create lt="creating an event|create an event">create an event</dfn>
 using <var>eventInterface</var>, which must be either {{Event}} or an interface that inherits from
-it, and optionally given a <a>realm</a> <var>realm</var>, run these steps:</p>
+it, and optionally given a <a>realm</a> <var>realm</var>, run these steps:
 
 <ol>
  <li><p>If <var>realm</var> is not given, then set it to null.
@@ -951,11 +951,11 @@ it, and optionally given a <a>realm</a> <var>realm</var>, run these steps:</p>
 <p class=note><a>Create an event</a> is meant to be used by other specifications which need to
 separately <a lt="create an event">create</a> and <a>dispatch</a> events, instead of simply
 <a lt="fire an event">firing</a> them. It ensures the event's attributes are initialized to the
-correct defaults.</p>
+correct defaults.
 
 <div algorithm>
 <p>The <dfn noexport>inner event creation steps</dfn>, given an <var>eventInterface</var>,
-<var>realm</var>, <var>time</var>, and <var>dictionary</var>, are as follows:</p>
+<var>realm</var>, <var>time</var>, and <var>dictionary</var>, are as follows:
 
 <ol>
  <li>
@@ -1056,7 +1056,7 @@ specified otherwise it returns null.
 <p>Each {{EventTarget}} object can have an associated
 <dfn export for=EventTarget>activation behavior</dfn> algorithm. The
 <a for=EventTarget>activation behavior</a> algorithm is passed an <a>event</a>, as indicated in the
-<a>dispatch</a> algorithm.</p>
+<a>dispatch</a> algorithm.
 
 <p class=note>This exists because user agents perform certain actions for certain
 {{EventTarget}} objects, e.g., the <{area}> element, in response to synthetic {{MouseEvent}}
@@ -1169,7 +1169,7 @@ or <a for=EventTarget>legacy-canceled-activation behavior</a>.
 
 <p class=note>In the future we could allow custom <a>get the parent</a> algorithms. Let us know
 if this would be useful for your programs. For now, all author-created {{EventTarget}}s do not
-participate in a tree structure.</p>
+participate in a tree structure.
 
 <div algorithm>
 <p>The <dfn>default passive value</dfn>, given an event type |type| and an {{EventTarget}}
@@ -1411,7 +1411,7 @@ property of the event being dispatched.
    with <var>event</var>.
 
    <li>
-    <p>While <var>parent</var> is non-null:</p>
+    <p>While <var>parent</var> is non-null:
 
     <ol>
      <li>
@@ -1567,7 +1567,7 @@ property of the event being dispatched.
 <p>To <dfn noexport id=concept-event-path-append>append to an event path</dfn>, given an
 <var>event</var>, <var>invocationTarget</var>, <var>shadowAdjustedTarget</var>,
 <var>relatedTarget</var>, <var>touchTargets</var>, and a <var>slot-in-closed-tree</var>, run these
-steps:</p>
+steps:
 
 <ol>
  <li><p>Let <var>invocationTargetInShadowTree</var> be false.
@@ -2012,7 +2012,7 @@ steps are:
 
  <li>
   <p><a>Run steps after a timeout</a> given <var>global</var>, "<code>AbortSignal-timeout</code>",
-  <var>milliseconds</var>, and the following step:</p>
+  <var>milliseconds</var>, and the following step:
 
   <ol>
    <li><p><a>Queue a global task</a> on the <a>timer task source</a> given <var>global</var> to
@@ -2439,10 +2439,10 @@ the standard using it has not been updated to account for <a>shadow trees</a>.</
 <p>A <a for=/>shadow root</a> is always attached to another <a>node tree</a> through its
 <a for=DocumentFragment>host</a>. A <a>shadow tree</a> is therefore never alone. The
 <a>node tree</a> of a <a for=/>shadow root</a>'s <a for=DocumentFragment>host</a> is sometimes
-referred to as the <dfn export id=concept-light-tree>light tree</dfn>.</p>
+referred to as the <dfn export id=concept-light-tree>light tree</dfn>.
 
 <p class=note>A <a>shadow tree</a>'s corresponding <a>light tree</a> can be a <a>shadow tree</a>
-itself.</p>
+itself.
 
 <p id=in-a-shadow-including-document>A <a for=/>node</a> is <dfn export>connected</dfn> if its
 <a>shadow-including root</a> is a <a for=/>document</a>.
@@ -2450,12 +2450,12 @@ itself.</p>
 <h5 id=shadow-tree-slots>Slots</h5>
 
 <p>A <a>shadow tree</a> contains zero or more <a for=/>elements</a> that are
-<dfn export id=concept-slot lt=slot>slots</dfn>.</p>
+<dfn export id=concept-slot lt=slot>slots</dfn>.
 
-<p class=note>A <a>slot</a> can only be created through HTML's <{slot}> element.</p>
+<p class=note>A <a>slot</a> can only be created through HTML's <{slot}> element.
 
 <p>A <a>slot</a> has an associated <dfn export for=slot>name</dfn> (a string). Unless stated
-otherwise it is the empty string.</p>
+otherwise it is the empty string.
 
 <p>Use these <a>attribute change steps</a> to update a <a>slot</a>'s <a for=slot>name</a>:
 
@@ -2481,20 +2481,20 @@ otherwise it is the empty string.</p>
 </ol>
 
 <p class=note>The first <a>slot</a> in a <a>shadow tree</a>, in <a>tree order</a>, whose
-<a for=slot>name</a> is the empty string, is sometimes known as the "default slot".</p>
+<a for=slot>name</a> is the empty string, is sometimes known as the "default slot".
 
 <p>A <a>slot</a> has an associated <dfn export for=slot>assigned nodes</dfn> (a list of
-<a>slottables</a>). Unless stated otherwise it is empty.</p>
+<a>slottables</a>). Unless stated otherwise it is empty.
 
 <h5 id=light-tree-slotables>Slottables</h5>
 
 <p>{{Element}} and {{Text}} <a for=/>nodes</a> are
-<dfn export id=concept-slotable lt=slottable>slottables</dfn>.</p>
+<dfn export id=concept-slotable lt=slottable>slottables</dfn>.
 
 <p class=note>A <a>slot</a> can be a <a>slottable</a>.
 
 <p>A <a>slottable</a> has an associated <dfn export for=slottable id=slotable-name>name</dfn> (a
-string). Unless stated otherwise it is the empty string.</p>
+string). Unless stated otherwise it is the empty string.
 
 <p>Use these <a>attribute change steps</a> to update a <a>slottable</a>'s <a for=slottable>name</a>:
 
@@ -2525,7 +2525,7 @@ string). Unless stated otherwise it is the empty string.</p>
 <dfn export for=slottable id=slotable-assigned-slot>assigned slot</dfn> (null or a <a>slot</a>).
 Unless stated otherwise it is null. A <a>slottable</a> is
 <dfn export for=slottable id=slotable-assigned>assigned</dfn> if its <a>assigned slot</a> is
-non-null.</p>
+non-null.
 
 <p>A <a>slottable</a> has an associated <dfn export for=slottable>manual slot assignment</dfn> (null
 or a <a>slot</a>). Unless stated otherwise, it is null.
@@ -2955,14 +2955,14 @@ optional boolean <dfn for="insert"><var>suppressObservers</var></dfn> (default f
  <li><p>Run the <a>children changed steps</a> for <var>parent</var>.
 
  <li>
-  <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially « ».</p>
+  <p>Let <var>staticNodeList</var> be a <a for=/>list</a> of <a for=/>nodes</a>, initially « ».
 
   <p class="note">We collect all <a for=/>nodes</a> <em>before</em> calling the
   <a>post-connection steps</a> on any one of them, instead of calling the
   <a>post-connection steps</a> <em>while</em> we're traversing the <a>node tree</a>. This is because
   the <a>post-connection steps</a> can modify the tree's structure, making live traversal unsafe,
   possibly leading to the <a>post-connection steps</a> being called multiple times on the same
-  <a>node</a>.</p>
+  <a>node</a>.
  </li>
 
  <li>
@@ -3009,10 +3009,10 @@ to do these things asynchronously, however.
  <li>
   <p>If <var>newParent</var>'s <a for=/>shadow-including root</a> is not the same as
   <var>node</var>'s <a for=/>shadow-including root</a>, then <a>throw</a> a
-  "{{HierarchyRequestError!!exception}}" {{DOMException}}.</p>
+  "{{HierarchyRequestError!!exception}}" {{DOMException}}.
 
   <p class=note>This has the side effect of ensuring that a move is only performed if
-  <var>newParent</var>'s <a>connected</a> is <var>node</var>'s <a>connected</a>.</p>
+  <var>newParent</var>'s <a>connected</a> is <var>node</var>'s <a>connected</a>.
  </li>
 
  <li><p>If <var>node</var> is a <a>host-including inclusive ancestor</a> of <var>newParent</var>,
@@ -3022,7 +3022,7 @@ to do these things asynchronously, however.
  then <a>throw</a> a "{{NotFoundError!!exception}}" {{DOMException}}.
 
  <li><p>If <var>node</var> is not an {{Element}} or a {{CharacterData}} <a for=/>node</a>, then
- <a>throw</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}}.</p></li>
+ <a>throw</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}}.
 
  <li><p>If <var>node</var> is a {{Text}} <a for=/>node</a> and <var>newParent</var> is a
  <a for=/>document</a>, then <a>throw</a> a "{{HierarchyRequestError!!exception}}" {{DOMException}}.
@@ -3124,10 +3124,10 @@ to do these things asynchronously, however.
  </li>
 
  <li><p><a>Queue a tree mutation record</a> for <var>oldParent</var> with « », « <var>node</var> »,
- <var>oldPreviousSibling</var>, and <var>oldNextSibling</var>.</p></li>
+ <var>oldPreviousSibling</var>, and <var>oldNextSibling</var>.
 
  <li><p><a>Queue a tree mutation record</a> for <var>newParent</var> with « <var>node</var> », « »,
- <var>newPreviousSibling</var>, and <var>child</var>.</p></li>
+ <var>newPreviousSibling</var>, and <var>child</var>.
 </ol>
 </div>
 
@@ -4676,7 +4676,7 @@ statement, switching on the interface <a>this</a> <a>implements</a>:
 </dl>
 
 <p>The <dfn attribute for=Node><code>isConnected</code></dfn> getter steps are to return true,
-if <a>this</a> is <a>connected</a>; otherwise false.</p>
+if <a>this</a> is <a>connected</a>; otherwise false.
 
 <p>The <dfn attribute for=Node><code>ownerDocument</code></dfn> getter steps are to return null,
 if <a>this</a> is a <a for=/>document</a>; otherwise <a>this</a>'s <a for=Node>node document</a>.
@@ -6168,7 +6168,7 @@ algorithm is passed <var ignore>node</var> and <var ignore>oldDocument</var>, as
 
 <p>Null or a {{CustomElementRegistry}} object <var>registry</var>
 <dfn>is a global custom element registry</dfn> if <var>registry</var> is non-null and
-<var>registry</var>'s <a for=CustomElementRegistry>is scoped</a> is false.</p>
+<var>registry</var>'s <a for=CustomElementRegistry>is scoped</a> is false.
 
 <p>A <a for=/>document</a> <var>document</var>'s <dfn>effective global custom element registry</dfn>
 is:
@@ -6456,7 +6456,7 @@ method steps are:
   </ol>
 
  <li><p><a>Append</a> the result of <a>creating an element</a> given <var>doc</var>,
- "<code>body</code>", and the <a>HTML namespace</a>, to the <{html}> element created earlier.</li>
+ "<code>body</code>", and the <a>HTML namespace</a>, to the <{html}> element created earlier.
 
  <li><p><var>doc</var>'s <a for=Document>origin</a> is <a>this</a>'s associated
  <a for=/>document</a>'s <a for=Document>origin</a>.
@@ -6564,34 +6564,34 @@ enum SlotAssignmentMode { "manual", "named" };
 <p>{{ShadowRoot}} <a for=/>nodes</a> are simply known as
 <dfn export id=concept-shadow-root lt="shadow root">shadow roots</dfn>.
 
-<p><a for=/>Shadow roots</a>'s associated <a for=DocumentFragment>host</a> is never null.</p>
+<p><a for=/>Shadow roots</a>'s associated <a for=DocumentFragment>host</a> is never null.
 <!-- If we ever change this, e.g., add a ShadowRoot object constructor, that would have serious
      consequences for innerHTML. -->
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>mode</dfn> ("<code>open</code>"
-or "<code>closed</code>").</p>
+or "<code>closed</code>").
 
 <p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>delegates focus</dfn>
-(a boolean). It is initially set to false.</p>
+(a boolean). It is initially set to false.
 
 <p><a for=/>Shadow roots</a> have an associated
 <dfn export for=ShadowRoot>available to element internals</dfn> (a boolean). It is initially set to
-false.</p>
+false.
 
 <p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>declarative</dfn>
-(a boolean). It is initially set to false.</p>
+(a boolean). It is initially set to false.
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>slot assignment</dfn>
 ("<code>manual</code>" or "<code>named</code>").
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>clonable</dfn> (a boolean).
-It is initially set to false.</p>
+It is initially set to false.
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>serializable</dfn> (a boolean).
-It is initially set to false.</p>
+It is initially set to false.
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>custom element registry</dfn>
-(null or a {{CustomElementRegistry}} object). It is initially null.</p>
+(null or a {{CustomElementRegistry}} object). It is initially null.
 
 <p><a for=/>Shadow roots</a> have an associated
 <dfn for=ShadowRoot>keep custom element registry null</dfn> (a boolean). It is initially false.
@@ -6611,10 +6611,10 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 <hr>
 
 <p>The <dfn attribute for=ShadowRoot><code>mode</code></dfn> getter steps are to return
-<a>this</a>'s <a for=ShadowRoot>mode</a>.</p>
+<a>this</a>'s <a for=ShadowRoot>mode</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>delegatesFocus</code></dfn> getter steps are to return
-<a>this</a>'s <a for=ShadowRoot>delegates focus</a>.</p>
+<a>this</a>'s <a for=ShadowRoot>delegates focus</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>slotAssignment</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>slot assignment</a>.
@@ -6683,7 +6683,7 @@ is an object or one of its <a>shadow-including ancestors</a>.
 </ul>
 
 <p>To <dfn export lt="retarget|retargeting">retarget</dfn> an object <var>A</var> against an object
-<var>B</var>, repeat these steps until they return an object:</p>
+<var>B</var>, repeat these steps until they return an object:
 
 <ol>
  <li>
@@ -6813,10 +6813,10 @@ behavior of the '':defined'' pseudo-class. Whether or not an element is <a for=E
 used to determine the behavior of the <a href=#mutation-algorithms>mutation algorithms</a>. The
 "<code>failed</code>" and "<code>precustomized</code>" states are used to ensure that if a
 <a>custom element constructor</a> fails to execute correctly the first time, it is not executed
-again by an <a lt="upgrade an element">upgrade</a>.</p>
+again by an <a lt="upgrade an element">upgrade</a>.
 
 <div class=example id=example-c5b21302>
- <p>The following code illustrates elements in each of these four states:</p>
+ <p>The following code illustrates elements in each of these four states:
 
  <pre><code class=lang-html>
   &lt;!DOCTYPE html>
@@ -7094,7 +7094,7 @@ null or a {{CustomElementRegistry}} object <var>registry</var>:
 <a>attribute</a> <var>attribute</var> to <var>value</var>, run these steps:
 
 <ol>
- <li><p>Let <var>oldValue</var> be <var>attribute</var>'s <a for=Attr>value</a>.</p></li>
+ <li><p>Let <var>oldValue</var> be <var>attribute</var>'s <a for=Attr>value</a>.
 
  <li><p>Set <var>attribute</var>'s <a for=Attr>value</a> to <var>value</var>.
 
@@ -7123,7 +7123,7 @@ steps:
 <a>attribute</a> <var>attribute</var>, run these steps:
 
 <ol>
- <li><p>Let <var>element</var> be <var>attribute</var>'s <a for=Attr>element</a>.</p></li>
+ <li><p>Let <var>element</var> be <var>attribute</var>'s <a for=Attr>element</a>.
 
  <li><a for=list>Remove</a> <var>attribute</var> from <var>element</var>'s <a for=Element>attribute
  list</a>.
@@ -7138,7 +7138,7 @@ steps:
 <a>attribute</a> <var>oldAttribute</var> with an <a>attribute</a> <var>newAttribute</var>:
 
 <ol>
- <li><p>Let <var>element</var> be <var>oldAttribute</var>'s <a for=Attr>element</a>.</p></li>
+ <li><p>Let <var>element</var> be <var>oldAttribute</var>'s <a for=Attr>element</a>.
 
  <li><p><a for=list>Replace</a> <var>oldAttribute</var> by <var>newAttribute</var> in
  <var>element</var>'s <a for=Element>attribute list</a>.
@@ -7189,16 +7189,16 @@ given null or a string <var>namespace</var>, a string <var>localName</var>, and 
 <div algorithm>
 <p>To <dfn export id=concept-element-attributes-get-value>get an attribute value</dfn> given an
 <a for=/>element</a> <var>element</var>, a string <var>localName</var>, and an optional null or
-string <var>namespace</var> (default null):</p>
+string <var>namespace</var> (default null):
 
 <ol>
  <li><p>Let <var>attr</var> be the result of
  <a lt="get an attribute by namespace and local name">getting an attribute</a> given
- <var>namespace</var>, <var>localName</var>, and <var>element</var>.</p></li>
+ <var>namespace</var>, <var>localName</var>, and <var>element</var>.
 
- <li><p>If <var>attr</var> is null, then return the empty string.</p></li>
+ <li><p>If <var>attr</var> is null, then return the empty string.
 
- <li><p>Return <var>attr</var>'s <a for=Attr>value</a>.</p></li>
+ <li><p>Return <var>attr</var>'s <a for=Attr>value</a>.
 </ol>
 </div>
 
@@ -7371,16 +7371,15 @@ claims as to whether using them is conforming or not.
 </dl>
 
 <p>IDL attributes that are defined to <dfn for=Attr id=concept-reflect>reflect</dfn> a string
-<var>name</var>, must have these getter and setter steps:</p>
+<var>name</var>, must have these getter and setter steps:
 
 <dl>
  <dt>getter steps
  <dd><p>Return the result of running <a>get an attribute value</a> given <a>this</a> and
- <var>name</var>.</p></dd>
+ <var>name</var>.
 
  <dt>setter steps
  <dd><p><a>Set an attribute value</a> for <a>this</a> using <var>name</var> and the given value.
- </p></dd>
 </dl>
 
 <p>The <dfn attribute for=Element><code>id</code></dfn> attribute must <a for=Attr>reflect</a>
@@ -7400,7 +7399,7 @@ particular {{DOMTokenList}} object are also known as the <a for=/>element</a>'s
 
 <p class=note><code>id</code>, <code>class</code>, and <code>slot</code> are effectively
 superglobal attributes as they can appear on any element, regardless of that element's
-namespace.</p>
+namespace.
 
 <hr>
 
@@ -10851,7 +10850,7 @@ method steps are:
  <a>throw</a> an "{{InvalidCharacterError!!exception}}" {{DOMException}}.
 
  <li><p>If <a>this</a>'s <a>token set</a> does not <a for=set>contain</a> <var>token</var>, then
- return false.</p>
+ return false.
 
  <li><p><a for=set>Replace</a> <var>token</var> in <a>this</a>'s <a>token set</a> with
  <var>newToken</var>.


### PR DESCRIPTION
This specification generally doesn't use optional closing tags, but some instances of `</p>` and `</li>` have snuck in.

For consistency, remove all instances of `</p>` and all instances of `</li>` except where the `<li>` wraps multiple blocks of text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1466.html" title="Last updated on May 26, 2026, 11:06 PM UTC (1b4c916)">Preview</a> | <a href="https://whatpr.org/dom/1466/e1e7699...1b4c916.html" title="Last updated on May 26, 2026, 11:06 PM UTC (1b4c916)">Diff</a>