### PR TITLE
Editorial: remove "run these steps" from algorithm headers

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6859,6 +6859,7 @@ again by an <a lt="upgrade an element">upgrade</a>.
 <a for=Element>namespace prefix</a>, followed by "<code>:</code>", followed by its
 <a for=Element>local name</a>.
 
+<div algorithm>
 <p>An <a for=/>element</a>'s <dfn for=Element>HTML-uppercased qualified name</dfn> is the return
 value of these steps:
 
@@ -6866,11 +6867,11 @@ value of these steps:
  <li><p>Let <var>qualifiedName</var> be <a>this</a>'s <a for=Element>qualified name</a>.
 
  <li><p>If <a>this</a> is in the <a>HTML namespace</a> and its <a for=Node>node document</a> is an
- <a>HTML document</a>, then set <var>qualifiedName</var> to <var>qualifiedName</var> in
- <a>ASCII uppercase</a>.
+ <a>HTML document</a>, then return <var>qualifiedName</var> in <a>ASCII uppercase</a>.
 
  <li>Return <var>qualifiedName</var>.
 </ol>
+</div>
 
 <p class=note>User agents could optimize <a for=Element>qualified name</a> and
 <a for=Element>HTML-uppercased qualified name</a> by storing them in internal slots.

--- a/dom.bs
+++ b/dom.bs
@@ -6875,6 +6875,7 @@ value of these steps:
 <p class=note>User agents could optimize <a for=Element>qualified name</a> and
 <a for=Element>HTML-uppercased qualified name</a> by storing them in internal slots.
 
+<div algorithm>
 <p>To <dfn export id=concept-create-element>create an element</dfn>, given a <a for=/>document</a>
 <var>document</var>, string <var>localName</var>, string-or-null <var>namespace</var>, and
 optionally a string-or-null <var>prefix</var> (default null), string-or-null <var>is</var> (default
@@ -7037,7 +7038,9 @@ null, or a {{CustomElementRegistry}} object <var>registry</var> (default "<code>
 
  <li><p>Return <var>result</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn>create an element internal</dfn> given a <a for=/>document</a> <var>document</var>, an
 interface <var>interface</var> a string <var>localName</var>, a string-or-null <var>namespace</var>,
 a string-or-null <var>prefix</var>, a string <var>state</var>, a string-or-null <var>is</var>, and
@@ -7057,6 +7060,7 @@ null or a {{CustomElementRegistry}} object <var>registry</var>:
 
  <li><p>Return <var>element</var>.
 </ol>
+</div>
 
 <p><a for=/>Elements</a> also have an
 <dfn export id=concept-element-attribute for=Element>attribute list</dfn>, which is a
@@ -7090,8 +7094,9 @@ null or a {{CustomElementRegistry}} object <var>registry</var>:
  <a for=Attr>namespace</a>.
 </ol>
 
+<div algorithm>
 <p>To <dfn export id=concept-element-attributes-change lt="change an attribute">change</dfn> an
-<a>attribute</a> <var>attribute</var> to <var>value</var>, run these steps:
+<a>attribute</a> <var>attribute</var> to <var>value</var>:
 
 <ol>
  <li><p>Let <var>oldValue</var> be <var>attribute</var>'s <a for=Attr>value</a>.
@@ -7101,10 +7106,11 @@ null or a {{CustomElementRegistry}} object <var>registry</var>:
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>attribute</var>'s
  <a for=Attr>element</a>, <var>oldValue</var>, and <var>value</var>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export id=concept-element-attributes-append lt="append an attribute">append</dfn> an
-<a>attribute</a> <var>attribute</var> to an <a for=/>element</a> <var>element</var>, run these
-steps:
+<a>attribute</a> <var>attribute</var> to an <a for=/>element</a> <var>element</var>:
 
 <ol>
  <li><p><a for=list>Append</a> <var>attribute</var> to <var>element</var>'s
@@ -7118,9 +7124,11 @@ steps:
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>, null, and
  <var>attribute</var>'s <a for=Attr>value</a>.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export id=concept-element-attributes-remove lt="remove an attribute">remove</dfn> an
-<a>attribute</a> <var>attribute</var>, run these steps:
+<a>attribute</a> <var>attribute</var>:
 
 <ol>
  <li><p>Let <var>element</var> be <var>attribute</var>'s <a for=Attr>element</a>.
@@ -7133,7 +7141,9 @@ steps:
  <li><p><a>Handle attribute changes</a> for <var>attribute</var> with <var>element</var>,
  <var>attribute</var>'s <a for=Attr>value</a>, and null.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn export id=concept-element-attributes-replace lt="replace an attribute">replace</dfn> an
 <a>attribute</a> <var>oldAttribute</var> with an <a>attribute</a> <var>newAttribute</var>:
 
@@ -7154,6 +7164,7 @@ steps:
  <var>oldAttribute</var>'s <a for=Attr>value</a>, and <var>newAttribute</var>'s
  <a for=Attr>value</a>.
 </ol>
+</div>
 
 <hr>
 


### PR DESCRIPTION
And adopt `<div algorithm>` some more.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1467.html" title="Last updated on May 28, 2026, 6:58 AM UTC (5b54474)">Preview</a> | <a href="https://whatpr.org/dom/1467/62faf47...5b54474.html" title="Last updated on May 28, 2026, 6:58 AM UTC (5b54474)">Diff</a>