### PR TITLE
Introduce keep custom element registry null for elements

### DIFF
--- a/dom.bs
+++ b/dom.bs
@@ -6892,8 +6892,7 @@ developers to pass a {{ShadowRoot}} node instead of a dictionary to {{Element/at
  <dd>Null or a {{CustomElementRegistry}} object.
 
  <dt><dfn export for=Element>keep custom element registry null</dfn>
- <dd>A boolean. It is initially false. Other specifications can set it to true to preserve an
- intentionally null <a for=Element>custom element registry</a> during cloning and adoption.
+ <dd>A boolean. It is initially false.
 
  <dt><dfn export id=concept-element-custom-element-state for=Element>custom element state</dfn>
  <dd>"<code>undefined</code>", "<code>failed</code>", "<code>uncustomized</code>",
@@ -6906,8 +6905,10 @@ developers to pass a {{ShadowRoot}} node instead of a dictionary to {{Element/at
  <dd>Null or a <a for=/>valid custom element name</a>.
 </dl>
 
-<p class=note>An <a for=/>element</a>'s <a for=Element>keep custom element registry null</a>
-only matters while its <a for=Element>custom element registry</a> is null.
+<p class=note>Other specifications can set an <a for=/>element</a>'s
+<a for=Element>keep custom element registry null</a> to true to preserve an intentionally null
+<a for=Element>custom element registry</a> during cloning and adoption. It only matters while the
+element's <a for=Element>custom element registry</a> is null.
 
 <p>When an <a for=/>element</a> is <a lt="create an element">created</a>, all of these values are
 initialized.

--- a/dom.bs
+++ b/dom.bs
@@ -4946,12 +4946,24 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
  <li><p>If <var>parent</var> is non-null, then <a for=/>append</a> <var>copy</var> to
  <var>parent</var>.
 
- <li><p>If <var>subtree</var> is true, then for each <var>child</var> of <var>node</var>'s
- <a for=tree>children</a>, in <a>tree order</a>: <a>clone a node</a> given <var>child</var> with
- <a for="clone a node"><i>document</i></a> set to <var>document</var>,
- <a for="clone a node"><i>subtree</i></a> set to <var>subtree</var>,
- <a for="clone a node"><i>parent</i></a> set to <var>copy</var>, and
- <a for="clone a node"><i>fallbackRegistry</i></a> set to <var>fallbackRegistry</var>.
+ <li>
+  <p>If <var>subtree</var> is true:
+
+  <ol>
+   <li><p>Let <var>childFallbackRegistry</var> be <var>fallbackRegistry</var>.
+
+   <li><p>If <var>node</var> is an <a for=/>element</a> and its
+   <a for=Element>keep custom element registry null</a> is true, then set
+   <var>childFallbackRegistry</var> to null.
+
+   <li><p>For each <var>child</var> of <var>node</var>'s <a for=tree>children</a>, in
+   <a>tree order</a>: <a>clone a node</a> given <var>child</var> with
+   <a for="clone a node"><i>document</i></a> set to <var>document</var>,
+   <a for="clone a node"><i>subtree</i></a> set to <var>subtree</var>,
+   <a for="clone a node"><i>parent</i></a> set to <var>copy</var>, and
+   <a for="clone a node"><i>fallbackRegistry</i></a> set to
+   <var>childFallbackRegistry</var>.
+  </ol>
 
  <li>
   <p>If <var>node</var> is an <a for=/>element</a>, <var>node</var> is a

--- a/dom.bs
+++ b/dom.bs
@@ -5011,7 +5011,8 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
   <ol>
    <li><p>Let <var>registry</var> be <var>node</var>'s <a for=Element>custom element registry</a>.
 
-   <li><p>If <var>registry</var> is null, then set <var>registry</var> to
+   <li><p>If <var>registry</var> is null and <var>node</var>'s
+   <a for=Element>keep custom element registry null</a> is false, then set <var>registry</var> to
    <var>fallbackRegistry</var>.
 
    <li><p>If <var>registry</var> <a>is a global custom element registry</a>, then set
@@ -5022,6 +5023,9 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
    <var>document</var>, <var>node</var>'s <a for=Element>local name</a>, <var>node</var>'s
    <a for=Element>namespace</a>, <var>node</var>'s <a for=Element>namespace prefix</a>,
    <var>node</var>'s <a><code>is</code> value</a>, false, and <var>registry</var>.
+
+   <li><p>Set <var>copy</var>'s <a for=Element>keep custom element registry null</a> to
+   <var>node</var>'s <a for=Element>keep custom element registry null</a>.
 
    <li>
     <p><a for=list>For each</a> <var>attribute</var> of <var>node</var>'s
@@ -6164,9 +6168,18 @@ algorithm is passed <var ignore>node</var> and <var ignore>oldDocument</var>, as
      <var>inclusiveDescendant</var>'s <a for=Element>attribute list</a> to <var>document</var>.
 
      <li>
-      <p>If <var>inclusiveDescendant</var>'s <a for=Element>custom element registry</a> is null or
-      <var>inclusiveDescendant</var>'s <a for=Element>custom element registry</a>'s
-      <a for=CustomElementRegistry>is scoped</a> is false:
+      <p>If any of the following are true:
+
+      <ul>
+       <li><p><var>inclusiveDescendant</var>'s <a for=Element>custom element registry</a> is null
+       and <var>inclusiveDescendant</var>'s
+       <a for=Element>keep custom element registry null</a> is false; or
+
+       <li><p><var>inclusiveDescendant</var>'s <a for=Element>custom element registry</a>
+       <a>is a global custom element registry</a>,
+      </ul>
+
+      <p>then:
 
       <ol>
        <li><p>Let <var>registry</var> be null.
@@ -6865,6 +6878,10 @@ developers to pass a {{ShadowRoot}} node instead of a dictionary to {{Element/at
  <dt><dfn export for=Element>custom element registry</dfn>
  <dd>Null or a {{CustomElementRegistry}} object.
 
+ <dt><dfn export for=Element>keep custom element registry null</dfn>
+ <dd>A boolean. It is initially false. Other specifications can set it to true to preserve an
+ intentionally null <a for=Element>custom element registry</a> during cloning and adoption.
+
  <dt><dfn export id=concept-element-custom-element-state for=Element>custom element state</dfn>
  <dd>"<code>undefined</code>", "<code>failed</code>", "<code>uncustomized</code>",
  "<code>precustomized</code>", or "<code>custom</code>".
@@ -6875,6 +6892,9 @@ developers to pass a {{ShadowRoot}} node instead of a dictionary to {{Element/at
  <dt><dfn export id=concept-element-is-value for=Element><code>is</code> value</dfn>
  <dd>Null or a <a for=/>valid custom element name</a>.
 </dl>
+
+<p class=note>An <a for=/>element</a>'s <a for=Element>keep custom element registry null</a>
+only matters while its <a for=Element>custom element registry</a> is null.
 
 <p>When an <a for=/>element</a> is <a lt="create an element">created</a>, all of these values are
 initialized.

--- a/dom.bs
+++ b/dom.bs
@@ -4952,7 +4952,8 @@ and an optional <a for=/>document</a> <dfn export for="clone a node"><var>docume
   <ol>
    <li><p>Let <var>childFallbackRegistry</var> be <var>fallbackRegistry</var>.
 
-   <li><p>If <var>node</var> is an <a for=/>element</a> and its
+   <li><p>If <var>node</var> is an <a for=/>element</a>, its
+   <a for=Element>custom element registry</a> is null, and its
    <a for=Element>keep custom element registry null</a> is true, then set
    <var>childFallbackRegistry</var> to null.
 


### PR DESCRIPTION
Introduce an element-level `keep custom element registry null` flag so HTML can preserve intentionally null custom element registries through cloning and adoption.

- [x] At least two implementers are interested (and none opposed):
   * Chromium
   * WebKit
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/62206
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/399124619
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1874414
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=302970
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A; this is an internal concept supporting https://github.com/whatwg/html/pull/12000
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/dom/1500.html" title="Last updated on Aug 28, 2026, 11:28 PM UTC (4ec7f25)">Preview</a> | <a href="https://whatpr.org/dom/1500/a2331a4...4ec7f25.html" title="Last updated on Aug 28, 2026, 11:28 PM UTC (4ec7f25)">Diff</a>