### PR TITLE
Editorial: remove remaining dictionary "is present" usage

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4176,7 +4176,7 @@ method steps are:
  <var>options</var>["{{MutationObserverInit/attributes}}"] is false, then <a>throw</a> a
  <code>TypeError</code>.
 
- <li><p>If <var>options</var>["{{MutationObserverInit/attributeFilter}}"] is present and
+ <li><p>If <var>options</var>["{{MutationObserverInit/attributeFilter}}"] [=map/exists=] and
  <var>options</var>["{{MutationObserverInit/attributes}}"] is false, then <a>throw</a> a
  <code>TypeError</code>.
 


### PR DESCRIPTION
Fixes #574.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1482.html" title="Last updated on Jul 7, 2026, 3:24 PM UTC (06ab5f0)">Preview</a> | <a href="https://whatpr.org/dom/1482/cbbbbe9...06ab5f0.html" title="Last updated on Jul 7, 2026, 3:24 PM UTC (06ab5f0)">Diff</a>