### PR TITLE
Copy a document's base URL when cloning

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4646,11 +4646,20 @@ statement, switching on the interface <a>this</a> <a>implements</a>:
 
 <dl class=domintro>
  <dt><code><var>node</var> . {{Node/baseURI}}</code>
- <dd>Returns <var>node</var>'s <a for=Node>node document</a>'s <a>document base URL</a>.
+ <dd>Returns <var>node</var>'s <a for=Node>node document</a>'s base URL.
 </dl>
 
-<p>The <dfn attribute for=Node><code>baseURI</code></dfn> getter steps are to return <a>this</a>'s
-<a for=Node>node document</a>'s <a>document base URL</a>, <a lt="URL serializer" spec=url>serialized</a>.
+<p>The <dfn attribute for=Node><code>baseURI</code></dfn> getter steps are:
+
+<ol>
+ <li><p>Let <var>baseURL</var> be the result of running <a>this</a>'s <a for=Node>node document</a>'s
+ <a>get the base URL</a> algorithm.
+
+ <li><p>If <var>baseURL</var> is null, then set <var>baseURL</var> to <a>this</a>'s
+ <a for=Node>node document</a>'s <a for=Document>URL</a>.
+
+ <li><p>Return <var>baseURL</var>, <a lt="URL serializer" spec=url>serialized</a>.
+</ol>
 
 <hr>
 
@@ -5034,6 +5043,9 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
      <a for=Document>URL</a>, <a for=Document>origin</a>, <a for=Document>type</a>,
      <a for=Document>mode</a>, and <a for=Document>allow declarative shadow roots</a>, to those of
      <var>node</var>.
+
+     <li><p>Set <var>copy</var>'s <a>base URL override</a> to the result of running <var>node</var>'s
+     <a>get the base URL</a>.
 
      <li><p>If <var>node</var>'s <a for=Document>custom element registry</a>'s
      <a for=CustomElementRegistry>is scoped</a> is true, then set <var>copy</var>'s
@@ -5617,6 +5629,15 @@ known as <dfn export id=concept-document lt="document">documents</dfn>.
 <a for=Document>type</a> is "<code>xml</code>"; otherwise an <dfn export>HTML document</dfn>.
 Whether a <a for=/>document</a> is an <a>HTML document</a> or an <a>XML document</a> affects the
 behavior of certain APIs.
+
+<p>Each <a for=/>document</a> has an associated <dfn export>get the base URL</dfn> algorithm, which
+returns a <a for=/>URL</a> or null. Unless specified otherwise it returns null.
+
+<p>Each <a for=/>document</a> has a <dfn export>base URL override</dfn> (a <a for=/>URL</a> or
+null), initially null.
+
+<p class=note>HTML overrides the <a>get the base URL</a> algorithm and uses the
+<a>base URL override</a> to account for the <code>base</code> element. [[!HTML]]
 
 <p>A <a for=/>document</a> is said to be in
 <dfn export id=concept-document-no-quirks>no-quirks mode</dfn> if its


### PR DESCRIPTION
Copy a document's base URL when cloning.

The baseURI getter now defers to a new "get the base URL" algorithm, which returns null by default and falls back to the node document's URL. HTML overrides this algorithm (to return the document base URL), so DOM no longer reaches into HTML for a value returned by a DOM API.

Cloning a document now copies its base URL into a new "base URL override", so that a shallow clone, which has no base element, still reports the base URL of the document it was cloned from.

HTML PR: https://github.com/whatwg/html/pull/12674

Fixes #454.

Tests: https://github.com/web-platform-tests/wpt/pull/61232

- [x] At least two implementers are interested (and none opposed):
   * Gecko (passes all tests)
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61232 <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Captcha :-( 
   * Gecko: N/A
   * WebKit: …
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1492.html" title="Last updated on Aug 27, 2026, 8:50 AM UTC (e0bd201)">Preview</a> | <a href="https://whatpr.org/dom/1492/8a5f57c...e0bd201.html" title="Last updated on Aug 27, 2026, 8:50 AM UTC (e0bd201)">Diff</a>