### PR TITLE
Clarify create an element assertion

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6954,8 +6954,30 @@ null, or a {{CustomElementRegistry}} object <var>registry</var> (default "<code>
        <li><p>Set <var>result</var> to the result of <a>constructing</a> <var>C</var>, with no
        arguments.
 
-       <li><p>Assert: <var>result</var>'s <a for=Element>custom element state</a> and
-       <a for=Element>custom element definition</a> are initialized.
+       <li>
+        <p><a for=/>Assert</a>: <var>result</var>'s <a for=Element>custom element state</a> is
+        "<code>custom</code>" and its <a for=Element>custom element definition</a> is non-null,
+        <var>result</var>'s <a for=Element>custom element state</a> is "<code>precustomized</code>",
+        or <var>result</var>'s <a for=Element>custom element state</a> is neither
+        "<code>custom</code>" nor "<code>precustomized</code>" and its
+        <a for=Element>custom element definition</a> is null.
+
+        <div class=example id=example-return-override>
+         <pre><code class=lang-javascript>
+          customElements.define("x-example", class extends HTMLElement {
+            constructor() {
+              // Non-conformant: returns an existing element instead of calling super().
+              return document.createElement("p");
+            }
+          });
+
+          document.createElement("x-example");
+         </code></pre>
+
+         <p>Here <var>result</var> is the <code>p</code> <a for=/>element</a>, whose
+         <a for=Element>custom element state</a> is "<code>uncustomized</code>" and whose
+         <a for=Element>custom element definition</a> is null.
+        </div>
 
        <li>
         <p>Assert: <var>result</var>'s <a for=Element>namespace</a> is the <a>HTML namespace</a>.

--- a/dom.bs
+++ b/dom.bs
@@ -6955,12 +6955,17 @@ null, or a {{CustomElementRegistry}} object <var>registry</var> (default "<code>
        arguments.
 
        <li>
-        <p><a for=/>Assert</a>: <var>result</var>'s <a for=Element>custom element state</a> is
-        "<code>custom</code>" and its <a for=Element>custom element definition</a> is non-null,
-        <var>result</var>'s <a for=Element>custom element state</a> is "<code>precustomized</code>",
-        or <var>result</var>'s <a for=Element>custom element state</a> is neither
-        "<code>custom</code>" nor "<code>precustomized</code>" and its
-        <a for=Element>custom element definition</a> is null.
+        <p><a for=/>Assert</a>: one of the following is true:
+
+        <ul class=brief>
+         <li><var>result</var>'s <a for=Element>custom element state</a> is "<code>custom</code>"
+         and its <a for=Element>custom element definition</a> is non-null;
+         <li><var>result</var>'s <a for=Element>custom element state</a> is
+         "<code>precustomized</code>"; or
+         <li><var>result</var>'s <a for=Element>custom element state</a> is neither
+         "<code>custom</code>" nor "<code>precustomized</code>" and its
+         <a for=Element>custom element definition</a> is null.
+        </ul>
 
         <div class=example id=example-return-override>
          <pre><code class=lang-javascript>


### PR DESCRIPTION
Instead of saying "initialized" let's enumerate what these values can actually be and provide an example of something that is potentially unexpected.

Fixes #1338.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1485.html" title="Last updated on Jul 15, 2026, 1:40 PM UTC (ef96cc8)">Preview</a> | <a href="https://whatpr.org/dom/1485/f8b241f...ef96cc8.html" title="Last updated on Jul 15, 2026, 1:40 PM UTC (ef96cc8)">Diff</a>