### PR TITLE
Order shadow root concepts consistently

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -4969,10 +4969,10 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
    <a for=Document>custom element registry</a>'s <a>effective global custom element registry</a>.
 
    <li><p><a>Attach a shadow root</a> with <var>copy</var>, <var>node</var>'s
-   <a for=Element>shadow root</a>'s <a for=ShadowRoot>mode</a>, true, <var>node</var>'s
-   <a for=Element>shadow root</a>'s <a for=ShadowRoot>serializable</a>, <var>node</var>'s
+   <a for=Element>shadow root</a>'s <a for=ShadowRoot>mode</a>, <var>node</var>'s
    <a for=Element>shadow root</a>'s <a for=ShadowRoot>delegates focus</a>, <var>node</var>'s
-   <a for=Element>shadow root</a>'s <a for=ShadowRoot>slot assignment</a>, and
+   <a for=Element>shadow root</a>'s <a for=ShadowRoot>serializable</a>, <var>node</var>'s
+   <a for=Element>shadow root</a>'s <a for=ShadowRoot>slot assignment</a>, true, and
    <var>shadowRootRegistry</var>.
 
    <li><p>Set <var>copy</var>'s <a for=Element>shadow root</a>'s <a for=ShadowRoot>declarative</a>
@@ -6626,9 +6626,9 @@ constructor steps are to set <a>this</a>'s <a for=Node>node document</a> to
 interface ShadowRoot : DocumentFragment {
   readonly attribute ShadowRootMode mode;
   readonly attribute boolean delegatesFocus;
+  readonly attribute boolean serializable;
   readonly attribute SlotAssignmentMode slotAssignment;
   readonly attribute boolean clonable;
-  readonly attribute boolean serializable;
   readonly attribute Element host;
 
   attribute EventHandler onslotchange;
@@ -6658,13 +6658,13 @@ false.
 <p><a for=/>Shadow roots</a> have an associated <dfn export for=ShadowRoot>declarative</dfn>
 (a boolean). It is initially set to false.
 
+<p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>serializable</dfn> (a boolean).
+It is initially set to false.
+
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>slot assignment</dfn>
 ("<code>manual</code>" or "<code>named</code>").
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>clonable</dfn> (a boolean).
-It is initially set to false.
-
-<p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>serializable</dfn> (a boolean).
 It is initially set to false.
 
 <p><a for=/>Shadow roots</a> have an associated <dfn for=ShadowRoot>custom element registry</dfn>
@@ -6693,14 +6693,14 @@ null if <var>event</var>'s <a>composed flag</a> is unset and <a for=/>shadow roo
 <p>The <dfn attribute for=ShadowRoot><code>delegatesFocus</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>delegates focus</a>.
 
+<p>The <dfn attribute for=ShadowRoot><code>serializable</code></dfn> getter steps are to return
+<a>this</a>'s <a for=ShadowRoot>serializable</a>.
+
 <p>The <dfn attribute for=ShadowRoot><code>slotAssignment</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>slot assignment</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>clonable</code></dfn> getter steps are to return
 <a>this</a>'s <a for=ShadowRoot>clonable</a>.
-
-<p>The <dfn attribute for=ShadowRoot><code>serializable</code></dfn> getter steps are to return
-<a>this</a>'s <a for=ShadowRoot>serializable</a>.
 
 <p>The <dfn attribute for=ShadowRoot><code>host</code></dfn> getter steps are to return
 <a>this</a>'s <a for=DocumentFragment>host</a>.
@@ -6836,9 +6836,9 @@ interface Element : Node {
 dictionary ShadowRootInit {
   required ShadowRootMode mode;
   boolean delegatesFocus = false;
+  boolean serializable = false;
   SlotAssignmentMode slotAssignment = "named";
   boolean clonable = false;
-  boolean serializable = false;
   CustomElementRegistry? customElementRegistry;
 };
 </pre>
@@ -7856,10 +7856,11 @@ are:
  "{{NotSupportedError!!exception}}" {{DOMException}}.
 
  <li><p>Run <a>attach a shadow root</a> with <a>this</a>,
- <var>init</var>["{{ShadowRootInit/mode}}"], <var>init</var>["{{ShadowRootInit/clonable}}"],
- <var>init</var>["{{ShadowRootInit/serializable}}"],
+ <var>init</var>["{{ShadowRootInit/mode}}"],
  <var>init</var>["{{ShadowRootInit/delegatesFocus}}"],
- <var>init</var>["{{ShadowRootInit/slotAssignment}}"], and <var>registry</var>.
+ <var>init</var>["{{ShadowRootInit/serializable}}"],
+ <var>init</var>["{{ShadowRootInit/slotAssignment}}"],
+ <var>init</var>["{{ShadowRootInit/clonable}}"], and <var>registry</var>.
 
  <li><p>Return <a>this</a>'s <a for=Element>shadow root</a>.
 </ol>
@@ -7867,9 +7868,9 @@ are:
 
 <div algorithm>
 <p>To <dfn id=concept-attach-a-shadow-root>attach a shadow root</dfn>, given an
-<a for=/>element</a> <var>element</var>, a string <var>mode</var>, a boolean <var>clonable</var>,
-a boolean <var>serializable</var>, a boolean <var>delegatesFocus</var>, a string
-<var>slotAssignment</var>, and null or a {{CustomElementRegistry}} object <var>registry</var>:
+<a for=/>element</a> <var>element</var>, a string <var>mode</var>, a boolean <var>delegatesFocus</var>,
+a boolean <var>serializable</var>, a string <var>slotAssignment</var>, a boolean <var>clonable</var>,
+and null or a {{CustomElementRegistry}} object <var>registry</var>:
 
 <ol>
  <li><p>If <var>element</var>'s <a for=Element>namespace</a> is not the <a>HTML namespace</a>,
@@ -7938,13 +7939,13 @@ a boolean <var>serializable</var>, a boolean <var>delegatesFocus</var>, a string
  "<code>precustomized</code>" or "<code>custom</code>", then set <var>shadow</var>'s
  <a for=ShadowRoot>available to element internals</a> to true.
 
- <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> to <var>slotAssignment</var>.
-
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>declarative</a> to false.
 
- <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>clonable</a> to <var>clonable</var>.
-
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>serializable</a> to <var>serializable</var>.
+
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>slot assignment</a> to <var>slotAssignment</var>.
+
+ <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>clonable</a> to <var>clonable</var>.
 
  <li><p>Set <var>shadow</var>'s <a for=ShadowRoot>custom element registry</a> to
  <var>registry</var>.


### PR DESCRIPTION
Present the shadow root associated concepts, IDL members, and "attach a shadow root" parameters and steps in one consistent order: mode, delegates focus, available to element internals, declarative, serializable, slot assignment, clonable, custom element registry, keep custom element registry null. The serialized concepts follow HTML's serialization order.

Note this reorders `ShadowRoot` interface members and `ShadowRootInit` dictionary members, which is observable via property enumeration.

Requires whatwg/html#12703 to update the "attach a shadow root" call sites and argument order.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1496.html" title="Last updated on Aug 20, 2026, 1:58 PM UTC (45f3a14)">Preview</a> | <a href="https://whatpr.org/dom/1496/9596708...45f3a14.html" title="Last updated on Aug 20, 2026, 1:58 PM UTC (45f3a14)">Diff</a>