### PR TITLE
Adopt a DocumentFragment with a host like any other node

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6156,9 +6156,6 @@ algorithm is passed <var ignore>node</var> and <var ignore>oldDocument</var>, as
  <li><p>If <var>node</var> is a <a for=/>shadow root</a>, then <a>throw</a> a
  "{{HierarchyRequestError!!exception}}" {{DOMException}}.
 
- <li><p>If <var>node</var> is a {{DocumentFragment}} <a for=/>node</a> whose
- <a for=DocumentFragment>host</a> is non-null, then return.
-
  <li><p><a>Adopt</a> <var>node</var> into <a>this</a>.
 
  <li><p>Return <var>node</var>.


### PR DESCRIPTION
adoptNode() previously short-circuited for a DocumentFragment whose host is non-null (i.e. a template's content) with a bare "return", which both contradicted the Node return type and matched no implementation. All engines instead adopt the fragment and return it, so remove the step.

Tests: https://github.com/web-platform-tests/wpt/pull/61140.

Fixes #813.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1486.html" title="Last updated on Jul 8, 2026, 12:32 PM UTC (ee00791)">Preview</a> | <a href="https://whatpr.org/dom/1486/f8b241f...ee00791.html" title="Last updated on Jul 8, 2026, 12:32 PM UTC (ee00791)">Diff</a>