### PR TITLE
Remove "allow declarative shadow roots"

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -5017,8 +5017,7 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
     <ol>
      <li><p>Set <var>copy</var>'s <a for=Document>encoding</a>, <a for=Document>content type</a>,
      <a for=Document>URL</a>, <a for=Document>origin</a>, <a for=Document>type</a>,
-     and <a for=Document>mode</a>, to those of
-     <var>node</var>.
+     and <a for=Document>mode</a>, to those of <var>node</var>.
 
      <li><p>If <var>node</var>'s <a for=Document>custom element registry</a>'s
      <a for=CustomElementRegistry>is scoped</a> is true, then set <var>copy</var>'s

--- a/dom.bs
+++ b/dom.bs
@@ -5017,7 +5017,7 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
     <ol>
      <li><p>Set <var>copy</var>'s <a for=Document>encoding</a>, <a for=Document>content type</a>,
      <a for=Document>URL</a>, <a for=Document>origin</a>, <a for=Document>type</a>,
-     <a for=Document>mode</a>, and <a for=Document>allow declarative shadow roots</a>, to those of
+     and <a for=Document>mode</a>, to those of
      <var>node</var>.
 
      <li><p>If <var>node</var>'s <a for=Document>custom element registry</a>'s
@@ -5583,8 +5583,7 @@ known as <dfn export id=concept-document lt="document">documents</dfn>.
 <dfn export for=Document id=concept-document-url>URL</dfn> (a <a for=/>URL</a>),
 <dfn export for=Document id=concept-document-origin>origin</dfn> (an <a for=/>origin</a>),
 <dfn export for=Document id=concept-document-type>type</dfn> ("<code>xml</code>" or "<code>html</code>"),
-<dfn export for=Document id=concept-document-mode>mode</dfn> ("<code>no-quirks</code>", "<code>quirks</code>", or "<code>limited-quirks</code>"),
-<dfn export for=Document>allow declarative shadow roots</dfn> (a boolean), and
+<dfn export for=Document id=concept-document-mode>mode</dfn> ("<code>no-quirks</code>", "<code>quirks</code>", or "<code>limited-quirks</code>"), and
 <dfn export for=Document>custom element registry</dfn> (null or a {{CustomElementRegistry}} object).
 [[!ENCODING]]
 [[!URL]]
@@ -5595,8 +5594,7 @@ known as <dfn export id=concept-document lt="document">documents</dfn>.
 "<code>application/xml</code>", <a for=Document>URL</a> is "<code>about:blank</code>",
 <a for=Document>origin</a> is an <a>opaque origin</a>,
 <a for=Document>type</a> is "<code>xml</code>", <a for=Document>mode</a> is
-"<code>no-quirks</code>", <a for=Document>allow declarative shadow roots</a> is false, and
-<a for=Document>custom element registry</a> is null.
+"<code>no-quirks</code>", and <a for=Document>custom element registry</a> is null.
 
 <p>A <a for=/>document</a> is said to be an <dfn export>XML document</dfn> if its
 <a for=Document>type</a> is "<code>xml</code>"; otherwise an <dfn export>HTML document</dfn>.


### PR DESCRIPTION
This is now a parser flag rather than a document associated boolean.

See whatwg/html#12624, also for checkboxes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1478.html" title="Last updated on Jul 2, 2026, 12:26 PM UTC (5d9c5aa)">Preview</a> | <a href="https://whatpr.org/dom/1478/729983a...5d9c5aa.html" title="Last updated on Jul 2, 2026, 12:26 PM UTC (5d9c5aa)">Diff</a>