### PR TITLE
Fix NodeIterator pre-remove steps for ancestors of root

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -10320,8 +10320,9 @@ given a {{NodeIterator}} object <var>nodeIterator</var> and <a for=/>node</a>
 
 <ol>
  <li><p>If <var>toBeRemovedNode</var> is not an <a for=tree>inclusive ancestor</a> of
- <var>nodeIterator</var>'s <a for=NodeIterator>reference</a>, or <var>toBeRemovedNode</var> is
- <var>nodeIterator</var>'s <a for=traversal>root</a>, then return.
+ <var>nodeIterator</var>'s <a for=NodeIterator>reference</a>, or <var>toBeRemovedNode</var> is an
+ <a for=tree>inclusive ancestor</a> of <var>nodeIterator</var>'s <a for=traversal>root</a>, then
+ return.
 
  <li>
   <p>If <var>nodeIterator</var>'s <a for=NodeIterator>pointer before reference</a> is true:


### PR DESCRIPTION
Generalize the first early-return clause of the `NodeIterator` pre-remove steps so it bails when *toBeRemovedNode* is an inclusive ancestor of *nodeIterator*'s root, not only when it equals the root.

Implementations (Gecko, Blink, WebKit) and the existing [`NodeIterator-removal.html`](https://github.com/web-platform-tests/wpt/blob/master/dom/traversal/NodeIterator-removal.html) WPT test already do this.

Corresponding WPT PR: https://github.com/web-platform-tests/wpt/pull/60997.

Closes #907.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1477.html" title="Last updated on Jun 30, 2026, 3:12 PM UTC (4ece054)">Preview</a> | <a href="https://whatpr.org/dom/1477/729983a...4ece054.html" title="Last updated on Jun 30, 2026, 3:12 PM UTC (4ece054)">Diff</a>