### PR TITLE
Restore deep cloning of shadow root contents.

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4964,7 +4964,7 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
     <p>For each <var>child</var> of <var>node</var>'s <a for=Element>shadow root</a>'s
     <a for=tree>children</a>, in <a>tree order</a>: <a>clone a node</a> given <var>child</var> with
     <a for="clone a node"><i>document</i></a> set to <var>document</var>,
-    <a for="clone a node"><i>subtree</i></a> set to <var>subtree</var>, and
+    <a for="clone a node"><i>subtree</i></a> set to true, and
     <a for="clone a node"><i>parent</i></a> set to <var>copy</var>'s <a for=Element>shadow root</a>.
 
     <p class="note">This intentionally does not pass the


### PR DESCRIPTION
This restores the behaviour introduced by #1272.

After #1334, the shadow-root cloning step says to clone each child of the shadow root with `subtree` set to `subtree`. When the original call is `host.cloneNode(false)`, that causes each direct child of a clonable shadow root to be cloned shallowly.

That contradicts the behaviour agreed in #1249 / #1272 and the WPT `shadow-dom/shadow-root-clonable.html`, which expects a clonable shadow root to be cloned in its entirety even when the shadow host is shallow-cloned.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1480.html" title="Last updated on Jul 4, 2026, 6:12 PM UTC (27a12ac)">Preview</a> | <a href="https://whatpr.org/dom/1480/995b4c3...27a12ac.html" title="Last updated on Jul 4, 2026, 6:12 PM UTC (27a12ac)">Diff</a>