### PR TITLE
Restore active custom element constructor map entries after construction

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6978,6 +6978,10 @@ null, or a {{CustomElementRegistry}} object <var>registry</var> (default "<code>
      <li><p>Let <var>C</var> be <var>definition</var>'s
      <a for="custom element definition">constructor</a>.
 
+     <li><p>Let <var>previousRegistry</var> be the <a>surrounding agent</a>'s
+     <a for="similar-origin window agent">active custom element constructor map</a>[<var>C</var>]
+     <a for=map>with default</a> null.
+
      <li><p><a for=map>Set</a> the <a>surrounding agent</a>'s
      <a for="similar-origin window agent">active custom element constructor map</a>[<var>C</var>] to
      <var>registry</var>.
@@ -7060,11 +7064,13 @@ null, or a {{CustomElementRegistry}} object <var>registry</var> (default "<code>
        <var>prefix</var>, "<code>failed</code>", null, and <var>registry</var>.
       </ol>
 
-     <li>
-      <p><a for=map>Remove</a> the <a>surrounding agent</a>'s
-      <a for="similar-origin window agent">active custom element constructor map</a>[<var>C</var>].
+     <li><p>If <var>previousRegistry</var> is null, then <a for=map>remove</a> the
+     <a>surrounding agent</a>'s
+     <a for="similar-origin window agent">active custom element constructor map</a>[<var>C</var>].
 
-      <p class=note>Under normal circumstances it will already have been removed at this point.
+     <li><p>Otherwise, <a for=map>set</a> the <a>surrounding agent</a>'s
+     <a for="similar-origin window agent">active custom element constructor map</a>[<var>C</var>] to
+     <var>previousRegistry</var>.
     </ol>
 
    <li>


### PR DESCRIPTION
Create an element sets the active custom element constructor map entry for the constructor it is about to construct, then removed it once construction finished. A re-entrant construction of the same constructor for a different registry therefore clobbered the outer entry, and its removal left the outer construction to resolve against the wrong registry.

Save the previous entry before setting it and restore it afterwards, so the outer registry survives a re-entrant construction. This mirrors the same change to the HTML element constructor and upgrade an element.

See https://github.com/whatwg/html/pull/12696.

<!--
Thank you for contributing to the DOM Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/61364
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Captcha :-( 
   * Gecko: N/A as Keith is actively implementing this
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=319658
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1494.html" title="Last updated on Jul 17, 2026, 11:32 AM UTC (d81e47e)">Preview</a> | <a href="https://whatpr.org/dom/1494/27c8bdf...d81e47e.html" title="Last updated on Jul 17, 2026, 11:32 AM UTC (d81e47e)">Diff</a>