### PR TITLE
Adopt node before removing child in replace

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -3194,6 +3194,11 @@ a <a for=/>node</a> <var>node</var> within a <a for=/>node</a> <var>parent</var>
 
  <li><p>Let <var>removedNodes</var> be the empty set.
 
+ <li><p><a>Adopt</a> <var>node</var> into <var>parent</var>'s <a for=Node>node document</a>.
+ <!-- This needs to come before child is removed below so that, when node is
+      already in the tree, its removal is observed while child is still present.
+      See https://github.com/whatwg/dom/issues/814. -->
+
  <li>
   <p>If <var>child</var>'s <a for=tree>parent</a> is non-null:
 

--- a/dom.bs
+++ b/dom.bs
@@ -3195,9 +3195,6 @@ a <a for=/>node</a> <var>node</var> within a <a for=/>node</a> <var>parent</var>
  <li><p>Let <var>removedNodes</var> be the empty set.
 
  <li><p><a>Adopt</a> <var>node</var> into <var>parent</var>'s <a for=Node>node document</a>.
- <!-- This needs to come before child is removed below so that, when node is
-      already in the tree, its removal is observed while child is still present.
-      See https://github.com/whatwg/dom/issues/814. -->
 
  <li>
   <p>If <var>child</var>'s <a for=tree>parent</a> is non-null:


### PR DESCRIPTION
replace removes child (with suppressObservers set) before inserting node. Because insert now adopts node as one of its steps, when node is already in the tree its removal from the old location — and the mutation record that removal queues — happened *after* child had already been silently removed. That gave the record a stale previousSibling and made the two records appear non-atomic.

Adopt node up front, before child is removed, so node's removal is observed while child is still present. This restores the record ordering and previousSibling that predates #754, which had removed replace's explicit adoption step without accounting for this interaction. All engines kept the pre-#754 behavior, so this aligns the standard with reality.

The related replace all algorithm intentionally keeps adopting inside insert: its only caller that can receive an already-present node is `replaceChildren()`, which postdates #754 and folds such a node into its single record.

Fixes #814.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * All engines already implement this behavior (it predates #754); this change aligns the standard with them.
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Existing coverage in dom/nodes/MutationObserver-childList.html (n52/n53) already asserts this behavior.
   * https://github.com/web-platform-tests/wpt/pull/61155 adds related `replaceChildren()` coverage.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * N/A
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1488.html" title="Last updated on Jul 8, 2026, 5:01 PM UTC (56023db)">Preview</a> | <a href="https://whatpr.org/dom/1488/c7f757c...56023db.html" title="Last updated on Jul 8, 2026, 5:01 PM UTC (56023db)">Diff</a>